### PR TITLE
feat: change "⊢" in conv goals to "|"

### DIFF
--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -30,6 +30,8 @@ export function goalsToString(goals: InteractiveGoals): string {
 }
 
 export function Goal({pos, goal}: {pos: DocumentPosition, goal: InteractiveGoal}) {
+    let prefix = '⊢'
+    if (goal.goalPrefix === '|') {prefix = '|'}
     return <div className="font-code tl pre-wrap">
         <ul className="list pl0">
             {goal.userName && <li key={'case'}><strong className="goal-case">case </strong>{goal.userName}</li>}
@@ -40,7 +42,7 @@ export function Goal({pos, goal}: {pos: DocumentPosition, goal: InteractiveGoal}
                 </li>
             })}
             <li key={'goal'}>
-                <strong className="goal-vdash">⊢ </strong><InteractiveCode pos={pos} fmt={goal.type} />
+                <strong className="goal-vdash">{prefix} </strong><InteractiveCode pos={pos} fmt={goal.type} />
             </li>
         </ul>
     </div>

--- a/lean4-infoview/src/infoview/rpcInterface.ts
+++ b/lean4-infoview/src/infoview/rpcInterface.ts
@@ -74,6 +74,7 @@ export interface InteractiveGoal {
     hyps: InteractiveHypothesis[]
     type: CodeWithInfos
     userName?: string
+    goalPrefix: string
 }
 
 function InteractiveGoal_registerRefs(rs: RpcSessions, pos: DocumentPosition, g: InteractiveGoal) {


### PR DESCRIPTION
In conv mode, we rewrite (and thus change) the original goal, the "|" signifies this. This is similar to Lean3.

Suggested by @javra.