### PR TITLE
fix: some more -32801 errors are reported in the console log.

### DIFF
--- a/lean4-infoview/src/infoview/messages.tsx
+++ b/lean4-infoview/src/infoview/messages.tsx
@@ -100,7 +100,8 @@ export function AllMessages({uri: uri0}: { uri: DocumentUri }) {
                 return await getInteractiveDiagnostics(rs, { uri: uri0, line: 0, character: 0 }) || [];
             } catch (err: any) {
                 if (err?.code === -32801) {
-                    // Document has been changed since we made the request, try again later?
+                    // Document has been changed since we made the request.
+                    // This can happen while typing quickly, so server will catch up on next edit.
                 } else {
                     console.log('getInteractiveDiagnostics error ', err)
                 }
@@ -176,8 +177,8 @@ export function useMessagesForFile(uri: DocumentUri, line?: number): Interactive
                 }
             } catch (err: any) {
                 if (err?.code === -32801) {
-                    // Document has been changed since we made the request, try again later?
-                    return;
+                    // Document has been changed since we made the request.
+                    // This can happen while typing quickly, so server will catch up on next edit.
                 } else {
                     console.log('getInteractiveDiagnostics error ', err)
                 }

--- a/lean4-infoview/src/infoview/messages.tsx
+++ b/lean4-infoview/src/infoview/messages.tsx
@@ -99,7 +99,12 @@ export function AllMessages({uri: uri0}: { uri: DocumentUri }) {
             try {
                 return await getInteractiveDiagnostics(rs, { uri: uri0, line: 0, character: 0 }) || [];
             } catch (err: any) {
-                console.log('getInteractiveDiagnostics error ', err)
+                if (err?.code === -32801) {
+                    // Document has been changed since we made the request, try again later?
+                    return;
+                } else {
+                    console.log('getInteractiveDiagnostics error ', err)
+                }
             }
         }
         return diags0.map(d => ({ ...(d as LeanDiagnostic), message: { text: d.message } }));
@@ -171,7 +176,12 @@ export function useMessagesForFile(uri: DocumentUri, line?: number): Interactive
                     setDiags(diags)
                 }
             } catch (err: any) {
-                console.log('getInteractiveDiagnostics error ', err)
+                if (err?.code === -32801) {
+                    // Document has been changed since we made the request, try again later?
+                    return;
+                } else {
+                    console.log('getInteractiveDiagnostics error ', err)
+                }
             }
         }
     }

--- a/lean4-infoview/src/infoview/messages.tsx
+++ b/lean4-infoview/src/infoview/messages.tsx
@@ -100,8 +100,10 @@ export function AllMessages({uri: uri0}: { uri: DocumentUri }) {
                 return await getInteractiveDiagnostics(rs, { uri: uri0, line: 0, character: 0 }) || [];
             } catch (err: any) {
                 if (err?.code === -32801) {
-                    // Document has been changed since we made the request.
-                    // This can happen while typing quickly, so server will catch up on next edit.
+                    // Document has been changed since we made the request. This can happen
+                    // while typing quickly. When the server catches up on next edit, it will
+                    // send new diagnostics to which the infoview responds by calling
+                    // `getInteractiveDiagnostics` again.
                 } else {
                     console.log('getInteractiveDiagnostics error ', err)
                 }

--- a/lean4-infoview/src/infoview/messages.tsx
+++ b/lean4-infoview/src/infoview/messages.tsx
@@ -101,7 +101,6 @@ export function AllMessages({uri: uri0}: { uri: DocumentUri }) {
             } catch (err: any) {
                 if (err?.code === -32801) {
                     // Document has been changed since we made the request, try again later?
-                    return;
                 } else {
                     console.log('getInteractiveDiagnostics error ', err)
                 }


### PR DESCRIPTION
Minor cleanup of console.log errors.  Do we want to implement a retry in the lazy fetch of updated diagnostics or just wait for the next edit? 