### PR TITLE
feat: add go-to-definition to infoview

### DIFF
--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -319,6 +319,7 @@ function InfoAux(props: InfoProps) {
             const [goals, termGoal] = await allReq;
             setGoals(goals);
             setTermGoal(termGoal);
+            setStatus('ready');
         } catch (err: any) {
             if (err?.code === -32801) {
                 // Document has been changed since we made the request, try again
@@ -326,8 +327,6 @@ function InfoAux(props: InfoProps) {
                 return;
             } else { onError(err); }
         }
-
-        setStatus('ready');
     });
 
     React.useEffect(() => void triggerUpdate(), [pos.uri, pos.line, pos.character, serverIsProcessing]);

--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -34,9 +34,9 @@ export function InfoStatusBar(props: InfoStatusBarProps) {
     const ec = React.useContext(EditorContext);
 
     const statusColTable: {[T in InfoStatus]: string} = {
-        'loading': 'gold',
-        'updating': 'gold',
-        'error': 'dark-red',
+        'loading': 'gold ',
+        'updating': 'gold ',
+        'error': 'dark-red ',
         'ready': '',
     }
     const statusColor = statusColTable[status];
@@ -44,7 +44,7 @@ export function InfoStatusBar(props: InfoStatusBarProps) {
     const isPinned = kind === 'pin';
 
     return (
-    <summary style={{transition: 'color 0.5s ease'}} className={'mv2 pointer' + statusColor}>
+    <summary style={{transition: 'color 0.5s ease'}} className={'mv2 pointer ' + statusColor}>
         {locationString}
         {isPinned && !isPaused && ' (pinned)'}
         {!isPinned && isPaused && ' (paused)'}
@@ -59,10 +59,10 @@ export function InfoStatusBar(props: InfoStatusBarProps) {
                 <a className="link pointer mh2 dim codicon codicon-go-to-file"
                    onClick={e => { e.preventDefault(); void ec.revealPosition(pos); }}
                    title="reveal file location" />}
-            <a className={'link pointer mh2 dim codicon ' + (isPinned ? 'codicon-pinned' : 'codicon-pin')}
+            <a className={'link pointer mh2 dim codicon ' + (isPinned ? 'codicon-pinned ' : 'codicon-pin ')}
                 onClick={e => { e.preventDefault(); onPin(pos); }}
                 title={isPinned ? 'unpin' : 'pin'} />
-            <a className={'link pointer mh2 dim codicon ' + (isPaused ? 'codicon-debug-continue' : 'codicon-debug-pause')}
+            <a className={'link pointer mh2 dim codicon ' + (isPaused ? 'codicon-debug-continue ' : 'codicon-debug-pause ')}
                onClick={e => { e.preventDefault(); setPaused(!isPaused); }}
                title={isPaused ? 'continue updating' : 'pause updating'} />
             <a className="link pointer mh2 dim codicon codicon-refresh"
@@ -124,7 +124,7 @@ export function InfoDisplay(props0: InfoDisplayProps) {
     const hasGoals = status !== 'error' && goals;
     const hasTermGoal = status !== 'error' && termGoal;
     const hasMessages = status !== 'error' && messages.length !== 0;
-    const sortClasses = 'link pointer mh2 dim codicon fr ' + (goalFilters.reverse ? 'codicon-arrow-up' : 'codicon-arrow-down');
+    const sortClasses = 'link pointer mh2 dim codicon fr ' + (goalFilters.reverse ? 'codicon-arrow-up ' : 'codicon-arrow-down ');
     const sortButton = <a className={sortClasses} title="reverse list" onClick={e => {
         setGoalFilters(s => {
             return { ...s, reverse: !s.reverse }
@@ -136,29 +136,29 @@ export function InfoDisplay(props0: InfoDisplayProps) {
             setGoalFilters(s => {
                 return { ...s, isType: !s.isType }
             } ); }}>
-                <span className={'popup-menu-icon codicon ' + (goalFilters.isType ? 'codicon-check' : 'codicon-blank')}>&nbsp;</span>
-                <span className='popup-menu-text'>types</span>
+                <span className={'popup-menu-icon codicon ' + (goalFilters.isType ? 'codicon-check ' : 'codicon-blank ')}>&nbsp;</span>
+                <span className='popup-menu-text '>types</span>
         </a>
         <br/>
         <a className='link pointer popup-menu' onClick={e => {
             setGoalFilters(s => {
                 return { ...s, isInstance: !s.isInstance }
             } ); }}>
-                <span className={'popup-menu-icon codicon ' + (goalFilters.isInstance ? 'codicon-check' : 'codicon-blank')}>&nbsp;</span>
-                <span className='popup-menu-text'>instances</span>
+                <span className={'popup-menu-icon codicon ' + (goalFilters.isInstance ? 'codicon-check ' : 'codicon-blank ')}>&nbsp;</span>
+                <span className='popup-menu-text '>instances</span>
         </a>
         <br/>
         <a className='link pointer popup-menu' onClick={e => {
             setGoalFilters(s => {
                 return { ...s, isHiddenAssumption: !s.isHiddenAssumption }
             } ); }}>
-                <span className={'popup-menu-icon codicon ' + (goalFilters.isHiddenAssumption ? 'codicon-check' : 'codicon-blank')}>&nbsp;</span>
-                <span className='popup-menu-text'>hidden assumptions</span>
+                <span className={'popup-menu-icon codicon ' + (goalFilters.isHiddenAssumption ? 'codicon-check ' : 'codicon-blank ')}>&nbsp;</span>
+                <span className='popup-menu-text '>hidden assumptions</span>
         </a>
     </span>
     const filterButton = <span className='fr'>
-        <WithTooltipOnHover tooltipContent={() => {return filterMenu}}>
-            <a className={'link pointer mh2 dim codicon ' + ((!goalFilters.isInstance || !goalFilters.isType || !goalFilters.isHiddenAssumption) ? 'codicon-filter-filled': 'codicon-filter')}/>
+        <WithTooltipOnHover mkTooltipContent={() => {return filterMenu}}>
+            <a className={'link pointer mh2 dim codicon ' + ((!goalFilters.isInstance || !goalFilters.isType || !goalFilters.isHiddenAssumption) ? 'codicon-filter-filled ': 'codicon-filter ')}/>
         </WithTooltipOnHover></span>
 
     return (
@@ -168,7 +168,7 @@ export function InfoDisplay(props0: InfoDisplayProps) {
             {hasError &&
                 <div className="error">
                     Error updating: {error}.
-                    <a className="link pointer dim" onClick={e => { e.preventDefault(); void triggerDisplayUpdate(); }}>Try again.</a>
+                    <a className="link pointer dim" onClick={e => { e.preventDefault(); void triggerDisplayUpdate(); }}> Try again.</a>
                 </div>}
             <div style={{display: hasGoals ? 'block' : 'none'}}>
                 <Details initiallyOpen>

--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -8,7 +8,7 @@ import { EditorContext, ProgressContext, RpcContext, VersionContext } from './co
 import { MessagesList, useMessagesFor } from './messages';
 import { getInteractiveGoals, getInteractiveTermGoal, InteractiveDiagnostic, InteractiveGoal, InteractiveGoals } from './rpcInterface';
 import { updatePlainGoals, updateTermGoal } from './goalCompat';
-import { HighlightOnHoverSpan, WithTooltipOnHover } from './tooltips'
+import { WithTooltipOnHover } from './tooltips'
 
 type InfoStatus = 'loading' | 'updating' | 'error' | 'ready';
 type InfoKind = 'cursor' | 'pin';

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -98,29 +98,6 @@ function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<SubexprInfo
     return undefined
   }, [rs, pos.uri, pos.line, pos.character, ct.info, goToLoc])
 
-  React.useEffect(() => {
-    const onKeyDown = (e : KeyboardEvent) => {
-      if (e.key === 'Control')
-        setHoverState(st => {
-          const newst = st === 'over' ? 'ctrlOver' : st
-          if (newst === 'ctrlOver') void fetchGoToLoc()
-          return newst
-        })
-    }
-
-    const onKeyUp = (e : KeyboardEvent) => {
-      if (e.key === 'Control')
-        setHoverState(st => st === 'ctrlOver' ? 'over' : st)
-    }
-
-    document.addEventListener('keydown', onKeyDown)
-    document.addEventListener('keyup', onKeyUp)
-    return () => {
-      document.removeEventListener('keydown', onKeyDown)
-      document.removeEventListener('keyup', onKeyUp)
-    }
-  }, [fetchGoToLoc])
-
   return (
     <WithTooltipOnHover
       mkTooltipContent={mkTooltip}
@@ -132,16 +109,6 @@ function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<SubexprInfo
           void ec.revealPosition({ uri: loc.uri, ...loc.range.start })
         })
         if (!e.ctrlKey) next(e)
-      }}
-      onPointerMove={e => {
-        if (e.ctrlKey)
-          setHoverState(st => {
-            const newst = st === 'over' ? 'ctrlOver' : st
-            if (newst === 'ctrlOver') void fetchGoToLoc()
-            return newst
-          })
-        else
-          setHoverState(st => st === 'ctrlOver' ? 'over' : st)
       }}
     >
       <DetectHoverSpan

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -86,7 +86,7 @@ function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<CodeToken>)
   return (
     <WithTooltipOnHover mkTooltipContent={mkTooltip} onClick={(e, next) => {
       // On ctrl-click, if location is known, go to it in the editor
-      if (e.ctrlKey && goToLoc !== undefined) ec.revealPosition({ uri: goToLoc.uri, ...goToLoc.range.start })
+      if (e.ctrlKey && goToLoc !== undefined) void ec.revealPosition({ uri: goToLoc.uri, ...goToLoc.range.start })
       if (!e.ctrlKey) next(e)
     }}>
       <DetectHoverSpan

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -97,26 +97,25 @@ function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<SubexprInfo
     }
     return undefined
   }, [rs, pos.uri, pos.line, pos.character, ct.info, goToLoc])
+  React.useEffect(() => { if (hoverState === 'ctrlOver') void fetchGoToLoc() }, [hoverState])
 
   return (
     <WithTooltipOnHover
       mkTooltipContent={mkTooltip}
       onClick={(e, next) => {
         // On ctrl-click, if location is known, go to it in the editor
-        if (e.ctrlKey) void fetchGoToLoc().then(loc => {
-          if (loc === undefined) return
+        if (e.ctrlKey) {
           setHoverState(st => st === 'over' ? 'ctrlOver' : st)
-          void ec.revealPosition({ uri: loc.uri, ...loc.range.start })
-        })
+          void fetchGoToLoc().then(loc => {
+            if (loc === undefined) return
+            void ec.revealPosition({ uri: loc.uri, ...loc.range.start })
+          })
+        }
         if (!e.ctrlKey) next(e)
       }}
     >
       <DetectHoverSpan
-        setHoverState={st => {
-          // On ctrl-hover, fetch the go-to location
-          if (st === 'ctrlOver') void fetchGoToLoc()
-          setHoverState(st)
-        }}
+        setHoverState={setHoverState}
         className={'highlightable '
                     + (hoverState !== 'off' ? 'highlight ' : '')
                     + (hoverState === 'ctrlOver' && goToLoc !== undefined ? 'underline ' : '')}

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -101,7 +101,11 @@ function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<SubexprInfo
   return (
     <WithTooltipOnHover mkTooltipContent={mkTooltip} onClick={(e, next) => {
       // On ctrl-click, if location is known, go to it in the editor
-      if (e.ctrlKey) void fetchGoToLoc().then(loc => loc && ec.revealPosition({ uri: loc.uri, ...loc.range.start }))
+      if (e.ctrlKey) void fetchGoToLoc().then(loc => {
+        if (loc === undefined) return
+        setHoverState(st => st === 'over' ? 'ctrlOver' : st)
+        void ec.revealPosition({ uri: loc.uri, ...loc.range.start })
+      })
       if (!e.ctrlKey) next(e)
     }}>
       <DetectHoverSpan

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { EditorContext, RpcContext } from './contexts'
 import { DocumentPosition } from './util'
-import { CodeToken, CodeWithInfos, InfoPopup, InfoWithCtx, InteractiveDiagnostics_infoToInteractive, Lean_Widget_getGoToLocation, TaggedText } from './rpcInterface'
+import { CodeToken, CodeWithInfos, InfoPopup, InfoWithCtx, InteractiveDiagnostics_infoToInteractive, getGoToLocation, TaggedText } from './rpcInterface'
 import { DetectHoverSpan, HoverState, WithTooltipOnHover } from './tooltips'
 import { Location } from 'vscode-languageserver-protocol'
 
@@ -93,9 +93,10 @@ function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<CodeToken>)
         setHoverState={st => {
           // On ctrl-hover, fetch the go-to location
           if (st === 'ctrlOver') {
-            void Lean_Widget_getGoToLocation(rs, pos, ct.info, 'definition').then(loc => {
-              if (loc) setGoToLoc(loc)
-            }).catch(e => console.error('Error in go-to-definition: ', e.toString()))
+            void getGoToLocation(rs, pos, 'definition', ct.info).then(lnks => {
+              if (lnks !== undefined && lnks.length > 0)
+                setGoToLoc({ uri: lnks[0].targetUri, range: lnks[0].targetSelectionRange })
+            }).catch(e => console.error('Error in go-to-definition: ', JSON.stringify(e)))
           }
           setHoverState(st)
         }}

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { EditorContext, RpcContext } from './contexts'
 import { DocumentPosition } from './util'
-import { CodeToken, CodeWithInfos, InfoPopup, InfoWithCtx, InteractiveDiagnostics_infoToInteractive, getGoToLocation, TaggedText } from './rpcInterface'
+import { SubexprInfo, CodeWithInfos, InfoPopup, InfoWithCtx, InteractiveDiagnostics_infoToInteractive, getGoToLocation, TaggedText } from './rpcInterface'
 import { DetectHoverSpan, HoverState, WithTooltipOnHover } from './tooltips'
 import { Location } from 'vscode-languageserver-protocol'
 
@@ -69,8 +69,8 @@ function TypePopupContents({pos, info, redrawTooltip}: {pos: DocumentPosition, i
   } else return <>Loading..</>
 }
 
-/** Tagged spans can be hovered over to display extra info stored in the associated `CodeToken`. */
-function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<CodeToken>) {
+/** Tagged spans can be hovered over to display extra info stored in the associated `SubexprInfo`. */
+function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<SubexprInfo>) {
   const mkTooltip = React.useCallback((redrawTooltip: () => void) =>
     <div className="font-code tl pre-wrap">
       <TypePopupContents pos={pos} info={ct.info}

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -122,15 +122,28 @@ function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<SubexprInfo
   }, [fetchGoToLoc])
 
   return (
-    <WithTooltipOnHover mkTooltipContent={mkTooltip} onClick={(e, next) => {
-      // On ctrl-click, if location is known, go to it in the editor
-      if (e.ctrlKey) void fetchGoToLoc().then(loc => {
-        if (loc === undefined) return
-        setHoverState(st => st === 'over' ? 'ctrlOver' : st)
-        void ec.revealPosition({ uri: loc.uri, ...loc.range.start })
-      })
-      if (!e.ctrlKey) next(e)
-    }}>
+    <WithTooltipOnHover
+      mkTooltipContent={mkTooltip}
+      onClick={(e, next) => {
+        // On ctrl-click, if location is known, go to it in the editor
+        if (e.ctrlKey) void fetchGoToLoc().then(loc => {
+          if (loc === undefined) return
+          setHoverState(st => st === 'over' ? 'ctrlOver' : st)
+          void ec.revealPosition({ uri: loc.uri, ...loc.range.start })
+        })
+        if (!e.ctrlKey) next(e)
+      }}
+      onPointerMove={e => {
+        if (e.ctrlKey)
+          setHoverState(st => {
+            const newst = st === 'over' ? 'ctrlOver' : st
+            if (newst === 'ctrlOver') void fetchGoToLoc()
+            return newst
+          })
+        else
+          setHoverState(st => st === 'ctrlOver' ? 'over' : st)
+      }}
+    >
       <DetectHoverSpan
         setHoverState={st => {
           // On ctrl-hover, fetch the go-to location

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { RpcContext } from './contexts'
 import { DocumentPosition } from './util'
 import { CodeToken, CodeWithInfos, InfoPopup, InfoWithCtx, InteractiveDiagnostics_infoToInteractive, TaggedText } from './rpcInterface'
-import { HighlightOnHoverSpan, WithTooltipOnHover } from './tooltips'
+import { DetectHoverSpan, HoverState, WithTooltipOnHover } from './tooltips'
 
 export interface InteractiveTextComponentProps<T> {
   pos: DocumentPosition
@@ -68,18 +68,27 @@ function TypePopupContents({pos, info, redrawTooltip}: {pos: DocumentPosition, i
   } else return <>Loading..</>
 }
 
-/** Tags in code represent values which can be hovered over to display extra info. */
+/** Tagged spans can be hovered over to display extra info stored in the associated `CodeToken`. */
 function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<CodeToken>) {
   const mkTooltip = React.useCallback((redrawTooltip: () => void) =>
     <div className="font-code tl pre-wrap">
       <TypePopupContents pos={pos} info={ct.info}
         redrawTooltip={redrawTooltip} />
     </div>, [pos.uri, pos.line, pos.character, ct.info])
+
+  const [hoverState, setHoverState] = React.useState<HoverState>('off')
   return (
-    <WithTooltipOnHover tooltipContent={mkTooltip}>
-      <HighlightOnHoverSpan>
+    <WithTooltipOnHover tooltipContent={mkTooltip} onClick={e => {
+      if (e.ctrlKey) {
+        console.log("gotodef", fmt)
+      }
+    }}>
+      <DetectHoverSpan
+        setHoverState={setHoverState}
+        className={'highlightable ' + (hoverState !== 'off' ? 'highlight ' : '') + (hoverState === 'ctrlOver' ? 'underline ' : '')}
+      >
         <InteractiveCode pos={pos} fmt={fmt} />
-      </HighlightOnHoverSpan>
+      </DetectHoverSpan>
     </WithTooltipOnHover>
   )
 }

--- a/lean4-infoview/src/infoview/rpcInterface.ts
+++ b/lean4-infoview/src/infoview/rpcInterface.ts
@@ -9,6 +9,7 @@ import { RpcPtr, LeanDiagnostic } from '@lean4/infoview-api'
 
 import { DocumentPosition } from './util'
 import { RpcSessions } from './rpcSessions'
+import { Location } from 'vscode-languageserver-protocol'
 
 export type TaggedText<T> =
     { text: string } |
@@ -153,4 +154,9 @@ export async function InteractiveDiagnostics_msgToInteractive(rs: RpcSessions, p
     const ret = await rs.call<TaggedText<MsgEmbed>>(pos, 'Lean.Widget.InteractiveDiagnostics.msgToInteractive', msg)
     if (ret) TaggedMsg_registerRefs(rs, pos, ret)
     return ret
+}
+
+export type GoToKind = 'definition' | 'declaration' | 'type'
+export async function Lean_Widget_getGoToLocation(rs: RpcSessions, pos: DocumentPosition, info: InfoWithCtx, kind: GoToKind): Promise<Location | undefined> {
+    return rs.call<Location>(pos, 'Lean.Widget.getGoToLocation', [info, kind])
 }

--- a/lean4-infoview/src/infoview/rpcInterface.ts
+++ b/lean4-infoview/src/infoview/rpcInterface.ts
@@ -39,15 +39,16 @@ export type InfoWithCtx = RpcPtr<'InfoWithCtx'>
 
 export interface CodeToken {
     info: InfoWithCtx
+    subexprPos?: number
 }
 
 export type CodeWithInfos = TaggedText<CodeToken>
 export type ExprWithCtx = RpcPtr<'ExprWithCtx'>
 
 export interface InfoPopup {
-  type?: CodeWithInfos
-  exprExplicit?: CodeWithInfos
-  doc?: string
+    type?: CodeWithInfos
+    exprExplicit?: CodeWithInfos
+    doc?: string
 }
 
 function CodeWithInfos_registerRefs(rs: RpcSessions, pos: DocumentPosition, ci: CodeWithInfos): void {

--- a/lean4-infoview/src/infoview/rpcInterface.ts
+++ b/lean4-infoview/src/infoview/rpcInterface.ts
@@ -37,12 +37,12 @@ export function TaggedText_stripTags<T>(tt: TaggedText<T>): string {
 
 export type InfoWithCtx = RpcPtr<'InfoWithCtx'>
 
-export interface CodeToken {
+export interface SubexprInfo {
     info: InfoWithCtx
     subexprPos?: number
 }
 
-export type CodeWithInfos = TaggedText<CodeToken>
+export type CodeWithInfos = TaggedText<SubexprInfo>
 export type ExprWithCtx = RpcPtr<'ExprWithCtx'>
 
 export interface InfoPopup {

--- a/lean4-infoview/src/infoview/rpcInterface.ts
+++ b/lean4-infoview/src/infoview/rpcInterface.ts
@@ -157,7 +157,7 @@ export async function InteractiveDiagnostics_msgToInteractive(rs: RpcSessions, p
     return ret
 }
 
-export type GoToKind = 'definition' | 'declaration' | 'type'
+export type GoToKind = 'declaration' | 'definition' | 'type'
 export async function getGoToLocation(rs: RpcSessions, pos: DocumentPosition, kind: GoToKind, info: InfoWithCtx): Promise<LocationLink[] | undefined> {
     interface GetGoToLocationParams {
         kind: GoToKind;

--- a/lean4-infoview/src/infoview/rpcInterface.ts
+++ b/lean4-infoview/src/infoview/rpcInterface.ts
@@ -159,5 +159,10 @@ export async function InteractiveDiagnostics_msgToInteractive(rs: RpcSessions, p
 
 export type GoToKind = 'definition' | 'declaration' | 'type'
 export async function getGoToLocation(rs: RpcSessions, pos: DocumentPosition, kind: GoToKind, info: InfoWithCtx): Promise<LocationLink[] | undefined> {
-    return rs.call<LocationLink[]>(pos, 'Lean.Widget.getGoToLocation', [kind, info])
+    interface GetGoToLocationParams {
+        kind: GoToKind;
+        info: InfoWithCtx;
+    }
+    const args: GetGoToLocationParams = { kind, info };
+    return rs.call<LocationLink[]>(pos, 'Lean.Widget.getGoToLocation', args)
 }

--- a/lean4-infoview/src/infoview/rpcInterface.ts
+++ b/lean4-infoview/src/infoview/rpcInterface.ts
@@ -9,7 +9,7 @@ import { RpcPtr, LeanDiagnostic } from '@lean4/infoview-api'
 
 import { DocumentPosition } from './util'
 import { RpcSessions } from './rpcSessions'
-import { Location } from 'vscode-languageserver-protocol'
+import { LocationLink } from 'vscode-languageserver-protocol'
 
 export type TaggedText<T> =
     { text: string } |
@@ -158,6 +158,6 @@ export async function InteractiveDiagnostics_msgToInteractive(rs: RpcSessions, p
 }
 
 export type GoToKind = 'definition' | 'declaration' | 'type'
-export async function Lean_Widget_getGoToLocation(rs: RpcSessions, pos: DocumentPosition, info: InfoWithCtx, kind: GoToKind): Promise<Location | undefined> {
-    return rs.call<Location>(pos, 'Lean.Widget.getGoToLocation', [info, kind])
+export async function getGoToLocation(rs: RpcSessions, pos: DocumentPosition, kind: GoToKind, info: InfoWithCtx): Promise<LocationLink[] | undefined> {
+    return rs.call<LocationLink[]>(pos, 'Lean.Widget.getGoToLocation', [kind, info])
 }

--- a/lean4-infoview/src/infoview/tooltips.tsx
+++ b/lean4-infoview/src/infoview/tooltips.tsx
@@ -157,8 +157,6 @@ export const WithTooltipOnHover =
   const hideDelay = 300
 
   const onClick = (e: React.MouseEvent<HTMLSpanElement>) => {
-    if (!isWithinHoverable(e.target)) return
-    e.stopPropagation()
     clearTimeout()
     setState(state => state === 'pin' ? 'hide' : 'pin')
   }
@@ -214,6 +212,8 @@ export const WithTooltipOnHover =
       {...props}
       ref={setRef}
       onClick={e => {
+        if (!isWithinHoverable(e.target)) return
+        e.stopPropagation()
         if (props.onClick !== undefined) props.onClick(e, onClick)
         else onClick(e)
       }}

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -12,6 +12,7 @@ import { getInfoViewAllErrorsOnLine, getInfoViewAutoOpen, getInfoViewAutoOpenSho
 import { Rpc } from './rpc';
 import { LeanClientProvider } from './utils/clientProvider'
 import * as ls from 'vscode-languageserver-protocol'
+import { c2pConverter, p2cConverter } from './utils/converters';
 
 const keepAlivePeriodMs = 10000
 
@@ -190,19 +191,15 @@ export class InfoProvider implements Disposable {
             let uri: Uri | undefined
             let pos: Position | undefined
             if (tdpp) {
-                const client = this.clientProvider.findClient(tdpp.textDocument.uri);
-                if (!client?.running) return;
-                uri = client.convertUriFromString(tdpp.textDocument.uri);
-                pos = client.convertPosition(tdpp.position);
+                uri = p2cConverter.asUri(tdpp.textDocument.uri);
+                pos = p2cConverter.asPosition(tdpp.position);
             }
             await this.handleInsertText(text, kind, uri, pos);
         },
         showDocument: async (show) => {
-            const client = this.clientProvider.findClient(show.uri);
-            if (!client?.running) return;
             void this.revealEditorSelection(
                 Uri.parse(show.uri),
-                client.convertRange(show.selection)
+                p2cConverter.asRange(show.selection)
             );
         },
 
@@ -493,7 +490,7 @@ export class InfoProvider implements Disposable {
         for (const [uri, processing] of client.progress) {
             const params: LeanFileProgressParams = {
                 textDocument: {
-                    uri: client.convertUri(uri)?.toString(),
+                    uri: c2pConverter.asUri(uri),
                     version: 0, // HACK: The infoview ignores this
                 },
                 processing,

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -1,9 +1,8 @@
 import { TextDocument, EventEmitter, Diagnostic,
     DocumentHighlight, Range, DocumentHighlightKind, workspace,
     Disposable, Uri, ConfigurationChangeEvent, OutputChannel, DiagnosticCollection,
-    Position, WorkspaceFolder } from 'vscode'
+    WorkspaceFolder } from 'vscode'
 import {
-    Code2ProtocolConverter,
     DidChangeTextDocumentParams,
     DidCloseTextDocumentParams,
     DidOpenTextDocumentNotification,
@@ -11,7 +10,6 @@ import {
     InitializeResult,
     LanguageClient,
     LanguageClientOptions,
-    Protocol2CodeConverter,
     PublishDiagnosticsParams,
     ServerOptions,
     State
@@ -29,12 +27,9 @@ import { join } from 'path';
  // @ts-ignore
 import { SemVer } from 'semver';
 import { fileExists } from './utils/fsHelper';
+import { c2pConverter, p2cConverter } from './utils/converters'
 
 const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-interface Lean4Diagnostic extends ls.Diagnostic {
-    fullRange: ls.Range;
-}
 
 export type ServerProgress = Map<Uri, LeanFileProgressProcessingInfo[]>;
 
@@ -195,11 +190,11 @@ export class LeanClient implements Disposable {
                 handleDiagnostics: (uri, diagnostics, next) => {
                     next(uri, diagnostics);
                     if (!this.client) return;
-                    const uri_ = this.client.code2ProtocolConverter.asUri(uri);
+                    const uri_ = c2pConverter.asUri(uri);
                     const diagnostics_ = [];
                     for (const d of diagnostics) {
                         const d_: ls.Diagnostic = {
-                            ...this.client.code2ProtocolConverter.asDiagnostic(d),
+                            ...c2pConverter.asDiagnostic(d),
                         };
                         diagnostics_.push(d_);
                     }
@@ -222,7 +217,7 @@ export class LeanClient implements Disposable {
                 didChange: async (data, next) => {
                     await next(data);
                     if (!this.running || !this.client) return; // there was a problem starting lean server.
-                    const params = this.client.code2ProtocolConverter.asChangeTextDocumentParams(data);
+                    const params = c2pConverter.asChangeTextDocumentParams(data);
                     this.didChangeEmitter.fire(params);
                 },
 
@@ -232,7 +227,7 @@ export class LeanClient implements Disposable {
                     }
                     await next(doc);
                     if (!this.running || !this.client) return; // there was a problem starting lean server.
-                    const params = this.client.code2ProtocolConverter.asCloseTextDocumentParams(doc);
+                    const params = c2pConverter.asCloseTextDocumentParams(doc);
                     this.didCloseEmitter.fire(params);
                 },
 
@@ -271,7 +266,6 @@ export class LeanClient implements Disposable {
             serverOptions,
             clientOptions
         )
-        this.patchConverters(this.client.protocol2CodeConverter, this.client.code2ProtocolConverter)
         try {
             this.client.onDidChangeState((s) =>{
                 // see https://github.com/microsoft/vscode-languageserver-node/issues/825
@@ -309,7 +303,7 @@ export class LeanClient implements Disposable {
         const starHandler = (method: string, params_: any) => {
             if (method === '$/lean/fileProgress' && this.client) {
                 const params = params_ as LeanFileProgressParams;
-                const uri = this.client.protocol2CodeConverter.asUri(params.textDocument.uri)
+                const uri = p2cConverter.asUri(params.textDocument.uri)
                 this.progressChangedEmitter.fire([uri.toString(), params.processing]);
                 // save the latest progress on this Uri in case infoview needs it later.
                 this.progress.set(uri, params.processing);
@@ -327,30 +321,6 @@ export class LeanClient implements Disposable {
         });
 
         this.restartedEmitter.fire(undefined)
-    }
-
-    private patchConverters(p2c: Protocol2CodeConverter, c2p: Code2ProtocolConverter) {
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        const oldAsDiagnostic = p2c.asDiagnostic
-        p2c.asDiagnostic = function (protDiag: Lean4Diagnostic): Diagnostic {
-            if (!protDiag.message) {
-                // Fixes: Notification handler 'textDocument/publishDiagnostics' failed with message: message must be set
-                protDiag.message = ' ';
-            }
-            const diag = oldAsDiagnostic.apply(this, [protDiag])
-            diag.fullRange = p2c.asRange(protDiag.fullRange)
-            return diag
-        }
-        p2c.asDiagnostics = async (diags) => diags.map(d => p2c.asDiagnostic(d))
-
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        const c2pAsDiagnostic = c2p.asDiagnostic;
-        c2p.asDiagnostic = function (diag: Diagnostic & {fullRange: Range}): Lean4Diagnostic {
-            const protDiag = c2pAsDiagnostic.apply(this, [diag])
-            protDiag.fullRange = c2p.asRange(diag.fullRange)
-            return protDiag
-        }
-        c2p.asDiagnostics = async (diags) => diags.map(d => c2p.asDiagnostic(d))
     }
 
     async openLean4Document(doc: TextDocument) {
@@ -484,27 +454,10 @@ export class LeanClient implements Disposable {
         return this.running  && this.client ? this.client.sendNotification(method, params) : undefined;
     }
 
-    convertUri(uri: Uri): Uri {
-        return this.running  && this.client ? Uri.parse(this.client.code2ProtocolConverter.asUri(uri)) : uri;
-    }
-
-    convertUriFromString(uri: string): Uri {
-        const u = Uri.parse(uri);
-        return this.running && this.client ? Uri.parse(this.client.code2ProtocolConverter.asUri(u)) : u;
-    }
-
-    convertPosition(pos: ls.Position) : Position | undefined {
-        return this.running ? this.client?.protocol2CodeConverter.asPosition(pos) : undefined;
-    }
-
-    convertRange(range: ls.Range | undefined): Range | undefined {
-        return this.running && range ? this.client?.protocol2CodeConverter.asRange(range) : undefined;
-    }
-
     async getDiagnosticParams(uri: Uri, diagnostics: readonly Diagnostic[]) : Promise<PublishDiagnosticsParams> {
         const params: PublishDiagnosticsParams = {
-            uri: this.convertUri(uri)?.toString(),
-            diagnostics: await this.client?.code2ProtocolConverter.asDiagnostics(diagnostics as Diagnostic[]) ?? []
+            uri: c2pConverter.asUri(uri),
+            diagnostics: await c2pConverter.asDiagnostics(diagnostics as Diagnostic[])
         };
         return params;
     }

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -27,7 +27,7 @@ import { join } from 'path';
  // @ts-ignore
 import { SemVer } from 'semver';
 import { fileExists } from './utils/fsHelper';
-import { c2pConverter, p2cConverter } from './utils/converters'
+import { c2pConverter, p2cConverter, patchConverters } from './utils/converters'
 
 const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
@@ -266,6 +266,7 @@ export class LeanClient implements Disposable {
             serverOptions,
             clientOptions
         )
+        patchConverters(this.client.protocol2CodeConverter, this.client.code2ProtocolConverter)
         try {
             this.client.onDidChangeState((s) =>{
                 // see https://github.com/microsoft/vscode-languageserver-node/issues/825

--- a/vscode-lean4/src/utils/converters.ts
+++ b/vscode-lean4/src/utils/converters.ts
@@ -14,33 +14,38 @@ import { createConverter as createP2CConverter } from 'vscode-languageclient/lib
 import { createConverter as createC2PConverter } from 'vscode-languageclient/lib/common/codeConverter';
 import * as ls from 'vscode-languageserver-protocol'
 import * as code from 'vscode'
+import { Code2ProtocolConverter, Protocol2CodeConverter } from 'vscode-languageclient';
 
 interface Lean4Diagnostic extends ls.Diagnostic {
     fullRange: ls.Range;
 }
 
 export const p2cConverter = createP2CConverter(undefined, true, true)
-
-// eslint-disable-next-line @typescript-eslint/unbound-method
-const oldAsDiagnostic = p2cConverter.asDiagnostic
-p2cConverter.asDiagnostic = function (protDiag: Lean4Diagnostic): code.Diagnostic {
-    if (!protDiag.message) {
-        // Fixes: Notification handler 'textDocument/publishDiagnostics' failed with message: message must be set
-        protDiag.message = ' ';
-    }
-    const diag = oldAsDiagnostic.apply(this, [protDiag])
-    diag.fullRange = p2cConverter.asRange(protDiag.fullRange)
-    return diag
-}
-p2cConverter.asDiagnostics = async (diags) => diags.map(d => p2cConverter.asDiagnostic(d))
-
 export const c2pConverter = createC2PConverter(undefined)
 
-// eslint-disable-next-line @typescript-eslint/unbound-method
-const c2pAsDiagnostic = c2pConverter.asDiagnostic
-c2pConverter.asDiagnostic = function (diag: code.Diagnostic & {fullRange: code.Range}): Lean4Diagnostic {
-    const protDiag = c2pAsDiagnostic.apply(this, [diag])
-    protDiag.fullRange = c2pConverter.asRange(diag.fullRange)
-    return protDiag
+export function patchConverters(p2cConverter: Protocol2CodeConverter, c2pConverter: Code2ProtocolConverter) {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const oldAsDiagnostic = p2cConverter.asDiagnostic
+    p2cConverter.asDiagnostic = function (protDiag: Lean4Diagnostic): code.Diagnostic {
+        if (!protDiag.message) {
+            // Fixes: Notification handler 'textDocument/publishDiagnostics' failed with message: message must be set
+            protDiag.message = ' ';
+        }
+        const diag = oldAsDiagnostic.apply(this, [protDiag])
+        diag.fullRange = p2cConverter.asRange(protDiag.fullRange)
+        return diag
+    }
+    p2cConverter.asDiagnostics = async (diags) => diags.map(d => p2cConverter.asDiagnostic(d))
+
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const c2pAsDiagnostic = c2pConverter.asDiagnostic
+    c2pConverter.asDiagnostic = function (diag: code.Diagnostic & {fullRange: code.Range}): Lean4Diagnostic {
+        const protDiag = c2pAsDiagnostic.apply(this, [diag])
+        protDiag.fullRange = c2pConverter.asRange(diag.fullRange)
+        return protDiag
+    }
+    c2pConverter.asDiagnostics = async (diags) => diags.map(d => c2pConverter.asDiagnostic(d))
 }
-c2pConverter.asDiagnostics = async (diags) => diags.map(d => c2pConverter.asDiagnostic(d))
+
+patchConverters(p2cConverter, c2pConverter)

--- a/vscode-lean4/src/utils/converters.ts
+++ b/vscode-lean4/src/utils/converters.ts
@@ -1,0 +1,46 @@
+/**
+ * For LSP communication, we need a way to translate between LSP types and corresponding VSCode types.
+ * By default this translation is provided as a bunch of methods on a `LanguageClient`, but this is
+ * awkward to use in multi-client workspaces wherein we need to look up specific clients. In fact the
+ * conversions are *not* stateful, so having them depend on the client is unnecessary. Instead, we
+ * provide global converters here.
+ *
+ * Some of the conversions are patched to support extended Lean-specific structures.
+ *
+ * @module
+ */
+
+import { createConverter as createP2CConverter } from 'vscode-languageclient/lib/common/protocolConverter';
+import { createConverter as createC2PConverter } from 'vscode-languageclient/lib/common/codeConverter';
+import * as ls from 'vscode-languageserver-protocol'
+import * as code from 'vscode'
+
+interface Lean4Diagnostic extends ls.Diagnostic {
+    fullRange: ls.Range;
+}
+
+export const p2cConverter = createP2CConverter(undefined, true, true)
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const oldAsDiagnostic = p2cConverter.asDiagnostic
+p2cConverter.asDiagnostic = function (protDiag: Lean4Diagnostic): code.Diagnostic {
+    if (!protDiag.message) {
+        // Fixes: Notification handler 'textDocument/publishDiagnostics' failed with message: message must be set
+        protDiag.message = ' ';
+    }
+    const diag = oldAsDiagnostic.apply(this, [protDiag])
+    diag.fullRange = p2cConverter.asRange(protDiag.fullRange)
+    return diag
+}
+p2cConverter.asDiagnostics = async (diags) => diags.map(d => p2cConverter.asDiagnostic(d))
+
+export const c2pConverter = createC2PConverter(undefined)
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const c2pAsDiagnostic = c2pConverter.asDiagnostic
+c2pConverter.asDiagnostic = function (diag: code.Diagnostic & {fullRange: code.Range}): Lean4Diagnostic {
+    const protDiag = c2pAsDiagnostic.apply(this, [diag])
+    protDiag.fullRange = c2pConverter.asRange(diag.fullRange)
+    return protDiag
+}
+c2pConverter.asDiagnostics = async (diags) => diags.map(d => c2pConverter.asDiagnostic(d))


### PR DESCRIPTION
- Add go-to-definition to the infoview with a ctrl+click UI mimicking VSCode.

https://user-images.githubusercontent.com/13901751/169145205-15d6cfe8-8fa6-422e-ba51-e1ed36fcf756.mp4
- Add `subexprPos` to `CodeToken` to know subexpression positions for visual tactics like interactive `rw` and `conv`.
- ~~Put RPC calls in a namespace and remove inconsistent namespace prefixes.~~

This needs a server PR (leanprover/lean4#1157).

