### PR TITLE
Add configuration default for `editor.wordSeparators`

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -380,7 +380,8 @@
 		"configurationDefaults": {
 			"[lean4]": {
 				"editor.unicodeHighlight.ambiguousCharacters": false,
-				"editor.tabSize": 2
+				"editor.tabSize": 2,
+				"editor.wordSeparators": "`~@$%^&*()-=+[{]}⟨⟩⦃⦄⟦⟧⟮⟯‹›\\|;:\",.<>/"
 			}
 		}
 	},


### PR DESCRIPTION
This allows editor selection expansion (for example when double-clicking a word) to respect custom parentheses used in Lean. The new value for the setting is based on the `wordPattern` property in `language-configuration.json`. For comparison, the default value of the setting is `` `~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?``.

An issue with the previous behavior was, for example, when double-clicking `b` in `⟨a, b⟩`, `b⟩` was selected instead of just `b` (as mentioned in https://github.com/leanprover/lean4/issues/767).