### PR TITLE
found a fix for flakey tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -132,6 +132,17 @@
             "cwd": "${workspaceFolder}/vscode-lean4/out/",
             "outFiles": ["${workspaceFolder}/vscode-lean4/out/test/suite/**/*.js"],
             "preLaunchTask": "watchTest"
-        }
+        },
+        {
+            "name": "Launch runTests.js",
+            "program": "${workspaceFolder}/vscode-lean4/out/test/suite/runTest.js",
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "cwd": "${workspaceFolder}/vscode-lean4/",
+            "sourceMaps": true,
+            "type": "node"
+        },
     ]
 }

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -418,7 +418,13 @@ export class LeanClient implements Disposable {
         assert(() => this.isStarted())
         if (this.client && this.running) {
             this.stoppedEmitter.fire(undefined);
-            await this.client.stop()
+            try {
+                // some timing conditions can happen while running unit tests that cause
+                // this to throw an exception which then causes those tests to fail.
+                await this.client.stop();
+            } catch (e) {
+                console.log(`Error stopping language client: ${e}`)
+            }
         }
 
         this.progress = new Map()


### PR DESCRIPTION
Some timing conditions can happen while running unit tests that cause the LanguageClient stop method to throw an exception which then causes those tests to fail.  We really don't care if stop fails, so I added a try/catch and this seems to help make the tests less flakey.

Note the first workflow run failed, but that is with an unrealted error: `Failed to get VS Code archive location`.