### PR TITLE
doc: add quickstart video to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This extension provides VSCode editor support for the Lean 4 programming languag
 all new [Language Server](https://docs.microsoft.com/en-us/visualstudio/extensibility/language-server-protocol)
 implemented in Lean.
 
+<div>
+<iframe width="1024" height="720" src="https://www.youtube.com/embed/yZo6k48L0VY" title="Quickstart Video" frameborder="0" allow="clipboard-write; encrypted-media;" allowfullscreen></iframe>
+</div>
+
 ## Installing the extension and Lean 4
 1. Install the extension from the [marketplace](https://marketplace.visualstudio.com/items?itemName=leanprover.lean4).
 1. Create a new folder called `foo` and add a file named `hello.lean`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ all new [Language Server](https://docs.microsoft.com/en-us/visualstudio/extensib
 implemented in Lean.
 
 <div>
-<iframe width="1024" height="720" src="https://www.youtube.com/embed/yZo6k48L0VY" title="Quickstart Video" frameborder="0" allow="clipboard-write; encrypted-media;" allowfullscreen></iframe>
+<video src="https://leanassets.blob.core.windows.net/videos/Getting%20Started%20with%20Lean%204%20in%20Visual%20Studio%20Code.mp4" style="width:1024px;" controls></video>
 </div>
 
 ## Installing the extension and Lean 4

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ This extension provides VSCode editor support for the Lean 4 programming languag
 all new [Language Server](https://docs.microsoft.com/en-us/visualstudio/extensibility/language-server-protocol)
 implemented in Lean.
 
-<div>
-<video src="https://leanassets.blob.core.windows.net/videos/Getting%20Started%20with%20Lean%204%20in%20Visual%20Studio%20Code.mp4" style="width:1024px;" controls></video>
-</div>
+See [Quick Start Demo Video](https://www.youtube.com/watch?v=yZo6k48L0VY).
 
 ## Installing the extension and Lean 4
 1. Install the extension from the [marketplace](https://marketplace.visualstudio.com/items?itemName=leanprover.lean4).


### PR DESCRIPTION
Can't embed the video unfortunately, it doesn't work on 
https://github.com/leanprover/vscode-lean4/tree/clovett/video
but it does work in 
https://github.dev/leanprover/vscode-lean4/tree/clovett/video
so it has to be a link that jumps the user out to YouTube.