### PR TITLE
Add intelligent wrapping for theorems with parentheses

### DIFF
--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -31,7 +31,8 @@ html,body {
 }
 
 .pre-wrap {
-    white-space: 'pre-wrap';
+    white-space: pre-wrap;
+    word-wrap: break-word;
 }
 
 .error {


### PR DESCRIPTION
Adding CSS word-wrap Property in order to allow intelligent wrapping for theorems with parentheses (including nested ones)