### PR TITLE
fix: multiple output channels named "Lean4" are showing up 

### DIFF
--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -125,6 +125,7 @@ export class LeanClient implements Disposable {
             }
         }
         const clientOptions: LanguageClientOptions = {
+            outputChannel: this.outputChannel,
             documentSelector: [documentSelector],
             initializationOptions: {
                 editDelay: getElaborationDelay(),

--- a/vscode-lean4/src/utils/leanpkg.ts
+++ b/vscode-lean4/src/utils/leanpkg.ts
@@ -11,6 +11,7 @@ export class LeanpkgService implements Disposable {
     private defaultVersion = 'leanprover/lean4:nightly';
     private localStorage : LocalStorageService;
     private versionChangedEmitter = new EventEmitter<string>();
+    private currentVersion : string = null;
     versionChanged = this.versionChangedEmitter.event
 
     constructor(localStorage : LocalStorageService) {
@@ -123,9 +124,12 @@ export class LeanpkgService implements Disposable {
         }
         if (uri.toString() === this.leanVersionFile.toString()) {
             const version = await this.readLeanVersion();
-            this.localStorage.setLeanVersion('');
-            // raise an event so the extension triggers handleVersionChanged.
-            this.versionChangedEmitter.fire(version);
+            if (version !== this.currentVersion){
+                this.currentVersion = version;
+                this.localStorage.setLeanVersion('');
+                // raise an event so the extension triggers handleVersionChanged.
+                this.versionChangedEmitter.fire(version);
+            }
         }
     }
 


### PR DESCRIPTION
It happens when you deliberately crash the lean client multiple times by requesting invalid versions.

The fix is easy, make LanguageClient use the one OutputChannel that our extension creates instead of having it create another one.