### PR TITLE
fix: elan installation on Unix

### DIFF
--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -494,7 +494,7 @@ export class LeanInstaller implements Disposable {
             }
             else{
                 const elanArgs = `-y --default-toolchain ${this.defaultToolchain}`;
-                const prompt = 'echo && read -n 1 -s -r -p "Install failed, press ENTER to continue..."';
+                const prompt = '(echo && read -n 1 -s -r -p "Install failed, press ENTER to continue...")';
 
                 terminal.sendText(`bash -c 'curl ${this.leanInstallerLinux} -sSf | sh -s -- ${elanArgs} || ${prompt}' && exit `);
             }


### PR DESCRIPTION
`||` and `&&` have the same precedence in bash