### PR TITLE
fix flakey test

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,8 +303,8 @@ the packages in tandem using Lerna.
 
 ### Testing
 - Make sure you have executed the above build steps
-- Run `npx lerna run --scope=@lean4 test`
-- See [test readme](test/readme.md) for more information.
+- Run `npm run test`
+- See [test readme](vscode-lean4/test/readme.md) for more information.
 
 ### Debugging
 - Open VS Code on this folder.

--- a/vscode-lean4/package-lock.json
+++ b/vscode-lean4/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lean4",
-	"version": "0.0.68",
+	"version": "0.0.69",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lean4",
-			"version": "0.0.68",
+			"version": "0.0.69",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"axios": "^0.24.0",

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -377,7 +377,7 @@ export class LeanClient implements Disposable {
 
     isSameWorkspace(uri: Uri){
         if (this.folderUri) {
-            if (this.folderUri.scheme != uri.scheme) return false;
+            if (this.folderUri.scheme !== uri.scheme) return false;
             if (this.folderUri.scheme === 'file') {
                 const realPath1 = fs.realpathSync(this.folderUri.fsPath).toLowerCase();
                 const realPath2 = fs.realpathSync(uri.fsPath).toLowerCase();

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -377,24 +377,12 @@ export class LeanClient implements Disposable {
         });
     }
 
-    async getRealPath(fsPath : string) : Promise<string> {
-        return new Promise<string>((resolve, reject) => {
-            fs.realpath(fsPath, (err, resolvedPath) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(resolvedPath);
-                }
-            });
-        });
-    }
-
     async isSameWorkspace(uri: Uri) : Promise<boolean> {
         if (this.folderUri) {
             if (this.folderUri.scheme !== uri.scheme) return false;
             if (this.folderUri.scheme === 'file') {
-                const realPath1 = await this.getRealPath(this.folderUri.fsPath);
-                const realPath2 = await this.getRealPath(uri.fsPath);
+                const realPath1 = await fs.promises.realpath(this.folderUri.fsPath);
+                const realPath2 = await fs.promises.realpath(uri.fsPath);
                 if (process.platform === 'win32') {
                     // windows paths are case insensitive.
                     return realPath2.toLowerCase().startsWith(realPath1.toLowerCase());

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -224,10 +224,8 @@ export class LeanClient implements Disposable {
 
                 didClose: (doc, next) => {
                     if (!this.isOpen.delete(doc.uri.toString())) {
-                        console.log(">> doc not open: " + doc.uri.toString())
                         return;
                     }
-                    console.log(">> didClose: " + doc.uri.toString())
                     next(doc);
                     if (!this.running || !this.client) return; // there was a problem starting lean server.
                     const params = this.client.code2ProtocolConverter.asCloseTextDocumentParams(doc);
@@ -369,7 +367,6 @@ export class LeanClient implements Disposable {
     }
 
     notifyDidOpen(doc: TextDocument) {
-        console.log(">> notifyDidOpen", doc.uri.toString());
         void this.client?.sendNotification(DidOpenTextDocumentNotification.type, {
             textDocument: {
                 uri: doc.uri.toString(),

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -176,7 +176,7 @@ export class LeanClientProvider implements Disposable {
     getKeyFromUri(uri: Uri | null) : string{
         const uriNonNull = uri ?? Uri.from({scheme: 'untitled'});
         const path = uriNonNull.toString();
-        if (uriNonNull.scheme == 'file' && process.platform === 'win32') {
+        if (uriNonNull.scheme === 'file' && process.platform === 'win32') {
             return path.toLowerCase();
         }
         return path;

--- a/vscode-lean4/test/suite/multi/multi.test.ts
+++ b/vscode-lean4/test/suite/multi/multi.test.ts
@@ -3,7 +3,7 @@ import { suite } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { waitForActiveExtension, waitForActiveEditor, waitForInfoViewOpen, waitForHtmlString,
-	assertLeanVersion } from '../utils/helpers';
+	assertStringInInfoview } from '../utils/helpers';
 import { InfoProvider } from '../../../src/infoview';
 import { LeanClientProvider} from '../../../src/utils/clientProvider';
 
@@ -34,14 +34,14 @@ suite('Multi-Folder Test Suite', () => {
 			'Info view did not open after 20 seconds');
 
 		// verify we have a nightly build running in this folder.
-		await assertLeanVersion(info, '4.0.0-nightly-');
+		await assertStringInInfoview(info, '4.0.0-nightly-');
 
 		// Now open a file from the other project
 		const doc2 = await vscode.workspace.openTextDocument(path.join(testsRoot, 'foo', 'Foo.lean'));
 		await vscode.window.showTextDocument(doc2, options);
 
 		// verify that a different version of lean is running here (leanprover/lean4:stable)
-		await assertLeanVersion(info, '4.0.0, commit');
+		await assertStringInInfoview(info, '4.0.0, commit');
 
 		// Now verify we have 2 LeanClients running.
 		const clients = lean.exports.clientProvider as LeanClientProvider;

--- a/vscode-lean4/test/suite/multi/multi.test.ts
+++ b/vscode-lean4/test/suite/multi/multi.test.ts
@@ -17,8 +17,9 @@ suite('Multi-Folder Test Suite', () => {
 		void vscode.window.showInformationMessage('Running tests: ' + __dirname);
 
 		const testsRoot = path.join(__dirname, '..', '..', '..', '..', 'test', 'test-fixtures', 'multi');
+		const options : vscode.TextDocumentShowOptions = { preview: false  };
 		const doc = await vscode.workspace.openTextDocument(path.join(testsRoot, 'test', 'Main.lean'));
-		await vscode.window.showTextDocument(doc);
+		await vscode.window.showTextDocument(doc, options);
 
 		const lean = await waitForActiveExtension('leanprover.lean4');
 		assert(lean, 'Lean extension not loaded');
@@ -37,14 +38,15 @@ suite('Multi-Folder Test Suite', () => {
 
 		// Now open a file from the other project
 		const doc2 = await vscode.workspace.openTextDocument(path.join(testsRoot, 'foo', 'Foo.lean'));
-		await vscode.window.showTextDocument(doc2);
+		await vscode.window.showTextDocument(doc2, options);
 
 		// verify that a different version of lean is running here (leanprover/lean4:stable)
 		await assertLeanVersion(info, '4.0.0, commit');
 
 		// Now verify we have 2 LeanClients running.
 		const clients = lean.exports.clientProvider as LeanClientProvider;
-		assert(clients.getClients().length === 2, "Expected 2 LeanClients to be running");
+		const actual = clients.getClients().length
+		assert(actual === 2, "Expected 2 LeanClients to be running, but found " + actual);
 
 		// make sure test is always run in predictable state, which is no file or folder open
 		await vscode.commands.executeCommand('workbench.action.closeAllEditors');

--- a/vscode-lean4/test/suite/simple/simple.test.ts
+++ b/vscode-lean4/test/suite/simple/simple.test.ts
@@ -126,7 +126,7 @@ suite('Lean3 Basics Test Suite', () => {
 	}).timeout(60000);
 
 	test('Goto definition in a package folder', async () => {
-		console.log('=================== Load Lean File goto definition in a package folder ===================');
+		console.log('=================== Goto definition in a package folder ===================');
 
 		// This test is run twice, once as an ad-hoc mode (no folder open)
 		// and again using "open folder" mode.
@@ -173,12 +173,8 @@ suite('Lean3 Basics Test Suite', () => {
 		expectedVersion = 'Lake Version:';
 		html = await waitForHtmlString(info, expectedVersion);
 
-		const lakeVersionString = extractPhrase(html, 'Lake Version:', '<').trim();
-		if (lakeVersionString) {
-			console.log(`>>> Found "${lakeVersionString}" in infoview`)
-		} else {
-			assert(false, 'Lake Version: not found in infoview');
-		}
+		// verify we have a nightly build running in this folder.
+		await assertLeanVersion(info, 'Lake Version:');
 
 		// make sure test is always run in predictable state, which is no file or folder open
 		await vscode.commands.executeCommand('workbench.action.closeAllEditors');

--- a/vscode-lean4/test/suite/simple/simple.test.ts
+++ b/vscode-lean4/test/suite/simple/simple.test.ts
@@ -3,7 +3,7 @@ import { suite } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { waitForActiveExtension, waitForActiveEditor, waitForInfoViewOpen, waitForHtmlString,
-	extractPhrase, findWord, assertLeanVersion } from '../utils/helpers';
+	extractPhrase, findWord, assertStringInInfoview } from '../utils/helpers';
 import { InfoProvider } from '../../../src/infoview';
 import { LeanClientProvider} from '../../../src/utils/clientProvider';
 import { LeanInstaller } from '../../../src/utils/leanInstaller';
@@ -40,7 +40,7 @@ suite('Lean3 Basics Test Suite', () => {
 		assert(await waitForInfoViewOpen(info, 60),
 			'Info view did not open after 60 seconds');
 
-		await assertLeanVersion(info, '4.0.0-nightly-');
+		await assertStringInInfoview(info, '4.0.0-nightly-');
 
 		// test goto definition to lean toolchain works
 
@@ -174,7 +174,7 @@ suite('Lean3 Basics Test Suite', () => {
 		html = await waitForHtmlString(info, expectedVersion);
 
 		// verify we have a nightly build running in this folder.
-		await assertLeanVersion(info, 'Lake Version:');
+		await assertStringInInfoview(info, 'Lake Version:');
 
 		// make sure test is always run in predictable state, which is no file or folder open
 		await vscode.commands.executeCommand('workbench.action.closeAllEditors');

--- a/vscode-lean4/test/suite/toolchains/toolchain.test.ts
+++ b/vscode-lean4/test/suite/toolchains/toolchain.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { waitForActiveExtension, waitForActiveEditor, waitForInfoViewOpen, waitForHtmlString,
-	extractPhrase, restartLeanServer, assertLeanVersion } from '../utils/helpers';
+	extractPhrase, restartLeanServer, assertStringInInfoview } from '../utils/helpers';
 import { InfoProvider } from '../../../src/infoview';
 import { LeanClientProvider} from '../../../src/utils/clientProvider';
 import { LeanInstaller } from '../../../src/utils/leanInstaller';
@@ -42,12 +42,12 @@ suite('Toolchain Test Suite', () => {
 		assert(await waitForInfoViewOpen(info, 60),
 			'Info view did not open after 60 seconds');
 
-		await assertLeanVersion(info, '4.0.0-nightly-');
+		await assertStringInInfoview(info, '4.0.0-nightly-');
 
 		// Now switch toolchains (simple suite uses leanprover/lean4:nightly by default)
 		await vscode.commands.executeCommand('lean4.selectToolchain', 'leanprover/lean4:stable');
 
-		await assertLeanVersion(info, '4.0.0, commit-');
+		await assertStringInInfoview(info, '4.0.0, commit-');
 
 		// make sure test is always run in predictable state, which is no file or folder open
 		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
@@ -180,7 +180,7 @@ suite('Toolchain Test Suite', () => {
 		installer.setPromptUser(false);
 
 		// verify we have a nightly build running in this folder.
-		await assertLeanVersion(info, '4.0.0-nightly-');
+		await assertStringInInfoview(info, '4.0.0-nightly-');
 
 		// Find out if we have a 'master' toolchain (setup in our workflow: on-push.yml)
 		// and use it if it is there, otherwise use 'leanprover/lean4:stable'.
@@ -197,7 +197,7 @@ suite('Toolchain Test Suite', () => {
 		fs.writeFileSync(toolchainFile, selectedToolChain);
 
 		// verify that we switched to leanprover/lean4:stable
-		const html = await assertLeanVersion(info, '4.0.0, commit');
+		const html = await assertStringInInfoview(info, '4.0.0, commit');
 
 		// check the path to lean.exe from the `eval IO.appPath`
 		const leanPath = extractPhrase(html, 'FilePath.mk', '<').trim();
@@ -208,7 +208,7 @@ suite('Toolchain Test Suite', () => {
 		fs.writeFileSync(toolchainFile, originalContents);
 
 		// Now make sure the reset works and we can go back to the previous nightly version.
-		await assertLeanVersion(info, '4.0.0-nightly-');
+		await assertStringInInfoview(info, '4.0.0-nightly-');
 
 		// make sure test is always run in predictable state, which is no file or folder open
 		await vscode.commands.executeCommand('workbench.action.closeAllEditors');

--- a/vscode-lean4/test/suite/utils/helpers.ts
+++ b/vscode-lean4/test/suite/utils/helpers.ts
@@ -172,10 +172,9 @@ export async function restartLeanServer(client: LeanClient, retries=10, delay=10
     return false;
 }
 
-export async function assertLeanVersion(infoView: InfoProvider, version: string) : Promise<string> {
-    const expectedVersion = '4.0.0-nightly-';
+export async function assertLeanVersion(infoView: InfoProvider, expectedVersion: string) : Promise<string> {
     const html = await waitForHtmlString(infoView, expectedVersion);
-    const pos = html.indexOf('4.0.0-nightly-');
+    const pos = html.indexOf(expectedVersion);
     if (pos >= 0) {
         // e.g. 4.0.0-nightly-2022-02-16
         const versionString = html.substring(pos, pos + 24)

--- a/vscode-lean4/test/suite/utils/helpers.ts
+++ b/vscode-lean4/test/suite/utils/helpers.ts
@@ -172,7 +172,7 @@ export async function restartLeanServer(client: LeanClient, retries=10, delay=10
     return false;
 }
 
-export async function assertLeanVersion(infoView: InfoProvider, expectedVersion: string) : Promise<string> {
+export async function assertStringInInfoview(infoView: InfoProvider, expectedVersion: string) : Promise<string> {
     const html = await waitForHtmlString(infoView, expectedVersion);
     const pos = html.indexOf(expectedVersion);
     if (pos >= 0) {


### PR DESCRIPTION
fix: sometimes depending on how we get to this function the Uri has different case on some folders, like I see "d:\temp\..." or "d:\Temp\..." and that caused this function to fail to see the file was in the same workspace and then it failed to create a new `lean --worker` at all for that file.  This was causing some test flakiness on Windows machines.

Also found and fixed some other obvious bugs in the tests and test utils.