### PR TITLE
feat: use lake serve, take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ This extension contributes the following settings (for a complete list, open the
 
 ### Server settings
 
-* `lean4.executablePath`: specifies the name of the Lean executable to be used when starting the Lean language server. Most users (i.e. those using `elan`) should not ever need to change this. If you are bundling Lean and `vscode-lean` with [Portable mode VS Code](https://code.visualstudio.com/docs/editor/portable), you might find it useful to specify a relative path to Lean. This can be done by starting this setting string with `%extensionPath%`; the extension will replace this with the absolute path of the extension folder. For example, with the default directory setup in Portable mode, `%extensionPath%/../../../lean` will point to `lean` in the same folder as the VS Code executable / application.
+* `lean4.toolchainPath`: specifies the location  of the Lean toolchain to be used when starting the Lean language server. Most users (i.e. those using `elan`) should not ever need to change this. If you are bundling Lean and `vscode-lean` with [Portable mode VS Code](https://code.visualstudio.com/docs/editor/portable), you might find it useful to specify a relative path to Lean. This can be done by starting this setting string with `%extensionPath%`; the extension will replace this with the absolute path of the extension folder. For example, with the default directory setup in Portable mode, `%extensionPath%/../../../lean` will point to `lean` in the same folder as the VS Code executable / application.
 
 * `lean4.serverEnv`: specifies any Environment variables to add to the Lean 4 language server environment.  Note that when opening a [remote folder](https://code.visualstudio.com/docs/remote/ssh) using VS Code the Lean 4 language server will be running on that remote machine.
 
@@ -215,7 +215,7 @@ The format below is: "`lean4.commandName` (command name): description", where `l
 Lean 4 file, the language server needs to be manually informed that it should re-elaborate the full file, including the
 imports. This command has a default keyboard binding of <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>.
 
-* `lean4.selectToolchain` (Lean 4: Select Lean Toolchain) Select version of the Lean toolchain to use for the current workspace.  This shows the list of available toolchains returned from `elan toolchain list` and allows you to easily switch. The Lean 4 language server will automatically be restarted using the selected toolchain.  This command also provides a choice labelled `Other...` where you can enter the full path to a Lean 4 executable to use instead.  This choice is remembered in your [Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings) and you can reset any custom choice by selecting `Reset workspace override...` from the list (if it is shown).
+* `lean4.selectToolchain` (Lean 4: Select Lean Toolchain) Select version of the Lean toolchain to use for the current workspace.  This shows the list of available toolchains returned from `elan toolchain list` and allows you to easily switch. The Lean 4 language server will automatically be restarted using the selected toolchain.  This command also provides a choice labelled `Other...` where you can enter the full path to a Lean 4 toolchain to use instead.  This choice is remembered in your [Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings) and you can reset any custom choice by selecting `Reset workspace override...` from the list (if it is shown).
 
     ![select-toolchain](vscode-lean4/media/select-toolchain.png)
 
@@ -229,6 +229,10 @@ imports. This command has a default keyboard binding of <kbd>Ctrl</kbd>+<kbd>Shi
     server will be restarted automatically using the your brand new locally built version of Lean.
     This is useful if you are adding features to Lean 4 that you want to test in the VS Code
     extension before an official Lean4 nightly build is published.
+
+    Alternatively, you can use the `Other...` option and just provide the full path containing
+    your build output at `.../build/release/stage1/`.
+
 
 ### Editing commands
 

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -22,10 +22,10 @@
 			"type": "object",
 			"title": "Lean 4",
 			"properties": {
-				"lean4.executablePath": {
+				"lean4.toolchainPath": {
 					"type": "string",
-					"default": "lean",
-					"markdownDescription": "Path to the Lean executable to use. **DO NOT CHANGE** from the default `lean` unless you know what you're doing!"
+					"default": "",
+					"markdownDescription": "Path to your Lean toolchain. Leave this blank to get the default location from your PATH environment or from the default elan install location."
 				},
 				"lean4.input.enabled": {
 					"type": "boolean",
@@ -80,6 +80,11 @@
 						"type": "string",
 						"description": "a path to add to the environment"
 					}
+				},
+				"lean4.enableLake": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "Enable Lake server when possible."
 				},
 				"lean4.serverArgs": {
 					"type": "array",
@@ -410,7 +415,8 @@
 		"axios": "^0.24.0",
 		"cheerio": "^1.0.0-rc.10",
 		"mobx": "5.15.7",
-		"vscode-languageclient": "=7.0.0"
+		"vscode-languageclient": "=7.0.0",
+		"semver": "=7.3.5"
 	},
 	"devDependencies": {
 		"@types/node": "^17.0.7",
@@ -422,7 +428,8 @@
 		"typescript": "^4.5.4",
 		"vsce": "~2.6.2",
 		"webpack": "^5.65.0",
-		"webpack-cli": "^4.9.1"
+		"webpack-cli": "^4.9.1",
+		"@types/semver": "^5.3.30"
 	},
 	"icon": "images/lean_logo.png",
 	"license": "Apache-2.0"

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -45,8 +45,12 @@ export function addDefaultElanPath() : void {
     }
 }
 
-export function executablePath(): string {
-    return workspace.getConfiguration('lean4').get('executablePath', 'lean')
+export function toolchainPath(): string {
+    return workspace.getConfiguration('lean4').get('toolchainPath', 'lean')
+}
+
+export function lakeEnabled(): boolean {
+    return workspace.getConfiguration('lean4').get('enableLake', false)
 }
 
 export function serverEnv(): object {
@@ -95,4 +99,11 @@ export function getInfoViewFilterIndex(): number {
 
 export function getElaborationDelay(): number {
     return workspace.getConfiguration('lean4').get('elaborationDelay', 200);
+}
+
+export function getLeanExecutableName(): string {
+    if (process.platform === 'win32') {
+        return 'lean.exe'
+    }
+    return 'lean'
 }

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -54,7 +54,7 @@ export async function activate(context: ExtensionContext): Promise<any> {
         }
     }
 
-    const pkgService = new LeanpkgService(storageManager)
+    const pkgService = new LeanpkgService()
     context.subscriptions.push(pkgService);
 
     const installer = new LeanInstaller(outputChannel, storageManager, defaultToolchain)

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -72,10 +72,6 @@ export async function activate(context: ExtensionContext): Promise<any> {
     context.subscriptions.push(pkgService);
 
     const versionInfo = await installer.checkLeanVersion(packageUri, toolchainVersion)
-    if (versionInfo.error){
-        console.log("Lean version error = " + versionInfo.error);
-    }
-    console.log("Lean version = " + versionInfo.version);
     // Check whether rootPath is a Lean 3 project (the Lean 3 extension also uses the deprecated rootPath)
     if (versionInfo.version === '3') {
         context.subscriptions.pop().dispose(); // stop installer

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -127,11 +127,13 @@ export class LeanClient implements Disposable {
         // The LanguageClient is much slower because it does 10 retries and everything.
         if (useLake) {
             // First check we have a version of lake that supports "lake serve"
-            const lakeVersion = await batchExecute(executable, ['--version'], this.folderUri?.fsPath, null);
+            let versionOptions = version ? ['+' + version, '--version'] : ['--version']
+            const lakeVersion = await batchExecute(executable, versionOptions, this.folderUri?.fsPath, null);
             const actual = this.extractVersion(lakeVersion)
             if (actual.compare('3.0.0') >= 0) {
                 const expectedError = 'Watchdog error: Cannot read LSP request: Stream was closed\n';
-                const rc = await testExecute(executable, ['serve'], this.folderUri?.fsPath, this.outputChannel, true, expectedError);
+                const serveOptions =  version ? ['+' + version, 'serve'] : ['serve'];
+                const rc = await testExecute(executable, serveOptions, this.folderUri?.fsPath, this.outputChannel, true, expectedError);
                 if (rc !== 0) {
                     const failover = 'Lake failed, using lean instead.'
                     console.log(failover);

--- a/vscode-lean4/src/utils/batch.ts
+++ b/vscode-lean4/src/utils/batch.ts
@@ -39,3 +39,83 @@ export async function batchExecute(
     });
 
 }
+
+
+export async function testExecute(
+    executablePath: string,
+    args: any[],
+    workingDirectory: string,
+    channel: OutputChannel,
+    closeStdInput: boolean,
+    expectedError: string,
+    timeout = 10000): Promise<number> {
+
+    return new Promise(function(resolve, reject){
+        let options = {}
+        if (workingDirectory !== undefined) {
+            options = { cwd: workingDirectory };
+        }
+        const msg = `Testing '${executablePath} ${args.join(' ')}'`
+        if (channel) channel.appendLine(msg);
+        console.log(msg)
+
+        let foundExpectedError = false;
+        const exe = spawn(executablePath, args, options);
+
+        if (exe.pid === undefined) {
+            resolve(-1);
+        }
+
+        exe.stdout.on('data', (line) => {
+            const s: string = line.toString();
+            console.log(s);
+        });
+
+        exe.stderr.on('data', (line) => {
+            const s: string = line.toString();
+            // no need to print the stream closed error.
+            if (expectedError === s) {
+                foundExpectedError = true;
+            }
+            else {
+                if (channel) channel.appendLine(s);
+                console.log(s);
+            }
+        });
+
+        if (closeStdInput){
+            exe.stdin.end();
+        }
+
+        let resolved = false
+        exe.on('close', (code) => {
+            if (!resolved) {
+                resolved = true
+                if (foundExpectedError) {
+                    code = 0;
+                }
+                resolve(code)
+            }
+        });
+
+        setTimeout(() => {
+            if (!resolved) {
+                resolved = true;
+                let code = exe.exitCode;
+                if (code !== null){
+                    if (foundExpectedError) {
+                        code = 0;
+                    }
+                    resolve(code)
+                }
+                else {
+                    // it is running!
+                    exe.kill()
+                    resolve(0)
+                }
+            }
+        }, timeout);
+
+    });
+
+}

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -167,13 +167,13 @@ export class LeanClientProvider implements Disposable {
     }
 
     async getLeanVersion(uri: Uri) : Promise<LeanVersion> {
-        let [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
+        const [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
         const path = folderUri?.toString();
         if (this.versions.has(path)){
             return this.versions.get(path);
         }
         let versionInfo : LeanVersion = null;
-        if (uri.scheme == 'untitled'){
+        if (uri.scheme === 'untitled'){
             versionInfo = { version: '4', error: null };
         } else {
             versionInfo = await this.installer.testLeanVersion(folderUri);
@@ -183,7 +183,7 @@ export class LeanClientProvider implements Disposable {
     }
 
     async ensureClient(uri: Uri, versionInfo: LeanVersion | null): Promise<LeanClient> {
-        let [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
+        const [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
 
         const path = folderUri?.toString();
         let  client: LeanClient = null;

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -1,6 +1,7 @@
 import { Disposable, OutputChannel, workspace, TextDocument, commands, window, EventEmitter, Uri, languages, TextEditor } from 'vscode';
 import { LocalStorageService} from './localStorage'
 import { LeanInstaller, LeanVersion } from './leanInstaller'
+import { LeanpkgService } from './leanpkg';
 import { LeanClient } from '../leanclient'
 import { LeanFileProgressProcessingInfo, RpcConnectParams, RpcKeepAliveParams } from '@lean4/infoview-api';
 import * as path from 'path';
@@ -12,6 +13,7 @@ export class LeanClientProvider implements Disposable {
     private localStorage: LocalStorageService;
     private outputChannel: OutputChannel;
     private installer : LeanInstaller;
+    private pkgService : LeanpkgService;
     private versions: Map<string, LeanVersion> = new Map();
     private clients: Map<string, LeanClient> = new Map();
     private pending: Map<string, boolean> = new Map();
@@ -27,10 +29,11 @@ export class LeanClientProvider implements Disposable {
     private clientRemovedEmitter = new EventEmitter<LeanClient>()
     clientRemoved = this.clientRemovedEmitter.event
 
-    constructor(localStorage : LocalStorageService, installer : LeanInstaller, outputChannel : OutputChannel) {
+    constructor(localStorage : LocalStorageService, installer : LeanInstaller, pkgService : LeanpkgService, outputChannel : OutputChannel) {
         this.localStorage = localStorage;
         this.outputChannel = outputChannel;
         this.installer = installer;
+        this.pkgService = pkgService;
 
         // Only change the document language for *visible* documents,
         // because this closes and then reopens the document.
@@ -64,22 +67,26 @@ export class LeanClientProvider implements Disposable {
             // or it could be a document Uri in the case of a command from
             // selectToolchainForActiveEditor.
             const path = uri?.toString()
-            if (path in this.testing) return;
+            if (this.testing.has(path)) {
+                console.log(`Blocking re-entrancy on ${path}`);
+                return;
+            }
             // avoid re-entrancy since testLeanVersion can take a while.
-            this.testing[path] = true;
+            this.testing.set(path, true);
             try {
                 // have to check again here in case elan install had --default-toolchain none.
                 const [workspaceFolder, packageUri, packageFileUri] = findLeanPackageRoot(uri);
                 const version = await installer.testLeanVersion(packageUri);
                 if (version.version === '4') {
-                    if (this.clients.has(path)) {
-                        const client = this.clients.get(path)
-                        void client.restart()
-                    } else {
-                        void this.ensureClient(packageUri, version);
+                    const [cached, client] = await this.ensureClient(uri, version);
+                    if (cached && client) {
+                        await client.restart();
                     }
+                } else if (version.error) {
+                    console.log(`Lean version not ok: ${version.error}`);
                 }
-            } catch {
+            } catch (e) {
+                console.log(`Exception checking lean version: ${e}`);
             }
             this.testing.delete(path);
         });
@@ -96,7 +103,7 @@ export class LeanClientProvider implements Disposable {
     }
 
     private refreshFileDependencies() {
-        this.activeClient.refreshFileDependencies(window.activeTextEditor.document);
+        this.activeClient?.refreshFileDependencies(window.activeTextEditor.document);
     }
 
     private restartActiveClient() {
@@ -104,6 +111,8 @@ export class LeanClientProvider implements Disposable {
     }
 
     async didOpenEditor(document: TextDocument) {
+        this.pkgService.didOpen(document.uri);
+
         // bail as quickly as possible on non-lean files.
         if (document.languageId !== 'lean' && document.languageId !== 'lean4') {
             return;
@@ -133,8 +142,10 @@ export class LeanClientProvider implements Disposable {
         }
 
         try {
-            const client = await this.ensureClient(document.uri, null);
-            await client.openLean4Document(document)
+            const [cached, client] = await this.ensureClient(document.uri, null);
+            if (client) {
+                await client.openLean4Document(document)
+            }
         } catch (e) {
             console.log(`### error opening document: ${e}`);
         }
@@ -182,12 +193,16 @@ export class LeanClientProvider implements Disposable {
         return versionInfo;
     }
 
-    async ensureClient(uri: Uri, versionInfo: LeanVersion | null): Promise<LeanClient> {
+    // Starts a LeanClient if the given file is in a new workspace we haven't seen before.
+    // Returns a boolean "true" if the LeanClient was already created.
+    // Returns a null client if it turns out the new workspace is a lean3 workspace.
+    async ensureClient(uri : Uri, versionInfo: LeanVersion | null) : Promise<[boolean,LeanClient]> {
         const [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
 
         const path = folderUri?.toString();
         let  client: LeanClient = null;
-        if (this.clients.has(path)) {
+        const cachedClient = this.clients.has(path);
+        if (cachedClient) {
             // we're good then
             client = this.clients.get(path);
         } else if (!this.clients.has(path) && !this.pending.has(path)) {
@@ -213,7 +228,7 @@ export class LeanClientProvider implements Disposable {
                 this.pending.delete(path);
                 this.clients.delete(path);
                 client.dispose();
-                return;
+                return [false, null];
             }
 
             client.serverFailed((err) => window.showErrorMessage(err));
@@ -236,7 +251,7 @@ export class LeanClientProvider implements Disposable {
         // tell the InfoView about this activated client.
         this.activeClient = client;
 
-        return client;
+        return [cachedClient, client];
     }
 
     dispose(): void {

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -1,8 +1,10 @@
 import { window, TerminalOptions, OutputChannel, commands, Disposable, EventEmitter, ProgressLocation, Uri } from 'vscode'
-import { executablePath, addServerEnvPaths } from '../config'
+import { toolchainPath, addServerEnvPaths, getLeanExecutableName  } from '../config'
 import { batchExecute } from './batch'
 import { LocalStorageService} from './localStorage'
 import { readLeanVersion } from './projectInfo';
+import { join, dirname } from 'path';
+import * as fs from 'fs';
 
 export class LeanVersion {
     version: string;
@@ -75,6 +77,12 @@ export class LeanInstaller implements Disposable {
     }
 
     async handleVersionChanged(packageUri : Uri) :  Promise<void> {
+        if (this.localStorage.getLeanVersion()){
+            // user has a local workspace override in effect, we don't care
+            // if the lean-toolchain is modified.
+            return;
+        }
+
         if (this.prompting) {
             return;
         }
@@ -91,14 +99,31 @@ export class LeanInstaller implements Disposable {
         this.prompting = false;
     }
 
+    async handleLakeFileChanged(uri: Uri) :  Promise<void> {
+        if (this.prompting) {
+            return;
+        }
+        this.prompting = true;
+        const restartItem = 'Restart Lean';
+        const item = await window.showErrorMessage('Lake file configuration changed', restartItem);
+        if (item === restartItem) {
+            this.installChangedEmitter.fire(uri);
+        }
+        this.prompting = false;
+    }
+
     async showInstallOptions(uri: Uri) : Promise<void> {
-        let executable = this.localStorage.getLeanPath();
-        if (!executable) executable = executablePath();
+        let path  = this.localStorage.getLeanPath();
+        if (!path ) path  = toolchainPath();
         // note; we keep the LeanClient alive so that it can be restarted if the
         // user changes the Lean: Executable Path.
         const installItem = 'Install Lean using Elan';
         const selectItem = 'Select Lean Toolchain';
-        const item = await window.showErrorMessage(`Failed to start '${executable}' language server`, installItem, selectItem)
+        let prompt = 'Failed to start \'lean\' language server'
+        if (path){
+            prompt += ` from ${path}`
+        }
+        const item = await window.showErrorMessage(prompt, installItem, selectItem)
         if (item === installItem) {
             try {
                 const result = await this.installElan();
@@ -131,6 +156,7 @@ export class LeanInstaller implements Disposable {
         // give an indication of any workspace override.
         const resetPrompt = 'Reset workspace override...';
         const versionOverride = this.localStorage.getLeanVersion();
+        const toolchainOverride = this.localStorage.getLeanPath();
         if (versionOverride){
             let found = false;
             for (let i = 0; i < installedToolChains.length; i++)
@@ -145,7 +171,10 @@ export class LeanInstaller implements Disposable {
             if (!found) {
                 installedToolChains.push(versionOverride + ' ' + this.workspaceSuffix);
             }
-            installedToolChains.push('Reset workspace override...');
+            installedToolChains.push(resetPrompt);
+        }
+        else if (toolchainOverride){
+            installedToolChains.push(resetPrompt);
         }
 
         const otherPrompt = 'Other...';
@@ -158,25 +187,50 @@ export class LeanInstaller implements Disposable {
         );
 
         if (selectedVersion === otherPrompt) {
-            const selectedProgram = await window.showInputBox({
-                title: 'Enter path',
-                value: defaultPath,
-                prompt: 'Enter full path to lean toolchain'
+            const selectedPath  = await window.showInputBox({
+                title: 'Enter custom toolchain path',
+                value: this.localStorage.getLeanPath(),
+                prompt: 'Enter full path to the lean toolchain you want to use or leave blank to use the default path'
             });
-            if (selectedProgram) {
-                this.localStorage.setLeanPath(selectedProgram);
-                this.localStorage.setLeanVersion(''); // clear the requested version as we have a full path.
-                this.installChangedEmitter.fire(uri);
+            if (selectedPath) {
+                const toolchainPath = this.checkToolchainPath(selectedPath);
+                if (toolchainPath) {
+                    this.localStorage.setLeanPath(toolchainPath);
+                    this.localStorage.setLeanVersion(''); // clear the requested version as we have a full path.
+                    this.installChangedEmitter.fire(uri);
+                }
             }
         }  else if (selectedVersion === resetPrompt){
             this.localStorage.setLeanVersion(''); // clear the requested version as we have a full path.
-            this.installChangedEmitter.fire(undefined);
+            this.installChangedEmitter.fire(uri);
         } else if (selectedVersion) {
             const s = this.removeSuffix(selectedVersion);
-            this.localStorage.setLeanPath('lean'); // make sure any local full path override is cleared.
+            this.localStorage.setLeanPath(''); // make sure any local full path override is cleared.
             this.localStorage.setLeanVersion(s);
             this.installChangedEmitter.fire(uri);
         }
+    }
+
+    private checkToolchainPath(path: string) : string | null {
+        let leanProgram = join(path, getLeanExecutableName());
+        if (fs.existsSync(leanProgram)) {
+            // then we want the parent folder.
+            path = dirname(path);
+        }
+
+        const binFolder = join(path, 'bin');
+        if (fs.existsSync(binFolder)) {
+            // ensure the lean program exists inside.
+            leanProgram = join(binFolder, getLeanExecutableName());
+            if (fs.existsSync(leanProgram)) {
+                return path;
+            }
+            void window.showErrorMessage(`Lean program not found in ${binFolder}`);
+        }
+        else {
+            void window.showErrorMessage('Lean toolchain should contain a \'bin\' folder');
+        }
+        return null;
     }
 
     private removeSuffix(version: string): string{
@@ -191,8 +245,6 @@ export class LeanInstaller implements Disposable {
     }
 
     async showToolchainOptions(uri: Uri) : Promise<void> {
-        let executable = this.localStorage.getLeanPath();
-        if (!executable) executable = executablePath();
         // note; we keep the LeanClient alive so that it can be restarted if the
         // user changes the Lean: Executable Path.
         const selectToolchain = 'Select lean toolchain';
@@ -205,7 +257,12 @@ export class LeanInstaller implements Disposable {
     async checkLeanVersion(packageUri: Uri, requestedVersion : string): Promise<LeanVersion> {
 
         let cmd = this.localStorage.getLeanPath();
-        if (!cmd) cmd = executablePath();
+        if (!cmd) cmd = toolchainPath();
+        if (!cmd) {
+            cmd = 'lean'
+        } else {
+            cmd = join(cmd, 'bin', 'lean')
+        }
         // if this workspace has a local override use it, otherwise fall back on the requested version.
         const version = this.localStorage.getLeanVersion() ?? requestedVersion;
 
@@ -349,9 +406,9 @@ export class LeanInstaller implements Disposable {
 
     private async installElan() : Promise<boolean> {
 
-        if (executablePath() !== 'lean') {
-            void window.showErrorMessage('It looks like you\'ve modified the `lean.executablePath` user setting.' +
-                'Please change it back to \'lean\' before installing elan.');
+        if (toolchainPath()) {
+            void window.showErrorMessage('It looks like you\'ve modified the `lean.toolchainPath` user setting.' +
+            'Please clear this setting before installing elan.');
             return false;
         } else {
             const terminalName = 'Lean installation via elan';

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -144,7 +144,6 @@ export class LeanInstaller implements Disposable {
     }
 
     async selectToolchain(uri: Uri) : Promise<void> {
-        let defaultPath = this.localStorage.getLeanPath();
         const [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
         const installedToolChains = await this.elanListToolChains(folderUri);
         if (installedToolChains.length === 1 && installedToolChains[0] === 'no installed toolchains') {

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -2,7 +2,7 @@ import { window, TerminalOptions, OutputChannel, commands, Disposable, EventEmit
 import { toolchainPath, addServerEnvPaths, getLeanExecutableName  } from '../config'
 import { batchExecute } from './batch'
 import { LocalStorageService} from './localStorage'
-import { readLeanVersion } from './projectInfo';
+import { readLeanVersion, findLeanPackageRoot } from './projectInfo';
 import { join, dirname } from 'path';
 import * as fs from 'fs';
 
@@ -145,10 +145,8 @@ export class LeanInstaller implements Disposable {
 
     async selectToolchain(uri: Uri) : Promise<void> {
         let defaultPath = this.localStorage.getLeanPath();
-        if (!defaultPath) {
-            defaultPath = 'lean';
-        }
-        const installedToolChains = await this.elanListToolChains(uri);
+        const [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
+        const installedToolChains = await this.elanListToolChains(folderUri);
         if (installedToolChains.length === 1 && installedToolChains[0] === 'no installed toolchains') {
             installedToolChains[0] = this.defaultToolchain
         }
@@ -386,7 +384,7 @@ export class LeanInstaller implements Disposable {
             });
             return result;
         } catch (err) {
-            return ['error']
+            return [`${err}`];
         }
     }
 

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -214,7 +214,7 @@ export class LeanInstaller implements Disposable {
             // assume untitled files are version 4?  Actually no...
             return { version: '4', error: null };
         }
-        if (packageUri?.scheme == 'file') {
+        if (packageUri?.scheme === 'file') {
             folderPath = packageUri.fsPath
         }
 

--- a/vscode-lean4/src/utils/leanpkg.ts
+++ b/vscode-lean4/src/utils/leanpkg.ts
@@ -63,11 +63,11 @@ export class LeanpkgService implements Disposable {
         // Note: just opening the file fires this event sometimes which is annoying, so
         // we compare the contents just to be sure and normalize whitespace so that
         // just adding a new line doesn't trigger the prompt.
-        const [workspaceFolder, packageUri, packageFileUri] = await findLeanPackageRoot(uri);
+        const [workspaceFolder, packageUri, packageFileUri] = findLeanPackageRoot(uri);
         if (packageUri) {
-            var fileUri = this.findLakeFile(packageUri);
+            const fileUri = this.findLakeFile(packageUri);
             if (fileUri) {
-                const contents = await this.readWhitespaceNormalized(fileUri);
+                const contents = this.readWhitespaceNormalized(fileUri);
                 let existing = ''
                 const key = packageUri.toString();
                 if (this.normalizedLakeFileContents.get(key)){

--- a/vscode-lean4/src/utils/leanpkg.ts
+++ b/vscode-lean4/src/utils/leanpkg.ts
@@ -1,30 +1,43 @@
 import { EventEmitter, Disposable, Uri, workspace, window, WorkspaceFolder } from 'vscode';
 import { LocalStorageService} from './localStorage'
-import { findLeanPackageVersionInfo } from './projectInfo';
+import { findLeanPackageRoot, findLeanPackageVersionInfo } from './projectInfo';
+import * as fs from 'fs';
+import * as path from 'path';
 
 export class LeanpkgService implements Disposable {
     private subscriptions: Disposable[] = [];
-    private defaultToolchain : string;
     private localStorage : LocalStorageService;
-    private currentVersion : string = null;
+    private currentVersion : Map<string,string> = new Map();
+    private lakeFileName : string = 'lakefile.lean'
+    private normalizedLakeFileContents : Map<string,string> = new Map();
 
     // This event is raised when the version in the package root changes.
     // The event provides the lean package root Uri.
     private versionChangedEmitter = new EventEmitter<Uri>();
     versionChanged = this.versionChangedEmitter.event
 
-    constructor(localStorage : LocalStorageService, defaultToolchain : string) {
+    // This event is raised if the 'lakefile.lean' file contents is changed.
+    // The event provides the lean package root Uri.
+    private lakeFileChangedEmitter = new EventEmitter<Uri>();
+    lakeFileChanged = this.lakeFileChangedEmitter.event
+
+    constructor(localStorage : LocalStorageService) {
         this.localStorage = localStorage;
-        this.defaultToolchain = defaultToolchain;
 
         // track changes in the version of lean specified in the lean-toolchain file
         // or the leanpkg.toml.  While this is looking for all files with these names
         // it ignores files that are not in the package root.
         ['**/lean-toolchain', '**/leanpkg.toml'].forEach(pattern => {
             const watcher = workspace.createFileSystemWatcher(pattern);
-            watcher.onDidChange((u) => this.handleFileChanged(u));
-            watcher.onDidCreate((u) => this.handleFileChanged(u));
-            watcher.onDidDelete((u) => this.handleFileChanged(u));
+            watcher.onDidChange((u) => this.handleFileChanged(u, true));
+            watcher.onDidCreate((u) => this.handleFileChanged(u, true));
+            watcher.onDidDelete((u) => this.handleFileChanged(u, true));
+            this.subscriptions.push(watcher);
+
+            const watcher2 = workspace.createFileSystemWatcher(`**/${this.lakeFileName}`);
+            watcher2.onDidChange((u) => this.handleLakeFileChanged(u, true));
+            watcher2.onDidCreate((u) => this.handleLakeFileChanged(u, true));
+            watcher2.onDidDelete((u) => this.handleLakeFileChanged(u, true));
             this.subscriptions.push(watcher);
         });
     }
@@ -33,19 +46,81 @@ export class LeanpkgService implements Disposable {
         for (const s of this.subscriptions) { s.dispose(); }
     }
 
-    private async handleFileChanged(uri: Uri) {
-        if (this.localStorage.getLeanVersion()){
-            // user has a local workspace override in effect, so leave it that way.
-            return;
+    didOpen(uri: Uri){
+        const fileName = path.basename(uri.fsPath);
+        if (fileName === this.lakeFileName){
+            void this.handleLakeFileChanged(uri, false);
         }
-        // note: apply the same rules here with findLeanPkgVersionInfo no matter
-        // if a file is added or removed so we always match the elan behavior.
-        const current = this.currentVersion;
-        // findLeanPkgVersionInfo changes this.currentVersion
-        const [packageUri, version] = await findLeanPackageVersionInfo(uri);
-        if (packageUri && version && version !== current) {
-            // raise an event so the extension triggers handleVersionChanged.
-            this.versionChangedEmitter.fire(packageUri);
+        else if (fileName === 'lean-toolchain'){
+            void this.handleFileChanged(uri, false);
+        }
+        else if (fileName === 'leanpkg.toml'){
+            void  this.handleFileChanged(uri, false);
         }
     }
+
+    private async handleLakeFileChanged(uri : Uri, raiseEvent : boolean)  {
+        // Note: just opening the file fires this event sometimes which is annoying, so
+        // we compare the contents just to be sure and normalize whitespace so that
+        // just adding a new line doesn't trigger the prompt.
+        const [workspaceFolder, packageUri, packageFileUri] = await findLeanPackageRoot(uri);
+        if (packageUri) {
+            var fileUri = this.findLakeFile(packageUri);
+            if (fileUri) {
+                const contents = await this.readWhitespaceNormalized(fileUri);
+                let existing = ''
+                const key = packageUri.toString();
+                if (this.normalizedLakeFileContents.get(key)){
+                    existing = this.normalizedLakeFileContents.get(key);
+                }
+                if (contents !== existing) {
+                    this.normalizedLakeFileContents.set(key, contents);
+                    if (raiseEvent) {
+                        // raise an event so the extension triggers handleLakeFileChanged.
+                        this.lakeFileChangedEmitter.fire(packageUri);
+                    }
+                }
+            }
+        }
+    }
+
+    private async handleFileChanged(uri: Uri, raiseEvent : boolean) {
+        // note: apply the same rules here with findLeanPkgVersionInfo no matter
+        // if a file is added or removed so we always match the elan behavior.
+        // findLeanPkgVersionInfo changes this.currentVersion
+        const [packageUri, version] = await findLeanPackageVersionInfo(uri);
+        if (packageUri && version) {
+            let existing = '';
+            const key = packageUri.toString();
+            if (this.currentVersion.has(key)){
+                existing = this.currentVersion.get(key);
+            }
+            if (existing !== version){
+                this.currentVersion.set(key, version);
+                if (raiseEvent) {
+                    // raise an event so the extension triggers handleVersionChanged.
+                    this.versionChangedEmitter.fire(packageUri);
+                }
+            }
+        }
+    }
+
+    private findLakeFile(packageUri: Uri) : Uri | null {
+        const fullPath = Uri.joinPath(packageUri, this.lakeFileName);
+        const url = fullPath.fsPath;
+        if (fs.existsSync(url)) {
+            return fullPath;
+        }
+        return null;
+    }
+
+    // Return file contents with whitespace normalized.
+    private readWhitespaceNormalized(fileUri: Uri) : string {
+        const contents = fs.readFileSync(fileUri.fsPath).toString();
+        // ignore whitespace changes by normalizing whitespace.
+        const re = /[ \t\r\n]+/g
+        const result = contents.replace(re, ' ');
+        return result.trim();
+    }
+
 }

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -9,7 +9,7 @@ export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
 
     const toolchainFileName = 'lean-toolchain';
     const tomlFileName = 'leanpkg.toml';
-    if (uri.scheme == 'untitled'){
+    if (uri.scheme === 'untitled'){
         // then return a Uri representing all untitled files.
         return [null, Uri.from({scheme: 'untitled'}), null];
     }
@@ -17,7 +17,7 @@ export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
     let wsFolder = workspace.getWorkspaceFolder(uri);
     if (!wsFolder && workspace.workspaceFolders) {
         workspace.workspaceFolders.forEach((f) => {
-            if (f.uri?.scheme == 'file' && f.uri.fsPath && uri.fsPath.startsWith(f.uri.fsPath)) {
+            if (f.uri?.scheme === 'file' && f.uri.fsPath && uri.fsPath.startsWith(f.uri.fsPath)) {
                 wsFolder = f;
             }
         });
@@ -26,7 +26,7 @@ export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
     if (wsFolder){
         // jump to the real workspace folder if we have a Workspace for this file.
         path = wsFolder.uri;
-    } else if (path.scheme == 'file') {
+    } else if (path.scheme === 'file') {
         // then start searching from the directory containing this document.
         // The given uri may already be a folder Uri in some cases.
         if (fs.lstatSync(path.fsPath).isFile()) {
@@ -34,7 +34,7 @@ export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
         }
         searchUpwards = true;
     }
-    if (path.scheme == 'file') {
+    if (path.scheme === 'file') {
         // search parent folders for a leanpkg.toml file, or a Lake lean-toolchain file.
         while (true) {
             // give preference to 'lean-toolchain' files if any.
@@ -73,7 +73,7 @@ export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
 export async function findLeanPackageVersionInfo(uri: Uri) : Promise<[Uri,string]> {
 
     const [_, packageUri, packageFileUri] =findLeanPackageRoot(uri);
-    if (!packageUri || packageUri.scheme == 'untitled') return null;
+    if (!packageUri || packageUri.scheme === 'untitled') return null;
 
     let version = null;
     if (packageFileUri) {
@@ -105,7 +105,7 @@ export async function readLeanVersion(packageUri: Uri){
     return null;
 }
 
-async function readLeanVersionFile(packageFileUri) : Promise<string> {
+async function readLeanVersionFile(packageFileUri : Uri) : Promise<string> {
     const url = new URL(packageFileUri.toString());
     const tomlFileName = 'leanpkg.toml';
     if (packageFileUri.path.endsWith(tomlFileName))
@@ -116,7 +116,6 @@ async function readLeanVersionFile(packageFileUri) : Promise<string> {
                     if (err) {
                         reject(err);
                     } else {
-                        let version = null;
                         const match = /lean_version\s*=\s*"([^"]*)"/.exec(data.toString());
                         if (match) resolve(match[1]);
                         reject(null);

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -4,7 +4,7 @@ import { Uri, workspace, WorkspaceFolder } from 'vscode';
 
 // Find the root of a Lean project and return the Uri for the package root and the Uri
 // for the 'leanpkg.toml' or 'lean-toolchain' file found there.
-export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
+export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder | null, Uri | null, Uri | null] {
     if (!uri) return [null, null, null];
 
     const toolchainFileName = 'lean-toolchain';
@@ -72,7 +72,7 @@ export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder, Uri,Uri] {
 // in any 'lean-toolchain' or 'leanpkg.toml' file found there.
 export async function findLeanPackageVersionInfo(uri: Uri) : Promise<[Uri,string]> {
 
-    const [_, packageUri, packageFileUri] =findLeanPackageRoot(uri);
+    const [_, packageUri, packageFileUri] = findLeanPackageRoot(uri);
     if (!packageUri || packageUri.scheme === 'untitled') return null;
 
     let version = null;


### PR DESCRIPTION
See [Zulip Discussion](https://leanprover.zulipchat.com/#narrow/stream/147302-lean4-dev/topic/Expose.20--load-dynlib.20to.20Lean.3F)

This PR is dependent on #117 

Proposal, replace the following setting:
![image](https://user-images.githubusercontent.com/18707114/148602700-f3240f36-9fb9-49bc-8cb6-b480c2f182fe.png)

With:
![image](https://user-images.githubusercontent.com/18707114/148603426-edc41ad7-c308-4cbe-84ad-1b7bdd5f7b77.png)

Then the rules for using `lake serve` would be:
1. is 'lake' or 'lake.exe' found in the toolchainPath, If not don't use `lake`
2. is there a `lakefile.lean` in the current workspace root?  If not don't use `lake`
3. If the above are both good, use `lake serve` with optional +version if there's a workspace override in effect.
4. If `lake serve` fails fall back on `lean --server`.

This PR also fixes a bug introduced by support for "multi-workspace" namely that the "currentVersion" maintained in LeanpkgService needs to be "per-workspace".