### PR TITLE
feat: support go-to-def on MacOS

### DIFF
--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -104,7 +104,7 @@ function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<SubexprInfo
       mkTooltipContent={mkTooltip}
       onClick={(e, next) => {
         // On ctrl-click, if location is known, go to it in the editor
-        if (e.ctrlKey) {
+        if (e.ctrlKey || e.metaKey) {
           setHoverState(st => st === 'over' ? 'ctrlOver' : st)
           void fetchGoToLoc().then(loc => {
             if (loc === undefined) return

--- a/lean4-infoview/src/infoview/tooltips.tsx
+++ b/lean4-infoview/src/infoview/tooltips.tsx
@@ -70,7 +70,13 @@ export const Tooltip = forwardAndUseRef<HTMLDivElement,
   return ReactDOM.createPortal(popper, document.body)
 })
 
+/** Hover state of an element. The pointer can be
+ * - elsewhere (`off`)
+ * - over the element (`over`)
+ * - over the element with Ctrl or Meta (⌘ on Mac) held (`ctrlOver`)
+ */
 export type HoverState = 'off' | 'over' | 'ctrlOver'
+
 /** An element which calls `setHoverState` when the hover state of its DOM children changes.
  *
  * It is implemented with JS rather than CSS in order to allow nesting of these elements. When nested,
@@ -91,19 +97,19 @@ export const DetectHoverSpan =
       if ('_DetectHoverSpanSeen' in e) return
       (e as any)._DetectHoverSpanSeen = {}
       if (!b) setHoverState('off')
-      else if (e.ctrlKey) setHoverState('ctrlOver')
+      else if (e.ctrlKey || e.metaKey) setHoverState('ctrlOver')
       else setHoverState('over')
     }
   }
 
   React.useEffect(() => {
     const onKeyDown = (e : KeyboardEvent) => {
-      if (e.key === 'Control')
+      if (e.key === 'Control' || e.key === 'Meta')
         setHoverState(st => st === 'over' ? 'ctrlOver' : st)
     }
 
     const onKeyUp = (e : KeyboardEvent) => {
-      if (e.key === 'Control')
+      if (e.key === 'Control' || e.key === 'Meta')
         setHoverState(st => st === 'ctrlOver' ? 'over' : st)
     }
 
@@ -121,7 +127,7 @@ export const DetectHoverSpan =
       onPointerOver={onPointerEvent(true)}
       onPointerOut={onPointerEvent(false)}
       onPointerMove={e => {
-        if (e.ctrlKey)
+        if (e.ctrlKey || e.metaKey)
           setHoverState(st => st === 'over' ? 'ctrlOver' : st)
         else
           setHoverState(st => st === 'ctrlOver' ? 'over' : st)


### PR DESCRIPTION
On Mac, meta-click rather than ctrl-click seems to be the default for go-to-definition.