### PR TITLE
Send RPC keep-alive from extension instead of infoview.

### DIFF
--- a/lean4-infoview/src/infoview/rpcSessions.tsx
+++ b/lean4-infoview/src/infoview/rpcSessions.tsx
@@ -9,14 +9,6 @@ import { EditorContext, RpcContext } from "./contexts"
 import { EditorConnection } from "./editorConnection"
 import { DocumentPosition, useClientNotificationEffect, useEvent } from "./util"
 
-interface RpcConnectParams {
-    uri: DocumentUri
-}
-
-interface RpcConnected {
-    sessionId: string
-}
-
 interface RpcCallParams extends TextDocumentPositionParams {
     sessionId: string
     method: string
@@ -29,13 +21,6 @@ interface RpcReleaseParams {
     refs: RpcPtr<any>[]
 }
 
-interface RpcKeepAliveParams {
-    uri: DocumentUri
-    sessionId: string
-}
-
-const keepAlivePeriodMs = 10000
-
 const RpcNeedsReconnect = -32900
 
 class RpcSession implements Disposable {
@@ -43,7 +28,6 @@ class RpcSession implements Disposable {
     #uri: DocumentUri
     /** A timeout mechanism for notifying the server about batches of GC'd refs in fewer messages. */
     #releaseTimeout?: number
-    #keepAliveInterval: number
     #refsToRelease: RpcPtr<any>[]
     #finalizers: FinalizationRegistry<RpcPtr<any>>
     #closed: boolean = false
@@ -51,15 +35,6 @@ class RpcSession implements Disposable {
     constructor(readonly sessionId: string, uri: DocumentUri, ec: EditorConnection) {
         this.#ec = ec
         this.#uri = uri
-
-        // We setup a recurring timer to keep the RPC session alive.
-        this.#keepAliveInterval = window.setInterval(() => {
-            const params: RpcKeepAliveParams = {
-                uri: this.#uri,
-                sessionId: this.sessionId,
-            }
-            void this.#ec.api.sendClientNotification('$/lean/rpc/keepAlive', params)
-        }, keepAlivePeriodMs)
 
         // Here we hook into the JS GC and send release-reference notifications
         // whenever the GC finalizes a number of `RpcPtr`s. Requires ES2021.
@@ -113,7 +88,7 @@ class RpcSession implements Disposable {
 
     dispose() {
         this.#closed = true;
-        window.clearInterval(this.#keepAliveInterval)
+        this.#ec.api.closeRpcSession(this.sessionId)
     }
 }
 
@@ -143,9 +118,8 @@ export class RpcSessions implements Disposable {
         if (this.#connecting.has(uri) || this.#connected.has(uri)) {
             throw new Error(`already connecting or connected at '${uri}'`)
         }
-        const connParams: RpcConnectParams = { uri }
-        let newSesh: Promise<RpcSession | undefined> = this.#ec.api.sendClientRequest('$/lean/rpc/connect', connParams)
-            .then((conn: RpcConnected) => new RpcSession(conn.sessionId, uri, this.#ec))
+        let newSesh: Promise<RpcSession | undefined> = this.#ec.api.createRpcSession(uri)
+            .then(sessionId => new RpcSession(sessionId, uri, this.#ec))
             .catch(() => {
                 this.#connecting.delete(uri)
                 return undefined

--- a/lean4-infoview/src/infoview/rpcSessions.tsx
+++ b/lean4-infoview/src/infoview/rpcSessions.tsx
@@ -4,24 +4,10 @@
  */
 import React from "react"
 import { DidCloseTextDocumentParams, Disposable, DocumentUri, TextDocumentPositionParams } from "vscode-languageserver-protocol"
-import { RpcPtr } from "../lspTypes"
+import { RpcPtr, RpcCallParams, RpcNeedsReconnect, RpcReleaseParams } from "../lspTypes"
 import { EditorContext, RpcContext } from "./contexts"
 import { EditorConnection } from "./editorConnection"
 import { DocumentPosition, useClientNotificationEffect, useEvent } from "./util"
-
-interface RpcCallParams extends TextDocumentPositionParams {
-    sessionId: string
-    method: string
-    params: any
-}
-
-interface RpcReleaseParams {
-    uri: DocumentUri
-    sessionId: string
-    refs: RpcPtr<any>[]
-}
-
-const RpcNeedsReconnect = -32900
 
 class RpcSession implements Disposable {
     #ec: EditorConnection

--- a/lean4-infoview/src/infoviewApi.ts
+++ b/lean4-infoview/src/infoviewApi.ts
@@ -1,4 +1,4 @@
-import { InitializeResult, Location, ShowDocumentParams, TextDocumentPositionParams } from "vscode-languageserver-protocol"
+import { DocumentUri, InitializeResult, Location, ShowDocumentParams, TextDocumentPositionParams } from "vscode-languageserver-protocol"
 
 export interface EditorFsApi {
   stat(path: string): Promise<any>;
@@ -53,6 +53,16 @@ export interface EditorApi {
 
   /** Highlight a range in a document in the editor. */
   showDocument(show: ShowDocumentParams): Promise<void>;
+
+  /**
+   * Creates an RPC session for the given uri and returns the session id.
+   * The extension takes care of keeping the RPC session alive.
+   * (The infoview cannot reliably send keep-alive messages because setInterval
+   * is throttled in the infoview when the vscode window is not visible.)
+   */
+  createRpcSession(uri: DocumentUri): Promise<string>;
+  /** Closes an RPC session created with `createRpcSession`. */
+  closeRpcSession(sessionId: string): Promise<void>;
 }
 
 export interface InfoviewTacticStateFilter {

--- a/lean4-infoview/src/lspTypes.ts
+++ b/lean4-infoview/src/lspTypes.ts
@@ -1,4 +1,4 @@
-import { Diagnostic, Range, VersionedTextDocumentIdentifier } from 'vscode-languageserver-protocol';
+import { Diagnostic, DocumentUri, Range, TextDocumentPositionParams, VersionedTextDocumentIdentifier } from 'vscode-languageserver-protocol';
 
 // Lean 4 extensions to LSP.
 
@@ -49,3 +49,30 @@ export function toKey(p: RpcPtr<any>): string {
 }
 
 }
+
+export interface RpcConnectParams {
+    uri: DocumentUri;
+}
+
+export interface RpcConnected {
+    sessionId: string
+}
+
+export interface RpcKeepAliveParams {
+    uri: DocumentUri
+    sessionId: string
+}
+
+export interface RpcCallParams extends TextDocumentPositionParams {
+    sessionId: string
+    method: string
+    params: any
+}
+
+export interface RpcReleaseParams {
+    uri: DocumentUri
+    sessionId: string
+    refs: RpcPtr<any>[]
+}
+
+export const RpcNeedsReconnect = -32900

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -3,28 +3,14 @@ import {
     commands, Disposable, DocumentSelector,
     ExtensionContext, languages, Range,
     Selection, TextEditor, TextEditorRevealType,
-    Uri, ViewColumn, WebviewPanel, window, workspace, env, Position, Diagnostic,
+    Uri, ViewColumn, WebviewPanel, window, workspace, env, Position,
 } from 'vscode';
-import { EditorApi, InfoviewApi, LeanFileProgressParams, TextInsertKind } from '@lean4/infoview';
+import { EditorApi, InfoviewApi, LeanFileProgressParams, TextInsertKind, RpcConnectParams, RpcConnected, RpcKeepAliveParams } from '@lean4/infoview';
 import { LeanClient } from './leanclient';
 import { getInfoViewAllErrorsOnLine, getInfoViewAutoOpen, getInfoViewAutoOpenShowGoal,
     getInfoViewFilterIndex, getInfoViewStyle, getInfoViewTacticStateFilters } from './config';
 import { Rpc } from './rpc';
 import * as ls from 'vscode-languageserver-protocol'
-import { LanguageClient } from 'vscode-languageclient/node';
-
-interface RpcConnectParams {
-    uri: ls.DocumentUri;
-}
-
-interface RpcConnected {
-    sessionId: string
-}
-
-interface RpcKeepAliveParams {
-    uri: ls.DocumentUri
-    sessionId: string
-}
 
 const keepAlivePeriodMs = 10000
 

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -181,7 +181,7 @@ export class InfoProvider implements Disposable {
                 // This event is triggered both the first time the server starts
                 // as well as when the server restarts.
 
-                this.clearSessions();
+                this.clearRpcSessions();
 
                 // The info view should auto-open the first time the server starts:
                 await this.autoOpen()
@@ -220,7 +220,7 @@ export class InfoProvider implements Disposable {
 
     dispose(): void {
         this.clearNotificationHandlers();
-        this.clearSessions();
+        this.clearRpcSessions();
         for (const s of this.subscriptions) { s.dispose(); }
     }
 
@@ -255,7 +255,7 @@ export class InfoProvider implements Disposable {
         this.serverNotifSubscriptions.clear();
     }
 
-    private clearSessions() {
+    private clearRpcSessions() {
         for (const [_, sess] of this.rpcSessions) sess.dispose();
         this.rpcSessions = new Map()
     }
@@ -289,7 +289,7 @@ export class InfoProvider implements Disposable {
             webviewPanel.onDidDispose(() => {
                 this.clearNotificationHandlers();
                 this.webviewPanel = undefined;
-                this.clearSessions(); // should be after `webviewPanel = undefined`
+                this.clearRpcSessions(); // should be after `webviewPanel = undefined`
             });
             this.webviewPanel = webviewPanel;
             webviewPanel.webview.html = this.initialHtml();

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -10,8 +10,50 @@ import { LeanClient } from './leanclient';
 import { getInfoViewAllErrorsOnLine, getInfoViewAutoOpen, getInfoViewAutoOpenShowGoal,
     getInfoViewFilterIndex, getInfoViewStyle, getInfoViewTacticStateFilters } from './config';
 import { Rpc } from './rpc';
-import { PublishDiagnosticsParams } from 'vscode-languageclient';
 import * as ls from 'vscode-languageserver-protocol'
+import { LanguageClient } from 'vscode-languageclient/node';
+
+interface RpcConnectParams {
+    uri: ls.DocumentUri;
+}
+
+interface RpcConnected {
+    sessionId: string
+}
+
+interface RpcKeepAliveParams {
+    uri: ls.DocumentUri
+    sessionId: string
+}
+
+const keepAlivePeriodMs = 10000
+
+async function rpcConnect(client: LeanClient, uri: ls.DocumentUri): Promise<string> {
+    const connParams: RpcConnectParams = { uri };
+    const result: RpcConnected = await client.sendRequest('$/lean/rpc/connect', connParams);
+    return result.sessionId;
+}
+
+class RpcSession implements Disposable {
+    keepAliveInterval?: NodeJS.Timeout;
+
+    constructor(client: LeanClient, public sessionId: string, public uri: ls.DocumentUri) {
+        this.keepAliveInterval = setInterval(() => {
+            const params: RpcKeepAliveParams = { uri, sessionId }
+            try {
+                client.sendNotification('$/lean/rpc/keepAlive', params)
+            } catch (e) {
+                console.log(`failed to send keepalive for ${uri}`, e)
+                clearInterval(this.keepAliveInterval)
+            }
+        }, keepAlivePeriodMs)
+    }
+
+    dispose() {
+        clearInterval(this.keepAliveInterval)
+        // TODO: at this point we could close the session
+    }
+}
 
 export class InfoProvider implements Disposable {
     /** Instance of the panel, if it is open. Otherwise `undefined`. */
@@ -24,6 +66,8 @@ export class InfoProvider implements Disposable {
     // Subscriptions are counted and only disposed of when count becomes 0.
     private serverNotifSubscriptions: Map<string, [number, Disposable]> = new Map();
     private clientNotifSubscriptions: Map<string, [number, Disposable]> = new Map();
+
+    private rpcSessions: Map<string, RpcSession> = new Map();
 
     private editorApi : EditorApi = {
         sendClientRequest: async (method: string, params: any): Promise<any> => {
@@ -123,6 +167,25 @@ export class InfoProvider implements Disposable {
                 this.client.convertRange(show.selection)
             );
         },
+
+        createRpcSession: async uri => {
+            const sessionId = await rpcConnect(this.client, uri);
+            const session = new RpcSession(this.client, sessionId, uri);
+            if (!this.webviewPanel) {
+                session.dispose();
+                throw Error('infoview disconnect while connecting to RPC session');
+            } else {
+                this.rpcSessions.set(sessionId, session);
+                return sessionId;
+            }
+        },
+        closeRpcSession: async sessionId => {
+            const session = this.rpcSessions.get(sessionId);
+            if (session) {
+                this.rpcSessions.delete(sessionId);
+                session.dispose();
+            }
+        },
     };
 
     constructor(private client: LeanClient, private readonly leanDocs: DocumentSelector, private context: ExtensionContext) {
@@ -131,6 +194,8 @@ export class InfoProvider implements Disposable {
             this.client.restarted(async () => {
                 // This event is triggered both the first time the server starts
                 // as well as when the server restarts.
+
+                this.clearSessions();
 
                 // The info view should auto-open the first time the server starts:
                 await this.autoOpen()
@@ -169,6 +234,7 @@ export class InfoProvider implements Disposable {
 
     dispose(): void {
         this.clearNotificationHandlers();
+        this.clearSessions();
         for (const s of this.subscriptions) { s.dispose(); }
     }
 
@@ -203,6 +269,11 @@ export class InfoProvider implements Disposable {
         this.serverNotifSubscriptions.clear();
     }
 
+    private clearSessions() {
+        for (const [_, sess] of this.rpcSessions) sess.dispose();
+        this.rpcSessions = new Map()
+    }
+
     private async openPreview(editor: TextEditor) {
         let column = editor ? editor.viewColumn + 1 : ViewColumn.Two;
         if (column === 4) { column = ViewColumn.Three; }
@@ -232,6 +303,7 @@ export class InfoProvider implements Disposable {
             webviewPanel.onDidDispose(() => {
                 this.clearNotificationHandlers();
                 this.webviewPanel = undefined;
+                this.clearSessions(); // should be after `webviewPanel = undefined`
             });
             this.webviewPanel = webviewPanel;
             webviewPanel.webview.html = this.initialHtml();


### PR DESCRIPTION
Fixes #73.

It also allows us to explicitly close sessions in the future instead of / in addition to the keep-alive system.