### PR TITLE
fix: select toolchain was broken!

### DIFF
--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -312,7 +312,7 @@ export class LeanClient implements Disposable {
         this.notifyDidOpen(doc);
     }
 
-    async notifyDidOpen(doc: TextDocument) {
+    notifyDidOpen(doc: TextDocument) {
         void this.client.sendNotification(DidOpenTextDocumentNotification.type, {
             textDocument: {
                 uri: doc.uri.toString(),

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -64,16 +64,17 @@ export class LeanClientProvider implements Disposable {
             // or it could be a document Uri in the case of a command from
             // selectToolchainForActiveEditor.
             const path = uri?.toString()
-            if (path in this.testing) return;
+            if (this.testing.has(path)) return;
             // avoid re-entrancy since testLeanVersion can take a while.
-            this.testing[path] = true;
+            this.testing.set(path, true);
             try {
                 // have to check again here in case elan install had --default-toolchain none.
                 const [workspaceFolder, packageUri, packageFileUri] = findLeanPackageRoot(uri);
                 const version = await installer.testLeanVersion(packageUri);
-                if (version.version === '4') {
-                    if (this.clients.has(path)) {
-                        const client = this.clients.get(path)
+                const packagePath = packageUri?.toString();
+                if (version.version === '4' && packagePath) {
+                    if (this.clients.has(packagePath)) {
+                        const client = this.clients.get(packagePath)
                         void client.restart()
                     } else {
                         void this.ensureClient(packageUri, version);

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -119,7 +119,7 @@ export class LeanInstaller implements Disposable {
     }
 
     async selectToolchain(uri: Uri) : Promise<void> {
-        let defaultPath = this.localStorage.getLeanPath();
+        const defaultPath = this.localStorage.getLeanPath();
         const [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
         const installedToolChains = await this.elanListToolChains(folderUri);
         if (installedToolChains.length === 1 && installedToolChains[0] === 'no installed toolchains') {

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -2,7 +2,7 @@ import { window, TerminalOptions, OutputChannel, commands, Disposable, EventEmit
 import { executablePath, addServerEnvPaths } from '../config'
 import { batchExecute } from './batch'
 import { LocalStorageService} from './localStorage'
-import { readLeanVersion } from './projectInfo';
+import { readLeanVersion, findLeanPackageRoot  } from './projectInfo';
 
 export class LeanVersion {
     version: string;
@@ -120,10 +120,8 @@ export class LeanInstaller implements Disposable {
 
     async selectToolchain(uri: Uri) : Promise<void> {
         let defaultPath = this.localStorage.getLeanPath();
-        if (!defaultPath) {
-            defaultPath = 'lean';
-        }
-        const installedToolChains = await this.elanListToolChains(uri);
+        const [workspaceFolder, folderUri, packageFileUri] = findLeanPackageRoot(uri);
+        const installedToolChains = await this.elanListToolChains(folderUri);
         if (installedToolChains.length === 1 && installedToolChains[0] === 'no installed toolchains') {
             installedToolChains[0] = this.defaultToolchain
         }
@@ -170,7 +168,7 @@ export class LeanInstaller implements Disposable {
             }
         }  else if (selectedVersion === resetPrompt){
             this.localStorage.setLeanVersion(''); // clear the requested version as we have a full path.
-            this.installChangedEmitter.fire(undefined);
+            this.installChangedEmitter.fire(uri);
         } else if (selectedVersion) {
             const s = this.removeSuffix(selectedVersion);
             this.localStorage.setLeanPath('lean'); // make sure any local full path override is cleared.


### PR DESCRIPTION
fix: newly restarted client also needs to get DidOpenTextDocumentNotifications for existing open docs otherwise the lean server raises this error and crashes on the next edit to the open file.
```
Watchdog error: cannot find open document 'file:///d%3A/Temp/lean_examples/Foo/Main.lean'
[Info  - 8:57:59 PM] Connection to server got closed. Server will restart.
```