### PR TITLE
fix: #115 : Infoview not working for external file

### DIFF
--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -417,7 +417,7 @@ export class InfoProvider implements Disposable {
             // The infoview gets information about file progress, diagnostics, etc.
             // by listening to notifications.  Send these notifications when the infoview starts
             // so that it has up-to-date information.
-            var client = this.clientProvider.findClient(editor.document?.uri?.toString());
+            const client = this.clientProvider.findClient(editor.document?.uri?.toString());
             if (client?.initializeResult) {
                 await this.webviewPanel.api.serverRestarted(client?.initializeResult);
             }

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -462,6 +462,7 @@ export class InfoProvider implements Disposable {
 
     private onLanguageChanged() {
         void this.autoOpen();
+        void this.sendPosition();
     }
 
     private getLocation(editor : TextEditor) : ls.Location | undefined {
@@ -478,9 +479,15 @@ export class InfoProvider implements Disposable {
     }
 
     private async sendPosition() {
-        if (!window.activeTextEditor || languages.match(this.leanDocs, window.activeTextEditor.document) === 0) return
-        await this.autoOpen();
+        if (!window.activeTextEditor) return
         const loc = this.getLocation(window.activeTextEditor);
+        if (languages.match(this.leanDocs, window.activeTextEditor.document) === 0){
+            // language is not yet 'lean4', but the LeanClient will fire the didSetLanguage event
+            // in openLean4Document and that's when we can send the position to update the
+            // InfoView for the newly opened document.
+            return;
+        }
+        await this.autoOpen();
         await this.webviewPanel?.api.changedCursorLocation(loc);
     }
 

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -301,6 +301,10 @@ export class LeanClient implements Disposable {
             return;
         }
 
+        // didOpenEditor may have also changed the language, so we fire the
+        // event here because the InfoView should be wired up to receive it now.
+        this.didSetLanguageEmitter.fire(doc.languageId)
+
         void this.client.sendNotification(DidOpenTextDocumentNotification.type, {
             textDocument: {
                 uri: doc.uri.toString(),

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -41,7 +41,7 @@ export class LeanClient implements Disposable {
     private outputChannel: OutputChannel;
     private storageManager : LocalStorageService;
     private workspaceFolder: WorkspaceFolder;
-
+    private folderUri: Uri;
     private subscriptions: Disposable[] = []
 
     private didChangeEmitter = new EventEmitter<DidChangeTextDocumentParams>()
@@ -78,11 +78,11 @@ export class LeanClient implements Disposable {
     /** Files which are open. */
     private isOpen: Set<string> = new Set()
 
-    constructor(workspaceFolder: WorkspaceFolder, storageManager : LocalStorageService, outputChannel : OutputChannel) {
+    constructor(workspaceFolder: WorkspaceFolder, folderUri: Uri, storageManager : LocalStorageService, outputChannel : OutputChannel) {
         this.storageManager = storageManager;
         this.outputChannel = outputChannel;
-        this.workspaceFolder = workspaceFolder;
-
+        this.workspaceFolder = workspaceFolder; // can be null when opening adhoc files.
+        this.folderUri = folderUri;
         this.subscriptions.push(workspace.onDidChangeConfiguration((e) => this.configChanged(e)));
     }
 
@@ -111,8 +111,8 @@ export class LeanClient implements Disposable {
             // user is requesting an explicit version for this workspace.
             options = ['+' + version, '--server']
         }
-        if (this.workspaceFolder) {
-            options.push('' + this.workspaceFolder.uri.fsPath)
+        if (this.folderUri) {
+            options.push('' + this.folderUri.fsPath)
         } else {
             options.push('untitled')
         }
@@ -130,11 +130,11 @@ export class LeanClient implements Disposable {
             language: 'lean4'
         }
 
-        if (this.workspaceFolder){
-            documentSelector.scheme = 'file'
-            documentSelector.pattern = `${this.workspaceFolder.uri.fsPath}/**/*`
-        } else {
-            documentSelector.scheme = 'untitled'
+        if (this.folderUri){
+            documentSelector.scheme = this.folderUri.scheme
+            if (this.folderUri.scheme !== 'untitled') {
+                documentSelector.pattern = `${this.folderUri.fsPath}/**/*`
+            }
         }
 
         const clientOptions: LanguageClientOptions = {
@@ -142,8 +142,7 @@ export class LeanClient implements Disposable {
             documentSelector: [documentSelector],
             workspaceFolder: this.workspaceFolder,
             initializationOptions: {
-                editDelay: getElaborationDelay(),
-		hasWidgets: true,
+                editDelay: getElaborationDelay(), hasWidgets: true,
             },
             middleware: {
                 handleDiagnostics: (uri, diagnostics, next) => {
@@ -223,6 +222,7 @@ export class LeanClient implements Disposable {
                     console.log('client starting');
                 } else if (s.newState === State.Running) {
                     console.log('client running');
+                    this.running = true; // may have been auto restarted after it failed.
                 } else if (s.newState === State.Stopped) {
                     console.log('client has stopped or it failed to start');
                     this.running = false;
@@ -291,6 +291,9 @@ export class LeanClient implements Disposable {
     }
 
     async openLean4Document(doc: TextDocument) {
+        if (this.isOpen.has(doc.uri.toString())) return;
+        this.isOpen.add(doc.uri.toString())
+
         if (!this.running) return; // there was a problem starting lean server.
 
         if (!this.isSameWorkspace(doc.uri)){
@@ -298,8 +301,6 @@ export class LeanClient implements Disposable {
             return;
         }
 
-        if (this.isOpen.has(doc.uri.toString())) return;
-        this.isOpen.add(doc.uri.toString())
         void this.client.sendNotification(DidOpenTextDocumentNotification.type, {
             textDocument: {
                 uri: doc.uri.toString(),
@@ -311,8 +312,8 @@ export class LeanClient implements Disposable {
     }
 
     isSameWorkspace(uri: Uri){
-        if (this.workspaceFolder) {
-            if (uri.toString().startsWith(this.workspaceFolder.uri.toString())) {
+        if (this.folderUri) {
+            if (uri.toString().startsWith(this.folderUri.toString())) {
                 // skip it, this file belongs to a different workspace...
                 return true;
             }
@@ -324,7 +325,7 @@ export class LeanClient implements Disposable {
     }
 
     getWorkspaceFolder() : string {
-        return this.workspaceFolder?.uri.toString();
+        return this.folderUri?.toString();
     }
 
     start(): Promise<void> {

--- a/vscode-lean4/src/taskgutter.ts
+++ b/vscode-lean4/src/taskgutter.ts
@@ -7,6 +7,7 @@ class LeanFileTaskGutter {
 
     constructor(private uri: string, private decorations: Map<LeanFileProgressKind, [TextEditorDecorationType, string]>, private processed: LeanFileProgressProcessingInfo[]) {
         this.schedule(100)
+        this.processed = []
     }
 
     setProcessed(processed: LeanFileProgressProcessingInfo[]) {

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -167,13 +167,13 @@ export class LeanClientProvider implements Disposable {
     }
 
     async getLeanVersion(uri: Uri) : Promise<LeanVersion> {
-        let [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
+        const [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
         const path = folderUri?.toString();
         if (this.versions.has(path)){
             return this.versions.get(path);
         }
         let versionInfo : LeanVersion = null;
-        if (uri.scheme == 'untitled'){
+        if (uri.scheme === 'untitled'){
             versionInfo = { version: '4', error: null };
         } else {
             versionInfo = await this.installer.testLeanVersion(folderUri);
@@ -183,7 +183,7 @@ export class LeanClientProvider implements Disposable {
     }
 
     async ensureClient(uri: Uri, versionInfo: LeanVersion | null): Promise<LeanClient> {
-        let [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
+        const [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
 
         const path = folderUri?.toString();
         let  client: LeanClient = null;

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -99,7 +99,7 @@ export class LeanClientProvider implements Disposable {
     }
 
     private getVisibleEditor(uri: Uri) : TextEditor | null {
-        var path = uri.toString();
+        const path = uri.toString();
         for (const editor of window.visibleTextEditors) {
             if (editor.document.uri.toString() === path){
                 return editor;
@@ -135,7 +135,7 @@ export class LeanClientProvider implements Disposable {
             return;
         }
 
-        let client = await this.ensureClient(document.uri, null);
+        const client = await this.ensureClient(document.uri, null);
         await client.openLean4Document(document)
     }
 

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -52,7 +52,7 @@ export class LeanClientProvider implements Disposable {
                 if (client) {
                     this.clients.delete(path);
                     this.versions.delete(path);
-                    void client.stop();
+                    client.dispose();
                     this.clientRemovedEmitter.fire(client);
                 }
             }
@@ -212,6 +212,7 @@ export class LeanClientProvider implements Disposable {
                 console.log(`Lean4 extension ignoring workspace '${folderUri}' because it is not a Lean 4 workspace.`);
                 this.pending.delete(path);
                 this.clients.delete(path);
+                client.dispose();
                 return;
             }
 

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -4,7 +4,7 @@ import { LeanInstaller, LeanVersion } from './leanInstaller'
 import { LeanClient } from '../leanclient'
 import { LeanFileProgressProcessingInfo, RpcConnectParams, RpcKeepAliveParams } from '@lean4/infoview-api';
 import * as path from 'path';
-import { urlToHttpOptions } from 'url';
+import { findLeanPackageRoot } from './projectInfo';
 
 // This class ensures we have one LeanClient per workspace folder.
 export class LeanClientProvider implements Disposable {
@@ -12,7 +12,7 @@ export class LeanClientProvider implements Disposable {
     private localStorage: LocalStorageService;
     private outputChannel: OutputChannel;
     private installer : LeanInstaller;
-    private versions: Map<string, string> = new Map();
+    private versions: Map<string, LeanVersion> = new Map();
     private clients: Map<string, LeanClient> = new Map();
     private pending: Map<string, boolean> = new Map();
     private testing: Map<string, boolean> = new Map();
@@ -59,19 +59,24 @@ export class LeanClientProvider implements Disposable {
         });
 
         installer.installChanged(async (uri: Uri | undefined) => {
+            // This Uri could be 'undefined' in the case of a selectToolChain "reset"
+            // Or it could be a package Uri in the case a lean package file was changed
+            // or it could be a document Uri in the case of a command from
+            // selectToolchainForActiveEditor.
             const path = uri?.toString()
             if (path in this.testing) return;
             // avoid re-entrancy since testLeanVersion can take a while.
             this.testing[path] = true;
             try {
                 // have to check again here in case elan install had --default-toolchain none.
-                const version = await installer.testLeanVersion(uri);
+                const [workspaceFolder, packageUri, packageFileUri] = findLeanPackageRoot(uri);
+                const version = await installer.testLeanVersion(packageUri);
                 if (version.version === '4') {
                     if (this.clients.has(path)) {
                         const client = this.clients.get(path)
                         void client.restart()
                     } else {
-                        void this.ensureClient(this.getDocument(path).uri, version);
+                        void this.ensureClient(packageUri, version);
                     }
                 }
             } catch {
@@ -79,23 +84,6 @@ export class LeanClientProvider implements Disposable {
             this.testing.delete(path);
         });
 
-    }
-
-    private getDocument(path: string) : TextDocument | null {
-        if (window.activeTextEditor && window.activeTextEditor.document.uri.toString() === path)
-        {
-            return window.activeTextEditor.document
-        }
-        else {
-            // This happens if vscode starts with a lean file open
-            // but the "Getting Started" page is active.
-            for (const editor of window.visibleTextEditors) {
-                if (editor.document.uri.toString() === path){
-                    return editor.document;
-                }
-            }
-        }
-        return null;
     }
 
     private getVisibleEditor(uri: Uri) : TextEditor | null {
@@ -129,22 +117,22 @@ export class LeanClientProvider implements Disposable {
             return;
         }
 
+        // All open .lean files are assumed to be Lean 4 files.
+        // We need to do this because by default, .lean is associated with language id `lean`,
+        // i.e. Lean 3. vscode-lean is expected to yield when isLean4Project is true.
+        if (document.languageId === 'lean') {
+            // Only change the document language for *visible* documents,
+            // because this closes and then reopens the document.
+            await languages.setTextDocumentLanguage(document, 'lean4');
+
+            // setTextDocumentLanguage triggers another didOpenEditor event,
+            // and we want that event callback to be the one that calls
+            // ensureClient, so we bail here so we don't try and do it twice
+            // on the same document.
+            return;
+        }
+
         try {
-            // All open .lean files are assumed to be Lean 4 files.
-            // We need to do this because by default, .lean is associated with language id `lean`,
-            // i.e. Lean 3. vscode-lean is expected to yield when isLean4Project is true.
-            if (document.languageId === 'lean') {
-                // Only change the document language for *visible* documents,
-                // because this closes and then reopens the document.
-                await languages.setTextDocumentLanguage(document, 'lean4');
-
-                // setTextDocumentLanguage triggers another didOpenEditor event,
-                // and we want that event callback to be the one that calls
-                // ensureClient, so we bail here so we don't try and do it twice
-                // on the same document.
-                return;
-            }
-
             const client = await this.ensureClient(document.uri, null);
             await client.openLean4Document(document)
         } catch (e) {
@@ -178,24 +166,31 @@ export class LeanClientProvider implements Disposable {
         return null;
     }
 
-    async ensureClient(uri: Uri, versionInfo: LeanVersion | null): Promise<LeanClient> {
-        let folder = workspace.getWorkspaceFolder(uri);
-        if (!folder && workspace.workspaceFolders) {
-            // Could be that doc.uri.scheme === 'untitled'.
-            workspace.workspaceFolders.forEach((f) => {
-                if (f.uri.fsPath && uri.fsPath.startsWith(f.uri.fsPath)) {
-                    folder = f;
-                }
-            });
+    async getLeanVersion(uri: Uri) : Promise<LeanVersion> {
+        let [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
+        const path = folderUri?.toString();
+        if (this.versions.has(path)){
+            return this.versions.get(path);
         }
+        let versionInfo : LeanVersion = null;
+        if (uri.scheme == 'untitled'){
+            versionInfo = { version: '4', error: null };
+        } else {
+            versionInfo = await this.installer.testLeanVersion(folderUri);
+        }
+        this.versions.set(path, versionInfo);
+        return versionInfo;
+    }
 
-        const folderUri = folder ? folder.uri : this.getFolderFromUri(uri);
+    async ensureClient(uri: Uri, versionInfo: LeanVersion | null): Promise<LeanClient> {
+        let [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
+
         const path = folderUri?.toString();
         let  client: LeanClient = null;
         if (this.clients.has(path)) {
             // we're good then
             client = this.clients.get(path);
-        } else if (!this.versions.has(path) && !this.pending.has(path)) {
+        } else if (!this.clients.has(path) && !this.pending.has(path)) {
             this.pending.set(path, true);
             console.log('Creating LeanClient for ' + path);
 
@@ -205,16 +200,13 @@ export class LeanClientProvider implements Disposable {
             // every open file.  A workspace could have multiple files open and we want
             // to remember all those open files are associated with this client before
             // testLeanVersion has completed.
-            client = new LeanClient(folder, folderUri, this.localStorage, this.outputChannel);
+            client = new LeanClient(workspaceFolder, folderUri, this.localStorage, this.outputChannel);
             this.subscriptions.push(client);
             this.clients.set(path, client);
 
             if (!versionInfo) {
-                // TODO: what is the uri for untitled documents?  Hopefully they get their own special
-                // LeanClient with some default version...
-                versionInfo = await this.installer.testLeanVersion(folderUri);
+                versionInfo = await this.getLeanVersion(folderUri);
             }
-            this.versions.set(path, versionInfo.version);
             if (versionInfo.version && versionInfo.version !== '4') {
                 // ignore workspaces that belong to a different version of Lean.
                 console.log(`Lean4 extension ignoring workspace '${folderUri}' because it is not a Lean 4 workspace.`);

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -116,27 +116,40 @@ export class LeanClientProvider implements Disposable {
     }
 
     async didOpenEditor(document: TextDocument) {
+        // bail as quickly as possible on non-lean files.
+        if (document.languageId !== 'lean' && document.languageId !== 'lean4') {
+            return;
+        }
+
         if (!this.getVisibleEditor(document.uri)) {
             // Sometimes VS code opens a document that has no editor yet.
-            // For example, this happens when the vs code opens files to get git information
-            // like this:
+            // For example, this happens when the vs code opens files to get git
+            // information using a "git:" Uri scheme:
             //  git:/d%3A/Temp/lean_examples/Foo/Foo/Hello.lean.git?%7B%22path%22%3A%22d%3A%5C%5CTemp%5C%5Clean_examples%5C%5CFoo%5C%5CFoo%5C%5CHello.lean%22%2C%22ref%22%3A%22%22%7D
             return;
         }
 
-        // All open .lean files are assumed to be Lean 4 files.
-        // We need to do this because by default, .lean is associated with language id `lean`,
-        // i.e. Lean 3. vscode-lean is expected to yield when isLean4Project is true.
-        if (document.languageId === 'lean') {
-            // Only change the document language for *visible* documents,
-            // because this closes and then reopens the document.
-            await languages.setTextDocumentLanguage(document, 'lean4');
-        } else if (document.languageId !== 'lean4') {
-            return;
-        }
+        try {
+            // All open .lean files are assumed to be Lean 4 files.
+            // We need to do this because by default, .lean is associated with language id `lean`,
+            // i.e. Lean 3. vscode-lean is expected to yield when isLean4Project is true.
+            if (document.languageId === 'lean') {
+                // Only change the document language for *visible* documents,
+                // because this closes and then reopens the document.
+                await languages.setTextDocumentLanguage(document, 'lean4');
 
-        const client = await this.ensureClient(document.uri, null);
-        await client.openLean4Document(document)
+                // setTextDocumentLanguage triggers another didOpenEditor event,
+                // and we want that event callback to be the one that calls
+                // ensureClient, so we bail here so we don't try and do it twice
+                // on the same document.
+                return;
+            }
+
+            const client = await this.ensureClient(document.uri, null);
+            await client.openLean4Document(document)
+        } catch (e) {
+            console.log(`### error opening document: ${e}`);
+        }
     }
 
     // Find the client for a given document.

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -214,7 +214,7 @@ export class LeanInstaller implements Disposable {
             // assume untitled files are version 4?  Actually no...
             return { version: '4', error: null };
         }
-        if (packageUri?.scheme == 'file') {
+        if (packageUri?.scheme === 'file') {
             folderPath = packageUri.fsPath
         }
 

--- a/vscode-lean4/src/utils/leanpkg.ts
+++ b/vscode-lean4/src/utils/leanpkg.ts
@@ -39,7 +39,7 @@ export class LeanpkgService implements Disposable {
                 rootPath = folder.uri;
             }
             if (!rootPath) {
-                rootPath = window.activeTextEditor.document.uri;
+                rootPath = window.activeTextEditor?.document.uri;
                 if (rootPath) {
                     // remove leaf filename part.
                     rootPath = Uri.joinPath(rootPath, '..');

--- a/vscode-lean4/src/utils/leanpkg.ts
+++ b/vscode-lean4/src/utils/leanpkg.ts
@@ -1,24 +1,25 @@
-import * as fs from 'fs';
-import { URL } from 'url';
 import { EventEmitter, Disposable, Uri, workspace, window, WorkspaceFolder } from 'vscode';
 import { LocalStorageService} from './localStorage'
+import { findLeanPackageVersionInfo } from './projectInfo';
 
 export class LeanpkgService implements Disposable {
     private subscriptions: Disposable[] = [];
-    private leanVersionFile : Uri = null;
-    private toolchainFileName : string = 'lean-toolchain'
-    private tomlFileName : string = 'leanpkg.toml'
     private defaultToolchain : string;
     private localStorage : LocalStorageService;
-    private versionChangedEmitter = new EventEmitter<Uri>();
     private currentVersion : string = null;
+
+    // This event is raised when the version in the package root changes.
+    // The event provides the lean package root Uri.
+    private versionChangedEmitter = new EventEmitter<Uri>();
     versionChanged = this.versionChangedEmitter.event
 
     constructor(localStorage : LocalStorageService, defaultToolchain : string) {
         this.localStorage = localStorage;
         this.defaultToolchain = defaultToolchain;
+
         // track changes in the version of lean specified in the lean-toolchain file
-        // or the leanpkg.toml.
+        // or the leanpkg.toml.  While this is looking for all files with these names
+        // it ignores files that are not in the package root.
         ['**/lean-toolchain', '**/leanpkg.toml'].forEach(pattern => {
             const watcher = workspace.createFileSystemWatcher(pattern);
             watcher.onDidChange((u) => this.handleFileChanged(u));
@@ -26,76 +27,6 @@ export class LeanpkgService implements Disposable {
             watcher.onDidDelete((u) => this.handleFileChanged(u));
             this.subscriptions.push(watcher);
         });
-    }
-
-    getWorkspaceLeanFolderUri(documentUri: Uri | undefined) : Uri {
-        let rootPath : Uri = null;
-        if (documentUri) {
-            // TODO: do we need to deal with nested workspace folders?
-            // According to this sample nested workspaces is a thing...
-            // https://github.com/microsoft/vscode-extension-samples
-            const folder = workspace.getWorkspaceFolder(documentUri);
-            if (folder){
-                rootPath = folder.uri;
-            }
-            if (!rootPath) {
-                rootPath = window.activeTextEditor?.document.uri;
-                if (rootPath) {
-                    // remove leaf filename part.
-                    rootPath = Uri.joinPath(rootPath, '..');
-                }
-            }
-        }
-
-        if (!rootPath) {
-            return null;
-        }
-        return rootPath;
-    }
-
-    async findLeanPkgVersionInfo(uri: Uri) : Promise<string> {
-        const path = this.getWorkspaceLeanFolderUri(uri)
-        if (!path || path.fsPath === '.') {
-            // this is a "new file" that has not been saved yet.
-        }
-        else {
-            let uri = path;
-            // search parent folders for a leanpkg.toml file, or a Lake lean-toolchain file.
-            while (true) {
-                const leanToolchain = Uri.joinPath(uri, this.toolchainFileName);
-                if (fs.existsSync(new URL(leanToolchain.toString()))) {
-                    this.leanVersionFile = leanToolchain;
-                    break;
-                }
-                else {
-                    const leanPkg = Uri.joinPath(uri, this.tomlFileName);
-                    if (fs.existsSync(new URL(leanPkg.toString()))) {
-                        this.leanVersionFile = leanPkg;
-                        break;
-                    }
-                    else {
-                        const parent = Uri.joinPath(uri, '..');
-                        if (parent === uri) {
-                            // no .toml file found.
-                            break;
-                        }
-                        uri = parent;
-                    }
-                }
-            }
-        }
-
-        let version = null;
-        if (this.leanVersionFile || this.leanVersionFile) {
-            try {
-                version = await this.readLeanVersion();
-                this.currentVersion = version;
-            } catch (err) {
-                console.log(err);
-            }
-        }
-
-        return version;
     }
 
     dispose(): void {
@@ -111,50 +42,10 @@ export class LeanpkgService implements Disposable {
         // if a file is added or removed so we always match the elan behavior.
         const current = this.currentVersion;
         // findLeanPkgVersionInfo changes this.currentVersion
-        const version = await this.findLeanPkgVersionInfo(uri);
-        if (version && version !== current) {
+        const [packageUri, version] = await findLeanPackageVersionInfo(uri);
+        if (packageUri && version && version !== current) {
             // raise an event so the extension triggers handleVersionChanged.
-            this.versionChangedEmitter.fire(uri);
-        }
-    }
-
-    private async readLeanVersion() {
-        if (this.leanVersionFile.path.endsWith(this.tomlFileName))
-        {
-            const url = new URL(this.leanVersionFile.toString());
-            return new Promise<string>((resolve, reject) => {
-                if (fs.existsSync(url)) {
-                    fs.readFile(url, { encoding: 'utf-8' }, (err, data) =>{
-                        if (err) {
-                            reject(err);
-                        } else {
-                            let version = this.defaultToolchain;
-                            const match = /lean_version\s*=\s*"([^"]*)"/.exec(data.toString());
-                            if (match) version = match[1];
-                            resolve(version);
-                        }
-                    });
-                } else {
-                    resolve(this.defaultToolchain);
-                }
-            });
-        } else {
-            // must be a lean-toolchain file, these are much simpler they only contain a version.
-            const url = new URL(this.leanVersionFile.toString());
-            return new Promise<string>((resolve, reject) => {
-                if (fs.existsSync(url)) {
-                    fs.readFile(url, { encoding: 'utf-8' }, (err, data) =>{
-                        if (err) {
-                            reject(err);
-                        } else {
-                            const version = data.trim() ?? this.defaultToolchain;
-                            resolve(version);
-                        }
-                    });
-                } else {
-                    resolve(this.defaultToolchain);
-                }
-            });
+            this.versionChangedEmitter.fire(packageUri);
         }
     }
 }

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -9,7 +9,7 @@ export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
 
     const toolchainFileName = 'lean-toolchain';
     const tomlFileName = 'leanpkg.toml';
-    if (uri.scheme == 'untitled'){
+    if (uri.scheme === 'untitled'){
         // then return a Uri representing all untitled files.
         return [null, Uri.from({scheme: 'untitled'}), null];
     }
@@ -17,7 +17,7 @@ export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
     let wsFolder = workspace.getWorkspaceFolder(uri);
     if (!wsFolder && workspace.workspaceFolders) {
         workspace.workspaceFolders.forEach((f) => {
-            if (f.uri?.scheme == 'file' && f.uri.fsPath && uri.fsPath.startsWith(f.uri.fsPath)) {
+            if (f.uri?.scheme === 'file' && f.uri.fsPath && uri.fsPath.startsWith(f.uri.fsPath)) {
                 wsFolder = f;
             }
         });
@@ -26,7 +26,7 @@ export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
     if (wsFolder){
         // jump to the real workspace folder if we have a Workspace for this file.
         path = wsFolder.uri;
-    } else if (path.scheme == 'file') {
+    } else if (path.scheme === 'file') {
         // then start searching from the directory containing this document.
         // The given uri may already be a folder Uri in some cases.
         if (fs.lstatSync(path.fsPath).isFile()) {
@@ -34,7 +34,7 @@ export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
         }
         searchUpwards = true;
     }
-    if (path.scheme == 'file') {
+    if (path.scheme === 'file') {
         // search parent folders for a leanpkg.toml file, or a Lake lean-toolchain file.
         while (true) {
             // give preference to 'lean-toolchain' files if any.
@@ -73,7 +73,7 @@ export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
 export async function findLeanPackageVersionInfo(uri: Uri) : Promise<[Uri,string]> {
 
     const [_, packageUri, packageFileUri] =findLeanPackageRoot(uri);
-    if (!packageUri || packageUri.scheme == 'untitled') return null;
+    if (!packageUri || packageUri.scheme === 'untitled') return null;
 
     let version = null;
     if (packageFileUri) {
@@ -105,7 +105,7 @@ export async function readLeanVersion(packageUri: Uri){
     return null;
 }
 
-async function readLeanVersionFile(packageFileUri) : Promise<string> {
+async function readLeanVersionFile(packageFileUri : Uri) : Promise<string> {
     const url = new URL(packageFileUri.toString());
     const tomlFileName = 'leanpkg.toml';
     if (packageFileUri.path.endsWith(tomlFileName))
@@ -116,7 +116,6 @@ async function readLeanVersionFile(packageFileUri) : Promise<string> {
                     if (err) {
                         reject(err);
                     } else {
-                        let version = null;
                         const match = /lean_version\s*=\s*"([^"]*)"/.exec(data.toString());
                         if (match) resolve(match[1]);
                         reject(null);

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -1,0 +1,147 @@
+import * as fs from 'fs';
+import { URL } from 'url';
+import { Uri, workspace, WorkspaceFolder } from 'vscode';
+
+// Find the root of a Lean project and return the Uri for the package root and the Uri
+// for the 'leanpkg.toml' or 'lean-toolchain' file found there.
+export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
+    if (!uri) return [null, null, null];
+
+    const toolchainFileName = 'lean-toolchain';
+    const tomlFileName = 'leanpkg.toml';
+    if (uri.scheme == 'untitled'){
+        // then return a Uri representing all untitled files.
+        return [null, Uri.from({scheme: 'untitled'}), null];
+    }
+    let path = uri;
+    let wsFolder = workspace.getWorkspaceFolder(uri);
+    if (!wsFolder && workspace.workspaceFolders) {
+        workspace.workspaceFolders.forEach((f) => {
+            if (f.uri?.scheme == 'file' && f.uri.fsPath && uri.fsPath.startsWith(f.uri.fsPath)) {
+                wsFolder = f;
+            }
+        });
+    }
+    let searchUpwards = false;
+    if (wsFolder){
+        // jump to the real workspace folder if we have a Workspace for this file.
+        path = wsFolder.uri;
+    } else if (path.scheme == 'file') {
+        // then start searching from the directory containing this document.
+        // The given uri may already be a folder Uri in some cases.
+        if (fs.lstatSync(path.fsPath).isFile()) {
+            path = Uri.joinPath(uri, '..');
+        }
+        searchUpwards = true;
+    }
+    if (path.scheme == 'file') {
+        // search parent folders for a leanpkg.toml file, or a Lake lean-toolchain file.
+        while (true) {
+            // give preference to 'lean-toolchain' files if any.
+            const leanToolchain = Uri.joinPath(path, toolchainFileName);
+            if (fs.existsSync(leanToolchain.fsPath)) {
+                return [wsFolder, path, leanToolchain];
+            }
+            else {
+                const leanPkg = Uri.joinPath(path, tomlFileName);
+                if (fs.existsSync(leanPkg.fsPath)) {
+                    return [wsFolder, path, leanPkg];
+                }
+                else if (searchUpwards) {
+                    const parent = Uri.joinPath(path, '..');
+                    if (parent === path) {
+                        // no project file found.
+                        break;
+                    }
+                    path = parent;
+                }
+                else {
+                    // don't search above a WorkspaceFolder barrier.
+                    break;
+                }
+            }
+        }
+    } else {
+        // TODO: do we care about HTTP schemes?
+        return [null, null, null];
+    }
+}
+
+// Find the lean project root for the given document and return the
+// Uri for the project root and the "version" information contained
+// in any 'lean-toolchain' or 'leanpkg.toml' file found there.
+export async function findLeanPackageVersionInfo(uri: Uri) : Promise<[Uri,string]> {
+
+    const [_, packageUri, packageFileUri] =findLeanPackageRoot(uri);
+    if (!packageUri || packageUri.scheme == 'untitled') return null;
+
+    let version = null;
+    if (packageFileUri) {
+        try {
+            version = await readLeanVersionFile(packageFileUri);
+        } catch (err) {
+            console.log(err);
+        }
+    }
+
+    return [packageUri, version];
+}
+
+// Find the 'leanpkg.toml' or 'lean-toolchain' in the given package root and
+// extract the Lean version info from it.
+export async function readLeanVersion(packageUri: Uri){
+    const toolchainFileName = 'lean-toolchain';
+    const tomlFileName = 'leanpkg.toml';
+    const leanToolchain = Uri.joinPath(packageUri, toolchainFileName);
+    if (fs.existsSync(new URL(leanToolchain.toString()))) {
+        return await readLeanVersionFile(leanToolchain);
+    }
+    else {
+        const leanPkg = Uri.joinPath(packageUri, tomlFileName);
+        if (fs.existsSync(new URL(leanPkg.toString()))) {
+            return readLeanVersionFile(leanPkg);
+        }
+    }
+    return null;
+}
+
+async function readLeanVersionFile(packageFileUri) : Promise<string> {
+    const url = new URL(packageFileUri.toString());
+    const tomlFileName = 'leanpkg.toml';
+    if (packageFileUri.path.endsWith(tomlFileName))
+    {
+        return new Promise<string>((resolve, reject) => {
+            if (fs.existsSync(url)) {
+                fs.readFile(url, { encoding: 'utf-8' }, (err, data) =>{
+                    if (err) {
+                        reject(err);
+                    } else {
+                        let version = null;
+                        const match = /lean_version\s*=\s*"([^"]*)"/.exec(data.toString());
+                        if (match) resolve(match[1]);
+                        reject(null);
+                    }
+                });
+            } else {
+                resolve(null);
+            }
+        });
+    } else {
+        // must be a lean-toolchain file, these are much simpler they only contain a version.
+        return new Promise<string>((resolve, reject) => {
+            if (fs.existsSync(url)) {
+                fs.readFile(url, { encoding: 'utf-8' }, (err, data) =>{
+                    if (err) {
+                        reject(err);
+                    } else if (data) {
+                        resolve(data.trim());
+                    } else {
+                        reject(null);
+                    }
+                });
+            } else {
+                reject(null);
+            }
+        });
+    }
+}

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -4,7 +4,7 @@ import { Uri, workspace, WorkspaceFolder } from 'vscode';
 
 // Find the root of a Lean project and return the Uri for the package root and the Uri
 // for the 'leanpkg.toml' or 'lean-toolchain' file found there.
-export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
+export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder | null, Uri | null, Uri | null] {
     if (!uri) return [null, null, null];
 
     const toolchainFileName = 'lean-toolchain';


### PR DESCRIPTION
Fixes #115

Turns out the work to support "untitled" files broke the "ad hoc" files.   Now I've tested the following scenarios:
- start vs code from start menu (not from a folder), File/Open file..., works (let's call this an "adhoc" file).
- start vs code from start menu (not from a folder), File/New file, set Lean4... works (let's call this an "untitled" file).
- start vs code from folder, open files in that folder, works!
   - now File/Open file... from somewhere else, also works!
   - now File/New file & set Lean4, also works!  
 
This last option now has 3 LeanClients running, one for the folder, and one for the adhoc package root, and one for 'untitled' files.  

For "adhoc" files the extension searches upwards in the directory hierarchy for a Lean package root and creates a new LeanClient for that root.  