### PR TITLE
fix: improve startup performance of LeanClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 out/
 dist/
 .vs/
+.vscode-test/
+build/
 
 ## Output
 node_modules/

--- a/README.md
+++ b/README.md
@@ -308,3 +308,22 @@ the packages in tandem using Lerna.
 
 **Note:** if breakpoints are not working, try changing one line of code in `function activate` in `extension.ts`, even
 adding a newline seems to work, then press F5.
+
+## Packaging
+
+To publish the extension on the VS Code marketplace you
+should follow [these instructions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension).
+But for a quick summary you need to install this tool
+
+```
+npm install -g vsce
+```
+
+Then run this command
+```
+cd <vscode-lean4-repo>\vscode-lean4
+vsce package
+```
+
+This gives you a .vsix which you can install using the VS Code
+command `Extensions: Install from VSIX...`.

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -2,7 +2,7 @@
 	"name": "lean4",
 	"displayName": "lean4",
 	"description": "Lean 4 language support for VS Code",
-	"version": "0.0.67",
+	"version": "0.0.68",
 	"publisher": "leanprover",
 	"engines": {
 		"vscode": "^1.57.0"

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -101,6 +101,7 @@ export class LeanClient implements Disposable {
 
     async restart(): Promise<void> {
         this.restartingEmitter.fire(undefined)
+        const startTime = Date.now()
 
         if (this.isStarted()) {
             await this.stop()
@@ -260,7 +261,8 @@ export class LeanClient implements Disposable {
                 if (s.newState === State.Starting) {
                     console.log('client starting');
                 } else if (s.newState === State.Running) {
-                    console.log('client running');
+                    const end = Date.now()
+                    console.log('client running, started in ', end - startTime, 'ms');
                     this.running = true; // may have been auto restarted after it failed.
                 } else if (s.newState === State.Stopped) {
                     console.log('client has stopped or it failed to start');
@@ -518,8 +520,7 @@ export class LeanClient implements Disposable {
         const versionOptions = version ? ['+' + version, '--version'] : ['--version']
         const start = Date.now()
         const lakeVersion = await batchExecute(executable, versionOptions, this.folderUri?.fsPath, undefined);
-        const end = Date.now()
-        console.log("Ran '" + executable + " " + versionOptions.join(' ') + "' in " + (end - start) + "ms");
+        console.log(`Ran '${executable} ${versionOptions.join(' ')}' in ${Date.now() - start} ms`);
         const actual = this.extractVersion(lakeVersion)
         if (actual.compare('3.0.0') > 0) {
             return true;

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -491,25 +491,12 @@ export class LeanClient implements Disposable {
         // to a known date like 'leanprover/lean4:nightly-2022-02-01'
         const toolchainVersion = await readLeanVersion(folderUri);
         if (toolchainVersion) {
-            const parts = toolchainVersion.split('/')
-            if (parts[0] === 'leanprover' && parts.length > 1){
-                const leanVersion = parts[1].split(':');
-                if (leanVersion[0] === 'lean4' && leanVersion.length > 1){
-                    const version = leanVersion[1];
-                    if (version === 'stable'){
-                        return new Date(2022, 2, 1);
-                    }
-                    // nightly-2022-02-01
-                    const dateParts = version.split('-');
-                    if (dateParts[0] === 'nightly' && dateParts.length === 4){
-                        try {
-                            return new Date(parseInt(dateParts[1]),
-                                            parseInt(dateParts[2]) - 1,
-                                            parseInt(dateParts[3]));
-
-                        } catch {}
-                    }
-                }
+            const match = /^leanprover\/lean4:nightly-(\d+)-(\d+)-(\d+)$/.exec(toolchainVersion);
+            if (match) {
+                return new Date(parseInt(match[1]), parseInt(match[2]) - 1, parseInt(match[3]));
+            }
+            if (toolchainVersion === 'leanprover/lean4:stable') {
+                return new Date(2022, 2, 1);
             }
         }
         return undefined;

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -120,17 +120,15 @@ export class LeanClient implements Disposable {
         let useLake = lakeEnabled();
         if (useLake && this.folderUri) {
             if (this.folderUri.scheme === 'file') {
-                const lakefile = Uri.joinPath(this.folderUri, 'lakefile.lean').toString()
-                if (!fs.existsSync(new URL(lakefile))) {
-                    useLake = false;
-                } else {
-                    const toolchainVersion = await readLeanVersion(this.folderUri);
-                    if (toolchainVersion) {
-                        const date = this.extractToolchainDate(toolchainVersion);
-                        if (date < new Date(2022, 1, 1)){
-                            useLake = false; // Feb 1 2022 is when the 3.0.0.pre switched to 3.0.0
-                        }
-                    }
+                let knownDate = false;
+                const date = await this.checkToolchainVersion(this.folderUri);
+                if (date){
+                    // Feb 16 2022 is when the 3.1.0.pre was released.
+                    useLake = date >= new Date(2022, 1, 16);
+                    knownDate = true;
+                }
+                if (useLake && !knownDate){
+                    useLake = await this.checkLakeVersion(executable, version);
                 }
             } else {
                 // probably 'untitled'
@@ -481,6 +479,54 @@ export class LeanClient implements Disposable {
         return this.running ? this.client?.initializeResult : undefined
     }
 
+    private async checkToolchainVersion(folderUri: Uri) : Promise<Date | undefined> {
+        const lakefile = Uri.joinPath(folderUri, 'lakefile.lean').toString()
+        if (!fs.existsSync(new URL(lakefile))) {
+            return undefined;
+        }
+
+        // see if we have a well known toolchain label that corresponds
+        // to a known date like 'leanprover/lean4:nightly-2022-02-01'
+        const toolchainVersion = await readLeanVersion(folderUri);
+        if (toolchainVersion) {
+            const parts = toolchainVersion.split('/')
+            if (parts[0] === 'leanprover' && parts.length > 1){
+                const leanVersion = parts[1].split(':');
+                if (leanVersion[0] === 'lean4' && leanVersion.length > 1){
+                    const version = leanVersion[1];
+                    if (version === 'stable'){
+                        return new Date(2022, 2, 1);
+                    }
+                    // nightly-2022-02-01
+                    const dateParts = version.split('-');
+                    if (dateParts[0] === 'nightly' && dateParts.length === 4){
+                        try {
+                            return new Date(parseInt(dateParts[1]),
+                                            parseInt(dateParts[2]) - 1,
+                                            parseInt(dateParts[3]));
+
+                        } catch {}
+                    }
+                }
+            }
+        }
+        return undefined;
+    }
+
+    async checkLakeVersion(executable: string, version: string) : Promise<boolean> {
+        // Check that the Lake version is high enough to support "lake serve" option.
+        const versionOptions = version ? ['+' + version, '--version'] : ['--version']
+        const start = Date.now()
+        const lakeVersion = await batchExecute(executable, versionOptions, this.folderUri?.fsPath, undefined);
+        const end = Date.now()
+        console.log("Ran '" + executable + " " + versionOptions.join(' ') + "' in " + (end - start) + "ms");
+        const actual = this.extractVersion(lakeVersion)
+        if (actual.compare('3.0.0') > 0) {
+            return true;
+        }
+        return false;
+    }
+
     private extractVersion(v: string | undefined) : SemVer {
         if (!v) return new SemVer('0.0.0');
         const prefix = 'Lake version'
@@ -492,30 +538,5 @@ export class LeanClient implements Disposable {
         } catch {
             return new SemVer('0.0.0');
         }
-    }
-
-    private extractToolchainDate(v: string) : Date {
-        // leanprover/lean4:nightly-2022-02-01
-        const parts = v.split('/')
-        if (parts[0] === 'leanprover' && parts.length > 1){
-            const leanVersion = parts[1].split(':');
-            if (leanVersion[0] === 'lean4' && leanVersion.length > 1){
-                const version = leanVersion[1];
-                if (version === 'stable'){
-                    return new Date(2022, 2, 1);
-                }
-                // nightly-2022-02-01
-                const dateParts = version.split('-');
-                if (dateParts[0] === 'nightly' && dateParts.length === 4){
-                    try {
-                        return new Date(parseInt(dateParts[1]),
-                                        parseInt(dateParts[2]) - 1,
-                                        parseInt(dateParts[3]));
-
-                    } catch {}
-                }
-            }
-        }
-        return new Date(1995, 1, 1); // unknown, so probably an old build.
     }
 }

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -242,7 +242,7 @@ export class LeanClientProvider implements Disposable {
                 const cached = this.clients.get(path);
                 this.clients.delete(path);
                 cached?.dispose();
-                window.showErrorMessage(err);
+                void window.showErrorMessage(err);
             });
 
             // aggregate progress changed events.

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -237,7 +237,13 @@ export class LeanClientProvider implements Disposable {
                 return [false, undefined];
             }
 
-            client.serverFailed((err) => window.showErrorMessage(err));
+            client.serverFailed((err) => {
+                // forget this client!
+                const cached = this.clients.get(path);
+                this.clients.delete(path);
+                cached?.dispose();
+                window.showErrorMessage(err);
+            });
 
             // aggregate progress changed events.
             client.progressChanged(arg => {

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -287,7 +287,7 @@ export class LeanInstaller implements Disposable {
             if (this.versionCache.has(folderPath)) {
                 const version = this.versionCache.get(folderPath);
                 if (version){
-                    return { version: version, error: undefined }
+                    return { version, error: undefined }
                 }
             }
         }

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -132,7 +132,7 @@ async function readLeanVersionFile(packageFileUri : Uri) : Promise<string | null
                         reject(err);
                     } else {
                         const match = /lean_version\s*=\s*"([^"]*)"/.exec(data.toString());
-                        if (match) resolve(match[1]);
+                        if (match) resolve(match[1].trim());
                         resolve(null);
                     }
                 });


### PR DESCRIPTION
1. add optimization that skips the lake test on well known versions because it is too slow where the optimization is based on well known lean-toolchain version strings.  
1. Cache `lean --version` check results because we were doing 2 checks on each reload.

### Results

I put a console output that measures full lean server "restart" time following a `Select Toolchain` choice, so I can run release bits to get good measurements, and with this PR it is:

| Version      | Full restart time| Lake? |
| ----------- | ----------- | -------------|
| leanprover/lean4:nightly-2022-02-01| 658 ms | no |
| leanprover/lean4:nightly-2022-02-16 | 823 ms | yes |
| leanprover/lean4:4.0.0-m3 | 656 ms | no |

Previously without this PR the times are:

| Version      | Full restart time | Lake? |
| ----------- | ----------- |-------------|
| leanprover/lean4:nightly-2022-02-01| 1594 ms | no |
| leanprover/lean4:nightly-2022-02-16 | 1526 ms | yes |
| leanprover/lean4:4.0.0-m3 | 1637 ms | no |

So I think this shows a pretty healthy speed up.