### PR TITLE
[issue 146] Spurious error from eslint extension

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
             "./lean4-infoview-api/tsconfig.json",
             "./lean4-infoview/tsconfig.json",
             "./vscode-lean4/tsconfig.json",
-            "./vscode-lean4/webview/tsconfig.json",
+            "./vscode-lean4/webview/tsconfig.json"
         ],
         "sourceType": "module"
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,8 @@
     "eslint.workingDirectories": [
         "./lean4-infoview",
         "./vscode-lean4",
+        "./lean4-infoview-api",
+        "./vscode-lean4/webview"
     ],
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true


### PR DESCRIPTION
This PR fixes the issue with eslint with tsconfig.json adding missing directories in eslint.workingDirectories inside .vscode/settings.json