### PR TITLE
fix: adhoc and untitled files were hitting some null reference exceptions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,7 @@ module.exports = {
                 "default": "array"
             }
         ],
+        "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/ban-types": "off",
         "@typescript-eslint/consistent-type-assertions": "error",
         "@typescript-eslint/explicit-member-accessibility": [

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -7,9 +7,9 @@ import * as path from 'path';
 
 export function getEnvPath() : string {
     if (process.platform === 'win32') {
-        return process.env.Path
+        return process.env.Path ?? ''
     } else {
-        return process.env.PATH
+        return process.env.PATH ?? ''
     }
 }
 
@@ -46,7 +46,7 @@ export function addDefaultElanPath() : void {
 }
 
 export function toolchainPath(): string {
-    return workspace.getConfiguration('lean4').get('toolchainPath', 'lean')
+    return workspace.getConfiguration('lean4').get('toolchainPath', '')
 }
 
 export function lakeEnabled(): boolean {
@@ -74,11 +74,11 @@ export function serverLoggingPath(): string {
 }
 
 export function getInfoViewStyle(): string {
-    return workspace.getConfiguration('lean4').get('infoViewStyle');
+    return workspace.getConfiguration('lean4').get('infoViewStyle', '');
 }
 
 export function getInfoViewAutoOpen(): boolean {
-    return workspace.getConfiguration('lean4').get('infoViewAutoOpen');
+    return workspace.getConfiguration('lean4').get('infoViewAutoOpen', true);
 }
 
 export function getInfoViewAutoOpenShowGoal(): boolean {

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -71,7 +71,7 @@ export async function activate(context: ExtensionContext): Promise<any> {
     const pkgService = new LeanpkgService()
     context.subscriptions.push(pkgService);
 
-    const versionInfo = await installer.checkLeanVersion(packageUri, toolchainVersion)
+    const versionInfo = await installer.checkLeanVersion(packageUri, toolchainVersion??defaultToolchain)
     // Check whether rootPath is a Lean 3 project (the Lean 3 extension also uses the deprecated rootPath)
     if (versionInfo.version === '3') {
         context.subscriptions.pop().dispose(); // stop installer

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -17,7 +17,7 @@ function isLean(languageId : string) : boolean {
 
 
 function getLeanDocument() : TextDocument | undefined {
-    let document : TextDocument | undefined = undefined;
+    let document : TextDocument | undefined;
     if (window.activeTextEditor && isLean(window.activeTextEditor.document.languageId))
     {
         document = window.activeTextEditor.document

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -548,9 +548,9 @@ export class InfoProvider implements Disposable {
                 builder.insert(prev_line.range.end, new_command);
             });
             editor.selection = new Selection(pos.line, spaces, pos.line, spaces);
-        } else if (pos) {
+        } else {
             await editor.edit((builder) => {
-                builder.insert(pos, text);
+                if (pos) builder.insert(pos, text);
             });
             editor.selection = new Selection(pos, pos)
         }

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -190,8 +190,8 @@ export class InfoProvider implements Disposable {
             if (tdpp) {
                 const client = this.clientProvider.findClient(tdpp.textDocument.uri);
                 if (!client?.running) return;
-                let uri = client.convertUriFromString(tdpp.textDocument.uri);
-                let pos = client.convertPosition(tdpp.position);
+                const uri = client.convertUriFromString(tdpp.textDocument.uri);
+                const pos = client.convertPosition(tdpp.position);
                 await this.handleInsertText(text, kind, uri, pos);
             }
         },
@@ -336,8 +336,7 @@ export class InfoProvider implements Disposable {
     }
 
     private updateStylesheet() {
-        const fontFamily =
-            workspace.getConfiguration('editor').get<string>('fontFamily')!.replace(/['"]/g, '');
+        const fontFamily = workspace.getConfiguration('editor').get<string>('fontFamily')?.replace(/['"]/g, '');
         const fontCodeCSS = `
             .font-code {
                 font-family: ${fontFamily};
@@ -444,11 +443,13 @@ export class InfoProvider implements Disposable {
     }
 
     private async sendDiagnostics(client: LeanClient) {
-        if (!this.webviewPanel) return;
-        client.getDiagnostics()?.forEach(async (uri, diags) => {
-            const params = client.getDiagnosticParams(uri, diags)
-            await this.webviewPanel!.api.gotServerNotification('textDocument/publishDiagnostics', params);
-        });
+        const panel = this.webviewPanel;
+        if (panel) {
+            client.getDiagnostics()?.forEach(async (uri, diags) => {
+                const params = client.getDiagnosticParams(uri, diags)
+                await panel.api.gotServerNotification('textDocument/publishDiagnostics', params);
+            });
+        }
     }
 
     private async sendProgress(client: LeanClient) {
@@ -497,7 +498,7 @@ export class InfoProvider implements Disposable {
     }
 
     private async revealEditorSelection(uri: Uri, selection?: Range) {
-        let editor: TextEditor | undefined = undefined;
+        let editor: TextEditor | undefined;
         for (const e of window.visibleTextEditors) {
             if (e.document.uri.toString() === uri.toString()) {
                 editor = e;
@@ -547,9 +548,9 @@ export class InfoProvider implements Disposable {
                 builder.insert(prev_line.range.end, new_command);
             });
             editor.selection = new Selection(pos.line, spaces, pos.line, spaces);
-        } else {
+        } else if (pos) {
             await editor.edit((builder) => {
-                builder.insert(pos!, text);
+                builder.insert(pos, text);
             });
             editor.selection = new Selection(pos, pos)
         }

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -246,7 +246,7 @@ export class LeanClient implements Disposable {
                     const nonWordPattern = '[`~@$%^&*()-=+\\[{\\]}⟨⟩⦃⦄⟦⟧⟮⟯‹›\\\\|;:\",./\\s]|^|$'
                     const regexp = new RegExp(`(?<=${nonWordPattern})${escapeRegExp(word)}(?=${nonWordPattern})`, 'g')
                     for (const match of text.matchAll(regexp)) {
-                        const start = doc.positionAt(match.index!)
+                        const start = doc.positionAt(match.index ?? 0)
                         highlights.push({
                             range: new Range(start, start.translate(0, match[0].length)),
                             kind: DocumentHighlightKind.Text,
@@ -281,7 +281,8 @@ export class LeanClient implements Disposable {
             await this.client.onReady();
             // tell the new client about the documents that are already open!
             for (const key of this.isOpen.keys()) {
-                this.notifyDidOpen(this.isOpen.get(key)!);
+                const doc = this.isOpen.get(key);
+                if (doc) this.notifyDidOpen(doc);
             }
             // if we got this far then the client is happy so we are running!
             this.running = true;

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -116,7 +116,7 @@ export class LeanClient implements Disposable {
 
         // check if the lake process will start.
         let useLake = lakeEnabled();
-        if (useLake && this.folderUri) {
+        if (useLake && this.folderUri && this.folderUri.scheme === 'file') {
             const lakefile = Uri.joinPath(this.folderUri, 'lakefile.lean').toString()
             if (!fs.existsSync(new URL(lakefile))) {
                 useLake = false;

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -26,6 +26,7 @@ import { cwd } from 'process'
 import * as fs from 'fs';
 import { URL } from 'url';
 import { join } from 'path';
+ // @ts-ignore
 import { SemVer } from 'semver';
 
 const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -46,7 +47,7 @@ export class LeanClient implements Disposable {
     private toolchainPath: string
     private outputChannel: OutputChannel;
     private storageManager : LocalStorageService;
-    private workspaceFolder: WorkspaceFolder;
+    private workspaceFolder: WorkspaceFolder | undefined;
     private folderUri: Uri;
     private subscriptions: Disposable[] = []
 
@@ -84,7 +85,7 @@ export class LeanClient implements Disposable {
     /** Files which are open. */
     private isOpen: Map<string, TextDocument> = new Map()
 
-    constructor(workspaceFolder: WorkspaceFolder, folderUri: Uri, storageManager : LocalStorageService, outputChannel : OutputChannel) {
+    constructor(workspaceFolder: WorkspaceFolder | undefined, folderUri: Uri, storageManager : LocalStorageService, outputChannel : OutputChannel) {
         this.storageManager = storageManager;
         this.outputChannel = outputChannel;
         this.workspaceFolder = workspaceFolder; // can be null when opening adhoc files.
@@ -128,7 +129,7 @@ export class LeanClient implements Disposable {
         if (useLake) {
             // First check we have a version of lake that supports "lake serve"
             const versionOptions = version ? ['+' + version, '--version'] : ['--version']
-            const lakeVersion = await batchExecute(executable, versionOptions, this.folderUri?.fsPath, null);
+            const lakeVersion = await batchExecute(executable, versionOptions, this.folderUri?.fsPath, undefined);
             const actual = this.extractVersion(lakeVersion)
             if (actual.compare('3.0.0') >= 0) {
                 const expectedError = 'Watchdog error: Cannot read LSP request: Stream was closed\n';
@@ -194,6 +195,7 @@ export class LeanClient implements Disposable {
             middleware: {
                 handleDiagnostics: (uri, diagnostics, next) => {
                     next(uri, diagnostics);
+                    if (!this.client) return;
                     const uri_ = this.client.code2ProtocolConverter.asUri(uri);
                     const diagnostics_ = [];
                     for (const d of diagnostics) {
@@ -213,7 +215,7 @@ export class LeanClient implements Disposable {
 
                 didChange: (data, next) => {
                     next(data);
-                    if (!this.running) return; // there was a problem starting lean server.
+                    if (!this.running || !this.client) return; // there was a problem starting lean server.
                     const params = this.client.code2ProtocolConverter.asChangeTextDocumentParams(data);
                     this.didChangeEmitter.fire(params);
                 },
@@ -221,7 +223,7 @@ export class LeanClient implements Disposable {
                 didClose: (doc, next) => {
                     if (!this.isOpen.delete(doc.uri.toString())) return;
                     next(doc);
-                    if (!this.running) return; // there was a problem starting lean server.
+                    if (!this.running || !this.client) return; // there was a problem starting lean server.
                     const params = this.client.code2ProtocolConverter.asTextDocumentIdentifier(doc);
                     this.didCloseEmitter.fire({textDocument: params});
                 },
@@ -244,7 +246,7 @@ export class LeanClient implements Disposable {
                     const nonWordPattern = '[`~@$%^&*()-=+\\[{\\]}⟨⟩⦃⦄⟦⟧⟮⟯‹›\\\\|;:\",./\\s]|^|$'
                     const regexp = new RegExp(`(?<=${nonWordPattern})${escapeRegExp(word)}(?=${nonWordPattern})`, 'g')
                     for (const match of text.matchAll(regexp)) {
-                        const start = doc.positionAt(match.index)
+                        const start = doc.positionAt(match.index!)
                         highlights.push({
                             range: new Range(start, start.translate(0, match[0].length)),
                             kind: DocumentHighlightKind.Text,
@@ -279,7 +281,7 @@ export class LeanClient implements Disposable {
             await this.client.onReady();
             // tell the new client about the documents that are already open!
             for (const key of this.isOpen.keys()) {
-                this.notifyDidOpen(this.isOpen.get(key));
+                this.notifyDidOpen(this.isOpen.get(key)!);
             }
             // if we got this far then the client is happy so we are running!
             this.running = true;
@@ -295,7 +297,7 @@ export class LeanClient implements Disposable {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         this.client.onNotification({
             method: (method: string, params_: any) => {
-                if (method === '$/lean/fileProgress') {
+                if (method === '$/lean/fileProgress' && this.client) {
                     const params = params_ as LeanFileProgressParams;
                     const uri = this.client.protocol2CodeConverter.asUri(params.textDocument.uri)
                     this.progressChangedEmitter.fire([uri.toString(), params.processing]);
@@ -305,12 +307,12 @@ export class LeanClient implements Disposable {
 
                 this.customNotificationEmitter.fire({method, params: params_});
             }
-        } as any, null);
+        } as any, ()=>{});
 
         // Reveal the standard error output channel when the server prints something to stderr.
         // The vscode-languageclient library already takes care of writing it to the output channel.
         (this.client as any)._serverProcess.stderr.on('data', () => {
-            this.client.outputChannel.show(true);
+            this.client?.outputChannel.show(true);
         });
 
         this.restartedEmitter.fire(undefined)
@@ -359,7 +361,7 @@ export class LeanClient implements Disposable {
     }
 
     notifyDidOpen(doc: TextDocument) {
-        void this.client.sendNotification(DidOpenTextDocumentNotification.type, {
+        void this.client?.sendNotification(DidOpenTextDocumentNotification.type, {
             textDocument: {
                 uri: doc.uri.toString(),
                 languageId: doc.languageId,
@@ -428,12 +430,12 @@ export class LeanClient implements Disposable {
         // didOpen packet emitted below initializes the version number to be 1.
         // This is not a problem though, since both client and server are fine
         // as long as the version numbers are monotonous.
-        void this.client.sendNotification('textDocument/didClose', {
+        void this.client?.sendNotification('textDocument/didClose', {
             'textDocument': {
                 uri
             }
         })
-        void this.client.sendNotification('textDocument/didOpen', {
+        void this.client?.sendNotification('textDocument/didOpen', {
             'textDocument': {
                 uri,
                 'languageId': 'lean4',
@@ -445,48 +447,49 @@ export class LeanClient implements Disposable {
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     sendRequest(method: string, params: any) : Promise<any> {
-        return this.running ? this.client.sendRequest(method, params) : undefined;
+        return this.running && this.client ? this.client.sendRequest(method, params) : new Promise<any>(()=>{});
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     sendNotification(method: string, params: any): void {
-        return this.running ? this.client.sendNotification(method, params) : undefined;
+        return this.running  && this.client ? this.client.sendNotification(method, params) : undefined;
     }
 
     convertUri(uri: Uri): Uri {
-        return this.running ? Uri.parse(this.client.code2ProtocolConverter.asUri(uri)) : uri;
+        return this.running  && this.client ? Uri.parse(this.client.code2ProtocolConverter.asUri(uri)) : uri;
     }
 
     convertUriFromString(uri: string): Uri {
         const u = Uri.parse(uri);
-        return this.running ? Uri.parse(this.client.code2ProtocolConverter.asUri(u)) : u;
+        return this.running && this.client ? Uri.parse(this.client.code2ProtocolConverter.asUri(u)) : u;
     }
 
     convertPosition(pos: ls.Position) : Position | undefined {
-        return this.running ? this.client.protocol2CodeConverter.asPosition(pos) : undefined;
+        return this.running ? this.client?.protocol2CodeConverter.asPosition(pos) : undefined;
     }
 
-    convertRange(range: ls.Range): Range | undefined {
-        return this.running ? this.client.protocol2CodeConverter.asRange(range) : undefined;
+    convertRange(range: ls.Range | undefined): Range | undefined {
+        return this.running && range ? this.client?.protocol2CodeConverter.asRange(range) : undefined;
     }
 
     getDiagnosticParams(uri: Uri, diagnostics: readonly Diagnostic[]) : PublishDiagnosticsParams {
         const params: PublishDiagnosticsParams = {
             uri: this.convertUri(uri)?.toString(),
-            diagnostics: this.client.code2ProtocolConverter.asDiagnostics(diagnostics as Diagnostic[]),
+            diagnostics: this.client?.code2ProtocolConverter.asDiagnostics(diagnostics as Diagnostic[]) ?? []
         };
         return params;
     }
 
     getDiagnostics() : DiagnosticCollection | undefined {
-        return this.running ? this.client.diagnostics : undefined;
+        return this.running ? this.client?.diagnostics : undefined;
     }
 
     get initializeResult() : InitializeResult | undefined {
-        return this.running ? this.client.initializeResult : undefined
+        return this.running ? this.client?.initializeResult : undefined
     }
 
-    private extractVersion(v: string) : SemVer {
+    private extractVersion(v: string | undefined) : SemVer {
+        if (!v) return new SemVer('0.0.0');
         const prefix = 'Lake version'
         if (v.startsWith(prefix)) v = v.slice(prefix.length).trim()
         const pos = v.indexOf('(')

--- a/vscode-lean4/src/taskgutter.ts
+++ b/vscode-lean4/src/taskgutter.ts
@@ -112,7 +112,8 @@ export class LeanTaskGutter implements Disposable {
             uris[uri] = true
             const processed = uri in this.status ? this.status[uri] : []
             if (this.gutters[uri]) {
-                this.gutters[uri]!.setProcessed(processed)
+                const gutter = this.gutters[uri];
+                if (gutter) gutter.setProcessed(processed)
             } else {
                 this.gutters[uri] = new LeanFileTaskGutter(uri, this.decorations, processed)
             }

--- a/vscode-lean4/src/taskgutter.ts
+++ b/vscode-lean4/src/taskgutter.ts
@@ -110,9 +110,9 @@ export class LeanTaskGutter implements Disposable {
             if (editor.document.languageId !== 'lean4' && editor.document.languageId !== 'lean') continue;
             const uri = editor.document.uri.toString();
             uris[uri] = true
-            const processed = uri in this.status ? this.status[uri] : undefined
+            const processed = uri in this.status ? this.status[uri] : []
             if (this.gutters[uri]) {
-                this.gutters[uri].setProcessed(processed)
+                this.gutters[uri]!.setProcessed(processed)
             } else {
                 this.gutters[uri] = new LeanFileTaskGutter(uri, this.decorations, processed)
             }

--- a/vscode-lean4/src/utils/batch.ts
+++ b/vscode-lean4/src/utils/batch.ts
@@ -4,8 +4,8 @@ import { spawn } from 'child_process';
 export async function batchExecute(
     executablePath: string,
     args: any[],
-    workingDirectory: string,
-    channel: OutputChannel): Promise<string> {
+    workingDirectory: string | null,
+    channel: OutputChannel | undefined): Promise<string | undefined> {
 
     return new Promise(function(resolve, reject){
         let output : string = '';
@@ -94,7 +94,7 @@ export async function testExecute(
                 if (foundExpectedError) {
                     code = 0;
                 }
-                resolve(code)
+                resolve(code ?? 0)
             }
         });
 

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -184,7 +184,7 @@ export class LeanClientProvider implements Disposable {
             return this.versions.get(path);
         }
         let versionInfo : LeanVersion = null;
-        if (uri.scheme === 'untitled'){
+        if (uri?.scheme === 'untitled'){
             versionInfo = { version: '4', error: null };
         } else {
             versionInfo = await this.installer.testLeanVersion(folderUri);

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -37,7 +37,10 @@ export class LeanInstaller implements Disposable {
 
     async testLeanVersion(packageUri: Uri | undefined) : Promise<LeanVersion> {
         // see if there is a lean-toolchain file and use that version info.
-        let  leanVersion = await readLeanVersion(packageUri);
+        let leanVersion = '';
+        if (packageUri) {
+            leanVersion = await readLeanVersion(packageUri);
+        }
         if (!leanVersion) {
             // see if there's a workspace override then.
             leanVersion = this.localStorage.getLeanVersion();
@@ -267,11 +270,12 @@ export class LeanInstaller implements Disposable {
         }
 
         let folderPath: string = '';
-        if (packageUri.scheme === 'scheme') {
+        const scheme = packageUri?.scheme
+        if (scheme === 'scheme') {
             // assume untitled files are version 4?  Actually no...
             return { version: '4', error: null };
         }
-        if (packageUri?.scheme === 'file') {
+        if (scheme === 'file') {
             folderPath = packageUri.fsPath
         }
 

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -201,12 +201,13 @@ export class LeanInstaller implements Disposable {
                 }
             }
         }  else if (selectedVersion === resetPrompt){
-            this.localStorage.setLeanVersion(''); // clear the requested version as we have a full path.
+            this.localStorage.setLeanPath(''); // make sure any local full path override is cleared.
+            this.localStorage.setLeanVersion(''); // clear any custom version.
             this.installChangedEmitter.fire(uri);
         } else if (selectedVersion) {
             const s = this.removeSuffix(selectedVersion);
             this.localStorage.setLeanPath(''); // make sure any local full path override is cleared.
-            this.localStorage.setLeanVersion(s);
+            this.localStorage.setLeanVersion(s); // request the specified version.
             this.installChangedEmitter.fire(uri);
         }
     }

--- a/vscode-lean4/src/utils/leanpkg.ts
+++ b/vscode-lean4/src/utils/leanpkg.ts
@@ -72,10 +72,10 @@ export class LeanpkgService implements Disposable {
             const fileUri = this.findLakeFile(packageUri);
             if (fileUri) {
                 const contents = this.readWhitespaceNormalized(fileUri);
-                let existing = ''
+                let existing : string | undefined;
                 const key = packageUri.toString();
                 if (this.normalizedLakeFileContents.get(key)){
-                    existing = this.normalizedLakeFileContents.get(key)!;
+                    existing = this.normalizedLakeFileContents.get(key);
                 }
                 if (contents !== existing) {
                     this.normalizedLakeFileContents.set(key, contents);
@@ -93,10 +93,10 @@ export class LeanpkgService implements Disposable {
         // if a file is added or removed so we always match the elan behavior.
         const [packageUri, version] = await findLeanPackageVersionInfo(uri);
         if (packageUri && version) {
-            let existing = '';
+            let existing : string | undefined;
             const key = packageUri.toString();
             if (this.currentVersion.has(key)){
-                existing = this.currentVersion.get(key)!;
+                existing = this.currentVersion.get(key);
             }
             if (existing !== version){
                 this.currentVersion.set(key, version);

--- a/vscode-lean4/src/utils/leanpkg.ts
+++ b/vscode-lean4/src/utils/leanpkg.ts
@@ -75,7 +75,7 @@ export class LeanpkgService implements Disposable {
                 let existing = ''
                 const key = packageUri.toString();
                 if (this.normalizedLakeFileContents.get(key)){
-                    existing = this.normalizedLakeFileContents.get(key);
+                    existing = this.normalizedLakeFileContents.get(key)!;
                 }
                 if (contents !== existing) {
                     this.normalizedLakeFileContents.set(key, contents);
@@ -96,7 +96,7 @@ export class LeanpkgService implements Disposable {
             let existing = '';
             const key = packageUri.toString();
             if (this.currentVersion.has(key)){
-                existing = this.currentVersion.get(key);
+                existing = this.currentVersion.get(key)!;
             }
             if (existing !== version){
                 this.currentVersion.set(key, version);

--- a/vscode-lean4/src/utils/localStorage.ts
+++ b/vscode-lean4/src/utils/localStorage.ts
@@ -11,7 +11,7 @@ export class LocalStorageService {
 
     getLeanPath() : string
     {
-        return this.storage.get<string>('LeanPath', null);
+        return this.storage.get<string>('LeanPath', '');
     }
 
     setLeanPath(path : string) : void
@@ -21,7 +21,7 @@ export class LocalStorageService {
 
     getLeanVersion() : string
     {
-        return this.storage.get<string>('LeanVersion', null);
+        return this.storage.get<string>('LeanVersion', '');
     }
 
     setLeanVersion(path : string) : void

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -102,7 +102,7 @@ export async function findLeanPackageVersionInfo(uri: Uri) : Promise<[Uri | null
 export async function readLeanVersion(packageUri: Uri) : Promise<string | null> {
     const toolchainFileName = 'lean-toolchain';
     const tomlFileName = 'leanpkg.toml';
-    if (packageUri.scheme == 'file') {
+    if (packageUri.scheme === 'file') {
         const leanToolchain = Uri.joinPath(packageUri, toolchainFileName);
         if (fs.existsSync(new URL(leanToolchain.toString()))) {
             return await readLeanVersionFile(leanToolchain);
@@ -120,7 +120,7 @@ export async function readLeanVersion(packageUri: Uri) : Promise<string | null> 
 async function readLeanVersionFile(packageFileUri : Uri) : Promise<string | null> {
     const url = new URL(packageFileUri.toString());
     const tomlFileName = 'leanpkg.toml';
-    if (packageFileUri.scheme != 'file'){
+    if (packageFileUri.scheme !== 'file'){
         return null;
     }
     if (packageFileUri.path.endsWith(tomlFileName))

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -41,7 +41,7 @@ export function findLeanPackageRoot(uri: Uri) : [WorkspaceFolder | null, Uri | n
         searchUpwards = true;
     }
 
-    let startFolder = path;
+    const startFolder = path;
     if (path.scheme === 'file') {
         // search parent folders for a leanpkg.toml file, or a Lake lean-toolchain file.
         while (true) {

--- a/vscode-lean4/src/utils/tempFolder.ts
+++ b/vscode-lean4/src/utils/tempFolder.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import { join, sep } from 'path';
 
 export class TempFolder implements Disposable {
-    folder : string = null;
+    folder : string;
 
     constructor(prefix: string){
         this.folder = fs.mkdtempSync(join(os.tmpdir(), prefix))

--- a/vscode-lean4/tsconfig.json
+++ b/vscode-lean4/tsconfig.json
@@ -12,6 +12,8 @@
         "sourceMap": true,
         "alwaysStrict": true,
         "rootDir": "./src",
+        "noImplicitAny": true,
+        "strictNullChecks": true
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
and not iterable exceptions in the results from findLeanPackageRoot and findLeanPackageVersionInfo.  I also turned on strictNullChecks and noImplicitAny compilerOptions which revealed & fixed a few more potential bugs.

I tested the following "open file/open folder" scenarios:
1. open random mathlib file (D:\git\leanprover\mathlib4\Mathlib\Data\Array\Basic.lean) and not open folder.  It installs the mathlib version of lean (currently leanprover/lean4:nightly-2022-01-23) and works.
1. Goto definition from mathlib to Array.push jumps to (C:\users\clovett\.elan\toolchains\leanprover--lean4---nightly-2022-01-23\lib\lean\src\init\prelude.lean) and creates a new LeanClient in (c:\users\clovett\.elan\toolchains\leanprover--lean4---nightly-2022-01-23").
1. Open folder of a local lake package folder, everything works as expected.
1. Open multi-folder workspace from a file named `workspace.code-workspace`.  2 separate LeanClients are created for each folder each running different versions of lean.
1. Open adhoc file that has no inherited lean-toolchain.  LeanClient starts in that folder and works fine with default toolchain.
1. An old leanpkg.toml project pointing to lean version "master" where that is a linked toolchain to a local build (C:\msys64\home\clovett\git\lean4\build\release\stage1) all works, and lean.versionString prints `4.0.0, commit 4fd2eef9f80b5124269dc885317b015c72925bc5`
1. File/New File, set language to lean4 (uses default toolchain)
1. File/New file... with no default toolchain installed, it auto-installs leanprover/lean4:nightly and works.

### Select Toolchain
and I tested the following select toolchain options:
1. open adhoc file with no inherited lean_toolchain, you get the default toolchain.  Then do Select Toolchain and switch to the "master" linked toolchain, and lean server is restarted and the master bits work fine.
1. open a folder with lean-toolchain, and it comes up with that toolchain.  Select Toolchain to switch to "master" works.
1. Now "Reset workspace override..." via the select toolchain menu and lean server is restarted and goes back to the lean-toolchain specified version.

## Edit lean-toolchain file
1. change the version from `leanprover/lean4:nightly-2022-02-13` to `leanprover/lean4:nightly-2022-02-08`.  You get a prompt saying "Lake file configuration changed" with a "Restart lean" button, click the button and it works, version changes to 2022-02-08.
1. delete `lean-toolchain` and reload folder.  It should use your default toolchain.  Then run `echo leanprover/lean4:nightly-2022-02-08 > lean-toolchain` and you will get a prompt saying "Lake file configuration changed" with a "Restart lean" button, click the button and it works, version changes to 2022-02-08.