### PR TITLE
fix: switch to new consistent elan-init.ps1 arguments.

### DIFF
--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -482,8 +482,12 @@ export class LeanInstaller implements Disposable {
             if (process.platform === 'win32') {
                 terminal.sendText(
                     `Invoke-WebRequest -Uri "${this.leanInstallerWindows}" -OutFile elan-init.ps1\n` +
-                    `.\\elan-init.ps1 -NoMenu 1 -PromptOnError 1 -DefaultToolchain ${this.defaultToolchain}\n` +
+                    `$rc = .\\elan-init.ps1 -NoPrompt 1 -DefaultToolchain ${this.defaultToolchain}\n` +
+                    'Write-Host "elan-init returned [$rc]"\n' +
                     'del .\\elan-init.ps1\n' +
+                    'if ($rc -ne 0) {\n' +
+                    '    Read-Host -Prompt "Press ENTER to continue"\n' +
+                    '}\n' +
                     'exit\n'
                     );
             }


### PR DESCRIPTION
Sebastian wanted me to change `elan-init.ps1` command line args to be more consitent with elan-init.exe.

See related elan PR https://github.com/leanprover/elan/pull/65 