### PR TITLE
fix: reveal file location should move the keyboard focus to the text editor

### DIFF
--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -379,6 +379,8 @@ export class InfoProvider implements Disposable {
         if (selection !== undefined) {
             editor.revealRange(selection, TextEditorRevealType.InCenterIfOutsideViewport);
             editor.selection = new Selection(selection.start, selection.end);
+            // ensure the text document has the keyboard focus.
+            window.showTextDocument(editor.document, { viewColumn: editor.viewColumn, preserveFocus: false });
         }
     }
 

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -380,7 +380,7 @@ export class InfoProvider implements Disposable {
             editor.revealRange(selection, TextEditorRevealType.InCenterIfOutsideViewport);
             editor.selection = new Selection(selection.start, selection.end);
             // ensure the text document has the keyboard focus.
-            window.showTextDocument(editor.document, { viewColumn: editor.viewColumn, preserveFocus: false });
+            void window.showTextDocument(editor.document, { viewColumn: editor.viewColumn, preserveFocus: false });
         }
     }
 


### PR DESCRIPTION
fixes #71 

A simple window.showTextDocument does the trick.