### PR TITLE
feat: widgets

### DIFF
--- a/lean4-infoview-api/src/lspTypes.ts
+++ b/lean4-infoview-api/src/lspTypes.ts
@@ -44,19 +44,24 @@ export interface LeanFileProgressParams {
 
 // https://stackoverflow.com/a/56749647
 declare const tag: unique symbol;
+/** An RPC pointer is a reference to an object on the lean server.
+ * An example where you need this is passing the Environment object,
+ * which we need to be able to reference but which would be too large to
+ * send over directly.
+ */
 export type RpcPtr<T> = { readonly [tag]: T, p: string }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace RpcPtr {
 
-export function copy<T>(p: RpcPtr<T>): RpcPtr<T> {
-    return { p: p.p } as RpcPtr<T>;
-}
+    export function copy<T>(p: RpcPtr<T>): RpcPtr<T> {
+        return { p: p.p } as RpcPtr<T>;
+    }
 
-/** Turns a reference into a unique string. Useful for React `key`s. */
-export function toKey(p: RpcPtr<any>): string {
-    return p.p;
-}
+    /** Turns a reference into a unique string. Useful for React `key`s. */
+    export function toKey(p: RpcPtr<any>): string {
+        return p.p;
+    }
 
 }
 
@@ -85,4 +90,25 @@ export interface RpcReleaseParams {
     refs: RpcPtr<any>[]
 }
 
-export const RpcNeedsReconnect = -32900
+export enum RpcErrorCode {
+    ParseError = -32700,
+    InvalidRequest = -32600,
+    MethodNotFound = -32601,
+    InvalidParams = -32602,
+    InternalError = -32603,
+    ServerNotInitialized = -32002,
+    UnknownErrorCode = -32001,
+    ContentModified = -32801,
+    RequestCancelled = -32800,
+    RpcNeedsReconnect = -32900,
+}
+
+export interface RpcError {
+    code: RpcErrorCode
+    message: string
+}
+
+export function isRpcError(x : any) : x is RpcError {
+    return !!(x?.code && x?.message)
+}
+

--- a/lean4-infoview/src/components.ts
+++ b/lean4-infoview/src/components.ts
@@ -1,3 +1,0 @@
-export { InteractiveCode } from './infoview/interactiveCode';
-export { InteractiveMessage } from './infoview/traceExplorer';
-export { EditorContext, RpcContext, VersionContext, ConfigContext, LspDiagnosticsContext, ProgressContext } from './infoview/contexts';

--- a/lean4-infoview/src/components.tsx
+++ b/lean4-infoview/src/components.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import { InteractiveCode } from './infoview/interactiveCode';
+import { InteractiveDiagnostics_msgToInteractive, TaggedText, MsgEmbed, ExprWithCtx, CodeWithInfos, MessageData } from './infoview/rpcInterface';
+import { InteractiveMessage } from './infoview/traceExplorer';
+import { DocumentPosition } from './infoview/util';
+import { RpcContext } from './infoview/contexts';
+
+export { DocumentPosition };
+export { EditorContext, RpcContext, VersionContext } from './infoview/contexts';
+export { EditorConnection } from './infoview/editorConnection';
+export { RpcSessions } from './infoview/rpcSessions';
+export { ServerVersion } from './infoview/serverVersion';
+
+/** Display the given message data as interactive, pretty-printed text. */
+export function InteractiveMessageData({pos, msg}: {pos: DocumentPosition, msg: MessageData}) {
+    const rs = React.useContext(RpcContext)
+    const [tt, setTt] = React.useState<TaggedText<MsgEmbed> | undefined>(undefined)
+
+    React.useEffect(() => {
+        void InteractiveDiagnostics_msgToInteractive(rs, pos, msg, 0)
+            .then(tt => tt && setTt(tt))
+    }, [pos.character, pos.line, pos.uri, msg])
+
+    if (tt) return <InteractiveMessage pos={pos} fmt={tt} />
+    else return <></>
+}

--- a/lean4-infoview/src/infoview/editorConnection.ts
+++ b/lean4-infoview/src/infoview/editorConnection.ts
@@ -7,6 +7,8 @@ import { DocumentPosition } from './util';
 
 export type EditorEvents = Eventify<InfoviewApi>;
 
+/** Provides higher-level wrappers around functionality provided by the editor,
+ * e.g. to insert a comment. See also {@link EditorApi}. */
 export class EditorConnection {
   constructor(readonly api: EditorApi, readonly events: EditorEvents) {}
 

--- a/lean4-infoview/src/infoview/errors.tsx
+++ b/lean4-infoview/src/infoview/errors.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export class ErrorBoundary extends React.Component<{}, {error: string | undefined}> {
+  constructor(props: {}) {
+    super(props);
+    this.state = { error: undefined };
+  }
+
+  static getDerivedStateFromError(error: any) {
+    // Update state so the next render will show the fallback UI.
+    return { error: error.toString() };
+  }
+
+  render() {
+    if (this.state.error) {
+      // You can render any custom fallback UI
+      return <div>
+          <h1>Error:</h1>{this.state.error}<br/>
+          <a onClick={() => this.setState({ error: undefined })}>Click to reload.</a>
+        </div>;
+    }
+
+    return this.props.children;
+  }
+}
+

--- a/lean4-infoview/src/infoview/goalCompat.ts
+++ b/lean4-infoview/src/infoview/goalCompat.ts
@@ -1,5 +1,5 @@
 import { PlainGoal, PlainTermGoal } from '@lean4/infoview-api';
-import { InteractiveGoal, InteractiveGoals, InteractiveHypothesis } from './rpcInterface';
+import { InteractiveGoal, InteractiveGoals, InteractiveHypothesisBundle } from './rpcInterface';
 
 function getGoals(plainGoals: PlainGoal): string[] {
     if (plainGoals.goals) return plainGoals.goals
@@ -21,7 +21,7 @@ function transformGoalToInteractive(g: string): InteractiveGoal {
     // by keeping indented lines with the most recent non-indented line
     const parts = (g.match(/(^(?!  ).*\n?(  .*\n?)*)/mg) ?? []).map(line => line.trim())
     let userName
-    const hyps: InteractiveHypothesis[] = []
+    const hyps: InteractiveHypothesisBundle[] = []
     let type = ''
     for (const p of parts) {
         if (p.match(/^(⊢) /mg)) {
@@ -30,7 +30,7 @@ function transformGoalToInteractive(g: string): InteractiveGoal {
             userName = p.slice(5)
         } else if (p.match(/^([^:\n< ][^:\n⊢{[(⦃]*) :/mg)) {
             const ss = p.split(':')
-            const hyp: InteractiveHypothesis = {
+            const hyp: InteractiveHypothesisBundle = {
                 isType: false,
                 isInstance: false,
                 names: ss[0].split(' ')

--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -1,8 +1,28 @@
 import * as React from 'react'
 import { DocumentPosition } from './util'
-import { ConfigContext } from './contexts'
 import { InteractiveCode } from './interactiveCode'
-import { InteractiveGoal, InteractiveGoals, InteractiveHypothesis, TaggedText_stripTags } from './rpcInterface'
+import { InteractiveGoal, InteractiveGoals, InteractiveHypothesisBundle, InteractiveHypothesisBundle_accessableNames, TaggedText_stripTags } from './rpcInterface'
+
+interface HypProps {
+    pos: DocumentPosition
+    hyp: InteractiveHypothesisBundle
+    index: number
+}
+
+export function Hyp({ pos, hyp : h, index }: HypProps) {
+    const names = InteractiveHypothesisBundle_accessableNames(h).map((n, i) =>
+            <span className="mr1">{n}</span>
+        )
+    const hypKey = (h.fvarIds?.[0] ?? index)
+    return <li>
+            <strong className="goal-hyp">{names}</strong>
+            :&nbsp;
+            <InteractiveCode pos={pos} fmt={h.type} />
+            {h.val && <>
+                := <InteractiveCode pos={pos} fmt={h.val} />
+            </>}
+    </li>
+}
 
 function goalToString(g: InteractiveGoal): string {
     let ret = ''
@@ -12,7 +32,7 @@ function goalToString(g: InteractiveGoal): string {
     }
 
     for (const h of g.hyps) {
-        const names = h.names.join(' ')
+        const names = InteractiveHypothesisBundle_accessableNames(h).join(' ')
         ret += `${names} : ${TaggedText_stripTags(h.type)}`
         if (h.val) {
             ret += ` := ${TaggedText_stripTags(h.val)}`
@@ -30,56 +50,67 @@ export function goalsToString(goals: InteractiveGoals): string {
 }
 
 export interface GoalFilterState {
-    /** If true reverse the list of InteractiveHypothesis, if false present the order received from LSP */
+    /** If true reverse the list of InteractiveHypothesisBundle, if false present the order received from LSP */
     reverse: boolean,
-    /** If true show InteractiveHypothesis that have isType=True, if false, hide InteractiveHypothesis that have isType=True. */
+    /** If true show InteractiveHypothesisBundle that have isType=True, if false, hide InteractiveHypothesisBundle that have isType=True. */
     isType: boolean,
-    /** If true show InteractiveHypothesis that have isInstance=True, if false, hide InteractiveHypothesis that have isInstance=True. */
+    /** If true show InteractiveHypothesisBundle that have isInstance=True, if false, hide InteractiveHypothesisBundle that have isInstance=True. */
     isInstance: boolean,
-    /** If true show InteractiveHypothesis that contain a dagger in the name, if false, hide InteractiveHypothesis that contain a dagger in the name. */
+    /** If true show InteractiveHypothesisBundle that contain a dagger in the name, if false, hide InteractiveHypothesisBundle that contain a dagger in the name. */
     isHiddenAssumption: boolean
 }
 
-function isHiddenAssumption(h: InteractiveHypothesis){
+function isHiddenAssumption(h: InteractiveHypothesisBundle) {
     return h.names.every(n => n.indexOf('✝') >= 0);
 }
 
-function getFilteredHypotheses(hyps: InteractiveHypothesis[], filter: GoalFilterState): InteractiveHypothesis[] {
+function getFilteredHypotheses(hyps: InteractiveHypothesisBundle[], filter: GoalFilterState): InteractiveHypothesisBundle[] {
     return hyps.filter(h =>
         (!h.isInstance || filter.isInstance) &&
         (!h.isType || filter.isType) &&
         (filter.isHiddenAssumption || !isHiddenAssumption(h)));
 }
 
-export function Goal({pos, goal, filter}: {pos: DocumentPosition, goal: InteractiveGoal, filter: GoalFilterState}) {
+interface GoalProps {
+    pos: DocumentPosition
+    goal: InteractiveGoal
+    filter: GoalFilterState
+    /** Where the goal appears in the goal list. */
+    index: number
+}
+
+
+export function Goal({ pos, goal, filter, index }: GoalProps) {
     const prefix = goal.goalPrefix ?? '⊢ '
     const filteredList = getFilteredHypotheses(goal.hyps, filter);
-    const hyps = filter.reverse  ? filteredList.slice().reverse() : filteredList;
-    const goalLi  = <li key={'goal'}>
-                        <strong className="goal-vdash">{prefix}</strong><InteractiveCode pos={pos} fmt={goal.type} />
-                     </li>
+    const hyps = filter.reverse ? filteredList.slice().reverse() : filteredList;
+    const goalId = goal.mvarId || index
+    const goalLi = <li key={'goal'}>
+        <strong className="goal-vdash">{prefix}</strong>
+        <InteractiveCode pos={pos} fmt={goal.type} />
+    </li>
     return <div className="font-code tl pre-wrap">
         <ul className="list pl0">
             {goal.userName && <li key={'case'}><strong className="goal-case">case </strong>{goal.userName}</li>}
-            {filter.reverse && goalLi }
-            {hyps.map ((h, i) => {
-                const names = h.names.reduce((acc, n) => acc + ' ' + n, '').slice(1)
-                return <li key={`hyp-${i}`}>
-                    <strong className="goal-hyp">{names}</strong> : <InteractiveCode pos={pos} fmt={h.type} />{h.val && <> := <InteractiveCode pos={pos} fmt={h.val}/></>}
-                </li>
-            })}
-            {!filter.reverse && goalLi }
+            {filter.reverse && goalLi}
+            {hyps.map((h, i) => <Hyp pos={pos} index={i} hyp={h} key={i}/>)}
+            {!filter.reverse && goalLi}
         </ul>
     </div>
 }
 
-export function Goals({pos, goals, filter}: {pos: DocumentPosition, goals: InteractiveGoals, filter: GoalFilterState}) {
-    const config = React.useContext(ConfigContext)
+interface GoalsProps {
+    pos: DocumentPosition
+    goals: InteractiveGoals
+    filter: GoalFilterState
+}
+
+export function Goals({ pos, goals, filter }: GoalsProps) {
     if (goals.goals.length === 0) {
         return <>Goals accomplished 🎉</>
     } else {
         return <>
-            {goals.goals.map ((g, i) => <Goal key={i} pos={pos} goal={g} filter={filter}/>)}
+            {goals.goals.map((g, i) => <Goal key={g.mvarId || i} pos={pos} goal={g} filter={filter} index={i} />)}
         </>
     }
 }

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 
 import { EditorContext, RpcContext } from './contexts'
-import { DocumentPosition } from './util'
-import { SubexprInfo, CodeWithInfos, InfoPopup, InfoWithCtx, InteractiveDiagnostics_infoToInteractive, getGoToLocation, TaggedText } from './rpcInterface'
+import { DocumentPosition, useAsync } from './util'
+import { SubexprInfo, CodeWithInfos, InfoPopup, InfoWithCtx, InteractiveDiagnostics_infoToInteractive, getGoToLocation, TaggedText, mapRpcError } from './rpcInterface'
 import { DetectHoverSpan, HoverState, WithTooltipOnHover } from './tooltips'
 import { Location } from 'vscode-languageserver-protocol'
 
@@ -32,48 +32,41 @@ export function InteractiveTaggedText<T>({pos, fmt, InnerTagUi}: InteractiveTagg
   else throw new Error(`malformed 'TaggedText': '${fmt}'`)
 }
 
+interface TypePopupContentsProps {
+  pos: DocumentPosition
+  info: SubexprInfo
+  redrawTooltip: () => void
+}
+
 /** Shows `explicitValue : itsType` and a docstring if there is one. */
-function TypePopupContents({pos, info, redrawTooltip}: {pos: DocumentPosition, info: InfoWithCtx, redrawTooltip: () => void}) {
+function TypePopupContents({ pos, info, redrawTooltip }: TypePopupContentsProps) {
   const rs = React.useContext(RpcContext)
   // When `err` is defined we show the error,
   // otherwise if `ip` is defined we show its contents,
   // otherwise a 'loading' message.
-  const [ip, setIp] = React.useState<InfoPopup>()
-  const [err, setErr] = React.useState<string>()
-
-  React.useEffect(() => {
-    InteractiveDiagnostics_infoToInteractive(rs, pos, info).then(val => {
-      if (val) {
-        setErr(undefined)
-        setIp(val)
-      }
-    }).catch(ex => {
-      if ('message' in ex) setErr('' + ex.message)
-      else if ('code' in ex) setErr(`RPC error (${ex.code})`)
-      else setErr(JSON.stringify(ex))
-    })
-  }, [rs, pos.uri, pos.line, pos.character, info])
+  const [_, ip, err] = useAsync(
+    () => InteractiveDiagnostics_infoToInteractive(rs, pos, info.info),
+    [rs, pos.uri, pos.line, pos.character, info.info, info.subexprPos])
 
   // We let the tooltip know to redo its layout whenever our contents change.
   React.useEffect(() => redrawTooltip(), [ip, err, redrawTooltip])
 
-  if (err)
-    return <>Error: {err}</>
-
-  if (ip) {
-    return <>
+  return <>
+    {ip && <>
       {ip.exprExplicit && <InteractiveCode pos={pos} fmt={ip.exprExplicit} />} : {ip.type && <InteractiveCode pos={pos} fmt={ip.type} />}
       {ip.doc && <hr />}
       {ip.doc && ip.doc} {/* TODO markdown */}
-    </>
-  } else return <>Loading..</>
+    </>}
+    {err && <>Error: {mapRpcError(err).message}</>}
+    {(!ip && !err) && <>Loading..</>}
+  </>
 }
 
 /** Tagged spans can be hovered over to display extra info stored in the associated `SubexprInfo`. */
 function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<SubexprInfo>) {
   const mkTooltip = React.useCallback((redrawTooltip: () => void) =>
     <div className="font-code tl pre-wrap">
-      <TypePopupContents pos={pos} info={ct.info}
+      <TypePopupContents pos={pos} info={ct}
         redrawTooltip={redrawTooltip} />
     </div>, [pos.uri, pos.line, pos.character, ct.info])
 
@@ -126,6 +119,11 @@ function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<SubexprInfo
   )
 }
 
-export function InteractiveCode({pos, fmt}: {pos: DocumentPosition, fmt: CodeWithInfos}) {
-  return InteractiveTaggedText({pos, fmt, InnerTagUi: InteractiveCodeTag})
+interface InteractiveCodeProps {
+  pos: DocumentPosition
+  fmt: CodeWithInfos
+}
+
+export function InteractiveCode(props: InteractiveCodeProps) {
+  return <InteractiveTaggedText InnerTagUi={InteractiveCodeTag} fmt={props.fmt} pos={props.pos} />
 }

--- a/lean4-infoview/src/infoview/main.tsx
+++ b/lean4-infoview/src/infoview/main.tsx
@@ -17,6 +17,7 @@ import { WithRpcSessions } from './rpcSessions';
 import { EditorConnection, EditorEvents } from './editorConnection';
 import { Event } from './event';
 import { ServerVersion } from './serverVersion';
+import { UserWidget } from './userWidget';
 
 
 function Main(props: {}) {
@@ -71,6 +72,7 @@ function Main(props: {}) {
                 <div className="mv2">
                     <AllMessages uri={curUri} />
                 </div>
+                <UserWidget />
             </div>)
     }
 

--- a/lean4-infoview/src/infoview/userWidget.tsx
+++ b/lean4-infoview/src/infoview/userWidget.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react';
+import type { Location } from 'vscode-languageserver-protocol';
+
+import { EditorContext, RpcContext } from './contexts';
+import { mapRpcError, } from './rpcInterface';
+import { DocumentPosition, useAsync, useEventResult } from './util';
+import { ErrorBoundary } from './errors';
+import { RpcSessions } from './rpcSessions';
+import { isRpcError, RpcErrorCode } from '@lean4/infoview-api';
+
+export interface GetWidgetResponse {
+    id: string
+    hash: number
+    props: any
+}
+
+function handleWidgetRpcError(e: unknown): undefined {
+    if (isRpcError(e)) {
+        if (e.code === RpcErrorCode.MethodNotFound || e.code === RpcErrorCode.InvalidParams) {
+            return undefined
+        } else {
+            throw Error(`RPC Error: ${RpcErrorCode[e.code]}: ${e.message}`)
+        }
+    } else if (e instanceof Error) {
+        throw e
+    } else {
+        throw Error(`Unknown rpc error ${JSON.stringify(e)}`)
+    }
+}
+
+export function Widget_getWidget(rs: RpcSessions, pos: DocumentPosition): Promise<GetWidgetResponse | undefined> {
+    return rs.call<GetWidgetResponse | undefined>(pos, 'Lean.Widget.getWidget', DocumentPosition.toTdpp(pos))
+        .catch<undefined>(handleWidgetRpcError);
+}
+
+export interface StaticJS {
+    javascript: string
+    hash: number
+}
+
+/** Gets the static JS code for a given widget.
+ *
+ * We make the assumption that either the code doesn't exist, or it exists and does not change for the lifetime of the widget.
+ * [todo] cache on widgetId, but then there needs to be some way of signalling that the widgetId's code has changed if the user edits it?
+ */
+export async function Widget_getStaticJS(rs: RpcSessions, pos: DocumentPosition, widgetId: string): Promise<StaticJS | undefined> {
+    try {
+        return await rs.call(pos, 'Lean.Widget.getStaticJS', { 'pos': DocumentPosition.toTdpp(pos), widgetId })
+    } catch (e) {
+        return handleWidgetRpcError(e)
+    }
+}
+
+
+function memoize<T extends (...args: any[]) => any>(fn: T, keyFn: any = (x: any) => x): T {
+    const cache = new Map()
+    const r: any = (...args: any[]) => {
+        const key = keyFn(...args)
+        if (!cache.has(key)) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            const result = fn(...args)
+            if (result) {
+                cache.set(key, result)
+            }
+            return result
+        }
+        return cache.get(key)
+    }
+    return r
+}
+
+const dynamicallyLoadComponent = memoize(function (hash: number, code: string,) {
+    return React.lazy(async () => {
+        const file = new File([code], `widget_${hash}.js`, { type: 'text/javascript' })
+        const url = URL.createObjectURL(file)
+        return await import(url)
+    })
+})
+
+interface GetWidgetResult {
+    component?: any
+    id: string
+    hash: number
+    props: any
+}
+
+const getCode = memoize(
+    (rc: RpcSessions, pos: DocumentPosition, widget: GetWidgetResponse) => Widget_getStaticJS(rc, pos, widget.id),
+    (rc: RpcSessions, pos: DocumentPosition, widget: GetWidgetResponse) => widget.hash,
+)
+
+async function getWidget(rc: RpcSessions, pos: DocumentPosition): Promise<undefined | GetWidgetResult> {
+    const widget = await Widget_getWidget(rc, pos)
+    if (!widget) {
+        return undefined
+    }
+    const code = await getCode(rc, pos, widget)
+    if (!code) {
+        return widget
+    }
+    const component = dynamicallyLoadComponent(widget.hash, code.javascript)
+    return { ...widget, component }
+}
+
+export function UserWidget(props: any) {
+    const ec = React.useContext(EditorContext);
+    const rs = React.useContext(RpcContext);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const curLoc = useEventResult<Location | undefined>(
+        ec.events.changedCursorLocation,
+        // @ts-ignore
+        (loc, prev) => loc ?? prev
+    )
+    if (!curLoc) {
+        return <>Waiting for a location.</>
+    }
+    const curPos: DocumentPosition = { uri: curLoc.uri, ...curLoc.range.start };
+    const [status, result, error] = useAsync(() => getWidget(rs, curPos), [curPos.uri, curPos.line, curPos.character])
+
+    const widgetId = result?.id
+    const ps = { pos: curPos, ...result?.props }
+    const component = result?.component
+
+    return (
+        <React.Suspense fallback={`Loading widget: ${widgetId} ${status}.`}>
+            <ErrorBoundary>
+                {component && <div>{React.createElement(component, ps)}</div>}
+                {error && <div>{mapRpcError(error).message}</div>}
+            </ErrorBoundary>
+        </React.Suspense>
+    )
+}

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -606,7 +606,7 @@ export class InfoProvider implements Disposable {
     private async handleInsertText(text: string, kind: TextInsertKind, uri?: Uri, pos?: Position) {
         let editor: TextEditor | undefined
         if (uri) {
-           editor = window.visibleTextEditors.find(e => e.document.uri === uri);
+           editor = window.visibleTextEditors.find(e => e.document.uri.path === uri.path);
         } else {
             editor = window.activeTextEditor;
             if (!editor) { // sometimes activeTextEditor is null.


### PR DESCRIPTION
Other changes:
- some docstrings
- refactor InteractiveHypothesis => InteractiveHypothesisBundle
- refactor: extract HypothesisBundle render to own component.
- introduce a `useAsync` hook for use with rpcs
- refactor TypePopupContents
- InteractiveGoal and InteractiveHypothesisBundle have mvarId? and fvarIds? fields
- helper function mapRpcError
- helper enum RpcErrorCode
- new override of useEventResult
- fix a bug in handleInsertText where it was doing reference eq instead of string eq.