### PR TITLE
Make elan install compatible with other Linux shells

### DIFF
--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -243,8 +243,8 @@ export class LeanInstaller implements Disposable {
             }
             else{
                 terminal.sendText(
-                    `curl ${this.leanInstallerLinux} -sSf | sh -s -- ${toolchain} && ` +
-                    `echo && ${promptAndExit}`);
+                    `bash -c 'curl ${this.leanInstallerLinux} -sSf | sh -s -- ${toolchain} && ` +
+                    `echo && ${promptAndExit}'`);
             }
 
             return result;


### PR DESCRIPTION
zsh's `read` does not support some of the given flags, and I don't even want to think about fish