### PR TITLE
refactor: preparing for user-widgets and context suggestions

### DIFF
--- a/lean4-infoview-api/src/lspTypes.ts
+++ b/lean4-infoview-api/src/lspTypes.ts
@@ -44,19 +44,24 @@ export interface LeanFileProgressParams {
 
 // https://stackoverflow.com/a/56749647
 declare const tag: unique symbol;
+/** An RPC pointer is a reference to an object on the lean server.
+ * An example where you need this is passing the Environment object,
+ * which we need to be able to reference but which would be too large to
+ * send over directly.
+ */
 export type RpcPtr<T> = { readonly [tag]: T, p: string }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace RpcPtr {
 
-export function copy<T>(p: RpcPtr<T>): RpcPtr<T> {
-    return { p: p.p } as RpcPtr<T>;
-}
+    export function copy<T>(p: RpcPtr<T>): RpcPtr<T> {
+        return { p: p.p } as RpcPtr<T>;
+    }
 
-/** Turns a reference into a unique string. Useful for React `key`s. */
-export function toKey(p: RpcPtr<any>): string {
-    return p.p;
-}
+    /** Turns a reference into a unique string. Useful for React `key`s. */
+    export function toKey(p: RpcPtr<any>): string {
+        return p.p;
+    }
 
 }
 
@@ -85,4 +90,25 @@ export interface RpcReleaseParams {
     refs: RpcPtr<any>[]
 }
 
-export const RpcNeedsReconnect = -32900
+export enum RpcErrorCode {
+    ParseError = -32700,
+    InvalidRequest = -32600,
+    MethodNotFound = -32601,
+    InvalidParams = -32602,
+    InternalError = -32603,
+    ServerNotInitialized = -32002,
+    UnknownErrorCode = -32001,
+    ContentModified = -32801,
+    RequestCancelled = -32800,
+    RpcNeedsReconnect = -32900,
+}
+
+export interface RpcError {
+    code: RpcErrorCode
+    message: string
+}
+
+export function isRpcError(x : any) : x is RpcError {
+    return !!(x?.code && x?.message)
+}
+

--- a/lean4-infoview-api/src/lspTypes.ts
+++ b/lean4-infoview-api/src/lspTypes.ts
@@ -101,6 +101,8 @@ export enum RpcErrorCode {
     ContentModified = -32801,
     RequestCancelled = -32800,
     RpcNeedsReconnect = -32900,
+    WorkerExited = -32901,
+    WorkerCrashed = -32902,
 }
 
 export interface RpcError {

--- a/lean4-infoview/src/components.ts
+++ b/lean4-infoview/src/components.ts
@@ -1,3 +1,0 @@
-export { InteractiveCode } from './infoview/interactiveCode';
-export { InteractiveMessage } from './infoview/traceExplorer';
-export { EditorContext, RpcContext, VersionContext, ConfigContext, LspDiagnosticsContext, ProgressContext } from './infoview/contexts';

--- a/lean4-infoview/src/components.tsx
+++ b/lean4-infoview/src/components.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { InteractiveDiagnostics_msgToInteractive, TaggedText, MsgEmbed, CodeWithInfos, MessageData, mapRpcError } from './infoview/rpcInterface';
+import { InteractiveDiagnostics_msgToInteractive, MessageData, mapRpcError } from './infoview/rpcInterface';
 import { InteractiveMessage } from './infoview/traceExplorer';
 import { DocumentPosition, useAsync } from './infoview/util';
 import { RpcContext } from './infoview/contexts';
@@ -25,7 +25,7 @@ export function InteractiveMessageData({ pos, msg }: { pos: DocumentPosition, ms
     } else if (status === 'pending') {
         return <>...</>
     } else {
-        return <div>failed to load messages
+        return <div>Failed to display message:
             {error && <span>{mapRpcError(error).message}</span>}
         </div>
     }

--- a/lean4-infoview/src/components.tsx
+++ b/lean4-infoview/src/components.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import { InteractiveCode } from './infoview/interactiveCode';
+import { InteractiveDiagnostics_msgToInteractive, TaggedText, MsgEmbed, ExprWithCtx, CodeWithInfos, MessageData } from './infoview/rpcInterface';
+import { InteractiveMessage } from './infoview/traceExplorer';
+import { DocumentPosition } from './infoview/util';
+import { RpcContext } from './infoview/contexts';
+
+export { DocumentPosition };
+export { EditorContext, RpcContext, VersionContext } from './infoview/contexts';
+export { EditorConnection } from './infoview/editorConnection';
+export { RpcSessions } from './infoview/rpcSessions';
+export { ServerVersion } from './infoview/serverVersion';
+
+/** Display the given message data as interactive, pretty-printed text. */
+export function InteractiveMessageData({pos, msg}: {pos: DocumentPosition, msg: MessageData}) {
+    const rs = React.useContext(RpcContext)
+    const [tt, setTt] = React.useState<TaggedText<MsgEmbed> | undefined>(undefined)
+
+    React.useEffect(() => {
+        void InteractiveDiagnostics_msgToInteractive(rs, pos, msg, 0)
+            .then(tt => tt && setTt(tt))
+    }, [pos.character, pos.line, pos.uri, msg])
+
+    if (tt) return <InteractiveMessage pos={pos} fmt={tt} />
+    else return <></>
+}

--- a/lean4-infoview/src/components.tsx
+++ b/lean4-infoview/src/components.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-import { InteractiveDiagnostics_msgToInteractive, MessageData, mapRpcError } from './infoview/rpcInterface';
+import { InteractiveDiagnostics_msgToInteractive, MessageData } from './infoview/rpcInterface';
 import { InteractiveMessage } from './infoview/traceExplorer';
-import { DocumentPosition, useAsync } from './infoview/util';
+import { DocumentPosition, useAsync, mapRpcError } from './infoview/util';
 import { RpcContext } from './infoview/contexts';
 
 export { DocumentPosition };

--- a/lean4-infoview/src/components.tsx
+++ b/lean4-infoview/src/components.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { InteractiveCode } from './infoview/interactiveCode';
 import { InteractiveDiagnostics_msgToInteractive, TaggedText, MsgEmbed, CodeWithInfos, MessageData, mapRpcError } from './infoview/rpcInterface';
 import { InteractiveMessage } from './infoview/traceExplorer';
 import { DocumentPosition, useAsync } from './infoview/util';
@@ -17,7 +16,7 @@ export function InteractiveMessageData({ pos, msg }: { pos: DocumentPosition, ms
     const rs = React.useContext(RpcContext)
 
     const [status, tt, error] = useAsync(
-        () => InteractiveDiagnostics_msgToInteractive(rs, pos, { msg, indent: 0 }),
+        () => InteractiveDiagnostics_msgToInteractive(rs, pos, msg, 0),
         [pos.character, pos.line, pos.uri, msg]
     )
 

--- a/lean4-infoview/src/components.tsx
+++ b/lean4-infoview/src/components.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
 import { InteractiveCode } from './infoview/interactiveCode';
-import { InteractiveDiagnostics_msgToInteractive, TaggedText, MsgEmbed, ExprWithCtx, CodeWithInfos, MessageData } from './infoview/rpcInterface';
+import { InteractiveDiagnostics_msgToInteractive, TaggedText, MsgEmbed, CodeWithInfos, MessageData, mapRpcError } from './infoview/rpcInterface';
 import { InteractiveMessage } from './infoview/traceExplorer';
-import { DocumentPosition } from './infoview/util';
+import { DocumentPosition, useAsync } from './infoview/util';
 import { RpcContext } from './infoview/contexts';
 
 export { DocumentPosition };
@@ -13,15 +13,21 @@ export { RpcSessions } from './infoview/rpcSessions';
 export { ServerVersion } from './infoview/serverVersion';
 
 /** Display the given message data as interactive, pretty-printed text. */
-export function InteractiveMessageData({pos, msg}: {pos: DocumentPosition, msg: MessageData}) {
+export function InteractiveMessageData({ pos, msg }: { pos: DocumentPosition, msg: MessageData }) {
     const rs = React.useContext(RpcContext)
-    const [tt, setTt] = React.useState<TaggedText<MsgEmbed> | undefined>(undefined)
 
-    React.useEffect(() => {
-        void InteractiveDiagnostics_msgToInteractive(rs, pos, msg, 0)
-            .then(tt => tt && setTt(tt))
-    }, [pos.character, pos.line, pos.uri, msg])
+    const [status, tt, error] = useAsync(
+        () => InteractiveDiagnostics_msgToInteractive(rs, pos, { msg, indent: 0 }),
+        [pos.character, pos.line, pos.uri, msg]
+    )
 
-    if (tt) return <InteractiveMessage pos={pos} fmt={tt} />
-    else return <></>
+    if (tt) {
+        return <InteractiveMessage pos={pos} fmt={tt} />
+    } else if (status === 'pending') {
+        return <>...</>
+    } else {
+        return <div>failed to load messages
+            {error && <span>{mapRpcError(error).message}</span>}
+        </div>
+    }
 }

--- a/lean4-infoview/src/infoview/editorConnection.ts
+++ b/lean4-infoview/src/infoview/editorConnection.ts
@@ -7,6 +7,8 @@ import { DocumentPosition } from './util';
 
 export type EditorEvents = Eventify<InfoviewApi>;
 
+/** Provides higher-level wrappers around functionality provided by the editor,
+ * e.g. to insert a comment. See also {@link EditorApi}. */
 export class EditorConnection {
   constructor(readonly api: EditorApi, readonly events: EditorEvents) {}
 

--- a/lean4-infoview/src/infoview/errors.tsx
+++ b/lean4-infoview/src/infoview/errors.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+
+/** Error boundary as described in https://reactjs.org/docs/error-boundaries.html */
 export class ErrorBoundary extends React.Component<{}, {error: string | undefined}> {
   constructor(props: {}) {
     super(props);
@@ -9,6 +11,11 @@ export class ErrorBoundary extends React.Component<{}, {error: string | undefine
   static getDerivedStateFromError(error: any) {
     // Update state so the next render will show the fallback UI.
     return { error: error.toString() };
+  }
+
+  componentDidCatch(error : any, errorInfo : any) {
+    // You can also log the error to an error reporting service
+    return
   }
 
   render() {

--- a/lean4-infoview/src/infoview/errors.tsx
+++ b/lean4-infoview/src/infoview/errors.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export class ErrorBoundary extends React.Component<{}, {error: string | undefined}> {
+  constructor(props: {}) {
+    super(props);
+    this.state = { error: undefined };
+  }
+
+  static getDerivedStateFromError(error: any) {
+    // Update state so the next render will show the fallback UI.
+    return { error: error.toString() };
+  }
+
+  render() {
+    if (this.state.error) {
+      // You can render any custom fallback UI
+      return <div>
+          <h1>Error:</h1>{this.state.error}<br/>
+          <a onClick={() => this.setState({ error: undefined })}>Click to reload.</a>
+        </div>;
+    }
+
+    return this.props.children;
+  }
+}
+

--- a/lean4-infoview/src/infoview/goalCompat.ts
+++ b/lean4-infoview/src/infoview/goalCompat.ts
@@ -1,5 +1,5 @@
 import { PlainGoal, PlainTermGoal } from '@lean4/infoview-api';
-import { InteractiveGoal, InteractiveGoals, InteractiveHypothesis } from './rpcInterface';
+import { InteractiveGoal, InteractiveGoals, InteractiveHypothesisBundle } from './rpcInterface';
 
 function getGoals(plainGoals: PlainGoal): string[] {
     if (plainGoals.goals) return plainGoals.goals
@@ -21,7 +21,7 @@ function transformGoalToInteractive(g: string): InteractiveGoal {
     // by keeping indented lines with the most recent non-indented line
     const parts = (g.match(/(^(?!  ).*\n?(  .*\n?)*)/mg) ?? []).map(line => line.trim())
     let userName
-    const hyps: InteractiveHypothesis[] = []
+    const hyps: InteractiveHypothesisBundle[] = []
     let type = ''
     for (const p of parts) {
         if (p.match(/^(⊢) /mg)) {
@@ -30,7 +30,7 @@ function transformGoalToInteractive(g: string): InteractiveGoal {
             userName = p.slice(5)
         } else if (p.match(/^([^:\n< ][^:\n⊢{[(⦃]*) :/mg)) {
             const ss = p.split(':')
-            const hyp: InteractiveHypothesis = {
+            const hyp: InteractiveHypothesisBundle = {
                 isType: false,
                 isInstance: false,
                 names: ss[0].split(' ')

--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -74,16 +74,15 @@ interface GoalProps {
     pos: DocumentPosition
     goal: InteractiveGoal
     filter: GoalFilterState
-    /** Where the goal appears in the goal list. */
-    index: number
+    /** Where the goal appears in the goal list. Or none if not present. */
+    index?: number
 }
 
 
-export function Goal({ pos, goal, filter, index }: GoalProps) {
+export function Goal({ pos, goal, filter }: GoalProps) {
     const prefix = goal.goalPrefix ?? '⊢ '
     const filteredList = getFilteredHypotheses(goal.hyps, filter);
     const hyps = filter.reverse ? filteredList.slice().reverse() : filteredList;
-    const goalId = goal.mvarId || index
     const goalLi = <li key={'goal'}>
         <strong className="goal-vdash">{prefix}</strong>
         <InteractiveCode pos={pos} fmt={goal.type} />

--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { DocumentPosition } from './util'
 import { InteractiveCode } from './interactiveCode'
-import { InteractiveGoal, InteractiveGoals, InteractiveHypothesisBundle, InteractiveHypothesisBundle_accessableNames, TaggedText_stripTags } from './rpcInterface'
+import { InteractiveGoal, InteractiveGoals, InteractiveHypothesisBundle, InteractiveHypothesisBundle_accessibleNames, TaggedText_stripTags } from './rpcInterface'
 
 interface HypProps {
     pos: DocumentPosition
@@ -10,17 +10,16 @@ interface HypProps {
 }
 
 export function Hyp({ pos, hyp : h, index }: HypProps) {
-    const names = InteractiveHypothesisBundle_accessableNames(h).map((n, i) =>
+    const names = InteractiveHypothesisBundle_accessibleNames(h).map((n, i) =>
             <span className="mr1">{n}</span>
         )
-    const hypKey = (h.fvarIds?.[0] ?? index)
     return <li>
-            <strong className="goal-hyp">{names}</strong>
-            :&nbsp;
-            <InteractiveCode pos={pos} fmt={h.type} />
-            {h.val && <>
-                := <InteractiveCode pos={pos} fmt={h.val} />
-            </>}
+        <strong className="goal-hyp">{names}</strong>
+        :&nbsp;
+        <InteractiveCode pos={pos} fmt={h.type} />
+        {h.val && <>
+            := <InteractiveCode pos={pos} fmt={h.val} />
+        </>}
     </li>
 }
 
@@ -32,7 +31,7 @@ function goalToString(g: InteractiveGoal): string {
     }
 
     for (const h of g.hyps) {
-        const names = InteractiveHypothesisBundle_accessableNames(h).join(' ')
+        const names = InteractiveHypothesisBundle_accessibleNames(h).join(' ')
         ret += `${names} : ${TaggedText_stripTags(h.type)}`
         if (h.val) {
             ret += ` := ${TaggedText_stripTags(h.val)}`
@@ -110,7 +109,7 @@ export function Goals({ pos, goals, filter }: GoalsProps) {
         return <>Goals accomplished 🎉</>
     } else {
         return <>
-            {goals.goals.map((g, i) => <Goal key={g.mvarId || i} pos={pos} goal={g} filter={filter} index={i} />)}
+            {goals.goals.map((g, i) => <Goal key={i} pos={pos} goal={g} filter={filter} index={i} />)}
         </>
     }
 }

--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -1,8 +1,28 @@
 import * as React from 'react'
 import { DocumentPosition } from './util'
-import { ConfigContext } from './contexts'
 import { InteractiveCode } from './interactiveCode'
-import { InteractiveGoal, InteractiveGoals, InteractiveHypothesis, TaggedText_stripTags } from './rpcInterface'
+import { InteractiveGoal, InteractiveGoals, InteractiveHypothesisBundle, InteractiveHypothesisBundle_accessableNames, TaggedText_stripTags } from './rpcInterface'
+
+interface HypProps {
+    pos: DocumentPosition
+    hyp: InteractiveHypothesisBundle
+    index: number
+}
+
+export function Hyp({ pos, hyp : h, index }: HypProps) {
+    const names = InteractiveHypothesisBundle_accessableNames(h).map((n, i) =>
+            <span className="mr1">{n}</span>
+        )
+    const hypKey = (h.fvarIds?.[0] ?? index)
+    return <li>
+            <strong className="goal-hyp">{names}</strong>
+            :&nbsp;
+            <InteractiveCode pos={pos} fmt={h.type} />
+            {h.val && <>
+                := <InteractiveCode pos={pos} fmt={h.val} />
+            </>}
+    </li>
+}
 
 function goalToString(g: InteractiveGoal): string {
     let ret = ''
@@ -12,7 +32,7 @@ function goalToString(g: InteractiveGoal): string {
     }
 
     for (const h of g.hyps) {
-        const names = h.names.join(' ')
+        const names = InteractiveHypothesisBundle_accessableNames(h).join(' ')
         ret += `${names} : ${TaggedText_stripTags(h.type)}`
         if (h.val) {
             ret += ` := ${TaggedText_stripTags(h.val)}`
@@ -30,56 +50,67 @@ export function goalsToString(goals: InteractiveGoals): string {
 }
 
 export interface GoalFilterState {
-    /** If true reverse the list of InteractiveHypothesis, if false present the order received from LSP */
+    /** If true reverse the list of InteractiveHypothesisBundle, if false present the order received from LSP */
     reverse: boolean,
-    /** If true show InteractiveHypothesis that have isType=True, if false, hide InteractiveHypothesis that have isType=True. */
+    /** If true show InteractiveHypothesisBundle that have isType=True, if false, hide InteractiveHypothesisBundle that have isType=True. */
     isType: boolean,
-    /** If true show InteractiveHypothesis that have isInstance=True, if false, hide InteractiveHypothesis that have isInstance=True. */
+    /** If true show InteractiveHypothesisBundle that have isInstance=True, if false, hide InteractiveHypothesisBundle that have isInstance=True. */
     isInstance: boolean,
-    /** If true show InteractiveHypothesis that contain a dagger in the name, if false, hide InteractiveHypothesis that contain a dagger in the name. */
+    /** If true show InteractiveHypothesisBundle that contain a dagger in the name, if false, hide InteractiveHypothesisBundle that contain a dagger in the name. */
     isHiddenAssumption: boolean
 }
 
-function isHiddenAssumption(h: InteractiveHypothesis){
+function isHiddenAssumption(h: InteractiveHypothesisBundle) {
     return h.names.every(n => n.indexOf('✝') >= 0);
 }
 
-function getFilteredHypotheses(hyps: InteractiveHypothesis[], filter: GoalFilterState): InteractiveHypothesis[] {
+function getFilteredHypotheses(hyps: InteractiveHypothesisBundle[], filter: GoalFilterState): InteractiveHypothesisBundle[] {
     return hyps.filter(h =>
         (!h.isInstance || filter.isInstance) &&
         (!h.isType || filter.isType) &&
         (filter.isHiddenAssumption || !isHiddenAssumption(h)));
 }
 
-export function Goal({pos, goal, filter}: {pos: DocumentPosition, goal: InteractiveGoal, filter: GoalFilterState}) {
+interface GoalProps {
+    pos: DocumentPosition
+    goal: InteractiveGoal
+    filter: GoalFilterState
+    /** Where the goal appears in the goal list. */
+    index: number
+}
+
+
+export function Goal({ pos, goal, filter, index }: GoalProps) {
     const prefix = goal.goalPrefix ?? '⊢ '
     const filteredList = getFilteredHypotheses(goal.hyps, filter);
-    const hyps = filter.reverse  ? filteredList.slice().reverse() : filteredList;
-    const goalLi  = <li key={'goal'}>
-                        <strong className="goal-vdash">{prefix}</strong><InteractiveCode pos={pos} fmt={goal.type} />
-                     </li>
+    const hyps = filter.reverse ? filteredList.slice().reverse() : filteredList;
+    const goalId = goal.mvarId || index
+    const goalLi = <li key={'goal'}>
+        <strong className="goal-vdash">{prefix}</strong>
+        <InteractiveCode pos={pos} fmt={goal.type} />
+    </li>
     return <div className="font-code tl pre-wrap">
         <ul className="list pl0">
             {goal.userName && <li key={'case'}><strong className="goal-case">case </strong>{goal.userName}</li>}
-            {filter.reverse && goalLi }
-            {hyps.map ((h, i) => {
-                const names = h.names.reduce((acc, n) => acc + ' ' + n, '').slice(1)
-                return <li key={`hyp-${i}`}>
-                    <strong className="goal-hyp">{names}</strong> : <InteractiveCode pos={pos} fmt={h.type} />{h.val && <> := <InteractiveCode pos={pos} fmt={h.val}/></>}
-                </li>
-            })}
-            {!filter.reverse && goalLi }
+            {filter.reverse && goalLi}
+            {hyps.map((h, i) => <Hyp pos={pos} index={i} hyp={h} key={i}/>)}
+            {!filter.reverse && goalLi}
         </ul>
     </div>
 }
 
-export function Goals({pos, goals, filter}: {pos: DocumentPosition, goals: InteractiveGoals, filter: GoalFilterState}) {
-    const config = React.useContext(ConfigContext)
+interface GoalsProps {
+    pos: DocumentPosition
+    goals: InteractiveGoals
+    filter: GoalFilterState
+}
+
+export function Goals({ pos, goals, filter }: GoalsProps) {
     if (goals.goals.length === 0) {
         return <>Goals accomplished 🎉</>
     } else {
         return <>
-            {goals.goals.map ((g, i) => <Goal key={i} pos={pos} goal={g} filter={filter}/>)}
+            {goals.goals.map((g, i) => <Goal key={g.mvarId || i} pos={pos} goal={g} filter={filter} index={i} />)}
         </>
     }
 }

--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -49,13 +49,13 @@ export function goalsToString(goals: InteractiveGoals): string {
 }
 
 export interface GoalFilterState {
-    /** If true reverse the list of InteractiveHypothesisBundle, if false present the order received from LSP */
+    /** If true reverse the list of hypotheses, if false present the order received from LSP */
     reverse: boolean,
-    /** If true show InteractiveHypothesisBundle that have isType=True, if false, hide InteractiveHypothesisBundle that have isType=True. */
+    /** If true show hypotheses that have isType=True, if false, hide hypotheses that have isType=True. */
     isType: boolean,
-    /** If true show InteractiveHypothesisBundle that have isInstance=True, if false, hide InteractiveHypothesisBundle that have isInstance=True. */
+    /** If true show hypotheses that have isInstance=True, if false, hide hypotheses that have isInstance=True. */
     isInstance: boolean,
-    /** If true show InteractiveHypothesisBundle that contain a dagger in the name, if false, hide InteractiveHypothesisBundle that contain a dagger in the name. */
+    /** If true show hypotheses that contain a dagger in the name, if false, hide hypotheses that contain a dagger in the name. */
     isHiddenAssumption: boolean
 }
 

--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -186,7 +186,7 @@ export function InfoDisplay(props0: InfoDisplayProps) {
                         Expected type {sortButton} {filterButton}
                     </summary>
                     <div className='ml1'>
-                        {hasTermGoal && <GoalUi pos={pos} goal={termGoal} filter={goalFilters} />}
+                        {hasTermGoal && <GoalUi pos={pos} goal={termGoal} filter={goalFilters} index={0} />}
                     </div>
                 </Details>
             </div>

--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -186,7 +186,7 @@ export function InfoDisplay(props0: InfoDisplayProps) {
                         Expected type {sortButton} {filterButton}
                     </summary>
                     <div className='ml1'>
-                        {hasTermGoal && <GoalUi pos={pos} goal={termGoal} filter={goalFilters} index={0} />}
+                        {hasTermGoal && <GoalUi pos={pos} goal={termGoal} filter={goalFilters} />}
                     </div>
                 </Details>
             </div>

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 
 import { EditorContext, RpcContext } from './contexts'
-import { DocumentPosition } from './util'
-import { SubexprInfo, CodeWithInfos, InfoPopup, InfoWithCtx, InteractiveDiagnostics_infoToInteractive, getGoToLocation, TaggedText } from './rpcInterface'
+import { DocumentPosition, useAsync } from './util'
+import { SubexprInfo, CodeWithInfos, InfoPopup, InfoWithCtx, InteractiveDiagnostics_infoToInteractive, getGoToLocation, TaggedText, mapRpcError } from './rpcInterface'
 import { DetectHoverSpan, HoverState, WithTooltipOnHover } from './tooltips'
 import { Location } from 'vscode-languageserver-protocol'
 
@@ -32,48 +32,41 @@ export function InteractiveTaggedText<T>({pos, fmt, InnerTagUi}: InteractiveTagg
   else throw new Error(`malformed 'TaggedText': '${fmt}'`)
 }
 
+interface TypePopupContentsProps {
+  pos: DocumentPosition
+  info: SubexprInfo
+  redrawTooltip: () => void
+}
+
 /** Shows `explicitValue : itsType` and a docstring if there is one. */
-function TypePopupContents({pos, info, redrawTooltip}: {pos: DocumentPosition, info: InfoWithCtx, redrawTooltip: () => void}) {
+function TypePopupContents({ pos, info, redrawTooltip }: TypePopupContentsProps) {
   const rs = React.useContext(RpcContext)
   // When `err` is defined we show the error,
   // otherwise if `ip` is defined we show its contents,
   // otherwise a 'loading' message.
-  const [ip, setIp] = React.useState<InfoPopup>()
-  const [err, setErr] = React.useState<string>()
-
-  React.useEffect(() => {
-    InteractiveDiagnostics_infoToInteractive(rs, pos, info).then(val => {
-      if (val) {
-        setErr(undefined)
-        setIp(val)
-      }
-    }).catch(ex => {
-      if ('message' in ex) setErr('' + ex.message)
-      else if ('code' in ex) setErr(`RPC error (${ex.code})`)
-      else setErr(JSON.stringify(ex))
-    })
-  }, [rs, pos.uri, pos.line, pos.character, info])
+  const [_, ip, err] = useAsync(
+    () => InteractiveDiagnostics_infoToInteractive(rs, pos, info.info),
+    [rs, pos.uri, pos.line, pos.character, info.info, info.subexprPos])
 
   // We let the tooltip know to redo its layout whenever our contents change.
   React.useEffect(() => redrawTooltip(), [ip, err, redrawTooltip])
 
-  if (err)
-    return <>Error: {err}</>
-
-  if (ip) {
-    return <>
+  return <>
+    {ip && <>
       {ip.exprExplicit && <InteractiveCode pos={pos} fmt={ip.exprExplicit} />} : {ip.type && <InteractiveCode pos={pos} fmt={ip.type} />}
       {ip.doc && <hr />}
       {ip.doc && ip.doc} {/* TODO markdown */}
-    </>
-  } else return <>Loading..</>
+    </>}
+    {err && <>Error: {mapRpcError(err).message}</>}
+    {(!ip && !err) && <>Loading..</>}
+  </>
 }
 
 /** Tagged spans can be hovered over to display extra info stored in the associated `SubexprInfo`. */
 function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<SubexprInfo>) {
   const mkTooltip = React.useCallback((redrawTooltip: () => void) =>
     <div className="font-code tl pre-wrap">
-      <TypePopupContents pos={pos} info={ct.info}
+      <TypePopupContents pos={pos} info={ct}
         redrawTooltip={redrawTooltip} />
     </div>, [pos.uri, pos.line, pos.character, ct.info])
 
@@ -126,6 +119,11 @@ function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<SubexprInfo
   )
 }
 
-export function InteractiveCode({pos, fmt}: {pos: DocumentPosition, fmt: CodeWithInfos}) {
-  return InteractiveTaggedText({pos, fmt, InnerTagUi: InteractiveCodeTag})
+interface InteractiveCodeProps {
+  pos: DocumentPosition
+  fmt: CodeWithInfos
+}
+
+export function InteractiveCode(props: InteractiveCodeProps) {
+  return <InteractiveTaggedText InnerTagUi={InteractiveCodeTag} fmt={props.fmt} pos={props.pos} />
 }

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 
 import { EditorContext, RpcContext } from './contexts'
-import { DocumentPosition, useAsync } from './util'
-import { SubexprInfo, CodeWithInfos, InfoPopup, InfoWithCtx, InteractiveDiagnostics_infoToInteractive, getGoToLocation, TaggedText, mapRpcError } from './rpcInterface'
+import { DocumentPosition, useAsync, mapRpcError } from './util'
+import { SubexprInfo, CodeWithInfos, InteractiveDiagnostics_infoToInteractive, getGoToLocation, TaggedText } from './rpcInterface'
 import { DetectHoverSpan, HoverState, WithTooltipOnHover } from './tooltips'
 import { Location } from 'vscode-languageserver-protocol'
 

--- a/lean4-infoview/src/infoview/rpcInterface.ts
+++ b/lean4-infoview/src/infoview/rpcInterface.ts
@@ -163,13 +163,13 @@ export async function getInteractiveDiagnostics(rs: RpcSessions, pos: DocumentPo
     return ret
 }
 
-export interface MessageToInteractive {
-    msg: MessageData
-    indent: number
-}
-
-export async function InteractiveDiagnostics_msgToInteractive(rs: RpcSessions, pos: DocumentPosition, msg: MessageToInteractive): Promise<TaggedText<MsgEmbed> | undefined> {
-    const ret = await rs.call<TaggedText<MsgEmbed>>(pos, 'Lean.Widget.InteractiveDiagnostics.msgToInteractive', msg)
+export async function InteractiveDiagnostics_msgToInteractive(rs: RpcSessions, pos: DocumentPosition, msg: MessageData, indent: number): Promise<TaggedText<MsgEmbed> | undefined> {
+    interface MessageToInteractive {
+        msg: MessageData
+        indent: number
+    }
+    const args: MessageToInteractive = { msg, indent }
+    const ret = await rs.call<TaggedText<MsgEmbed>>(pos, 'Lean.Widget.InteractiveDiagnostics.msgToInteractive', args)
     if (ret) TaggedMsg_registerRefs(rs, pos, ret)
     return ret
 }

--- a/lean4-infoview/src/infoview/rpcInterface.ts
+++ b/lean4-infoview/src/infoview/rpcInterface.ts
@@ -73,7 +73,7 @@ export interface InteractiveHypothesisBundle {
     isType?: boolean,
     /** The pretty names of the variables in the bundle.
      * If the name is inaccessible this will be `"[anonymous]"`.
-     * Use `InteractiveHypothesis_accessableNames` to filter these out.
+     * Use `InteractiveHypothesis_accessibleNames` to filter these out.
      */
     names: string[]
     /** The free variable id associated with each of the vars listed in `names`. */
@@ -83,7 +83,7 @@ export interface InteractiveHypothesisBundle {
 }
 
 /** Filter out inaccessible / anonymous pretty names from the names list. */
-export function InteractiveHypothesisBundle_accessableNames(ih : InteractiveHypothesisBundle) : string[] {
+export function InteractiveHypothesisBundle_accessibleNames(ih : InteractiveHypothesisBundle) : string[] {
     return ih.names.filter(x => !x.includes('[anonymous]'))
 }
 

--- a/lean4-infoview/src/infoview/rpcInterface.ts
+++ b/lean4-infoview/src/infoview/rpcInterface.ts
@@ -5,7 +5,7 @@
  * @module
  */
 
-import { RpcPtr, LeanDiagnostic, isRpcError, RpcErrorCode } from '@lean4/infoview-api'
+import { RpcPtr, LeanDiagnostic } from '@lean4/infoview-api'
 
 import { DocumentPosition } from './util'
 import { RpcSessions } from './rpcSessions'
@@ -110,7 +110,7 @@ export interface InteractiveGoals {
     goals: InteractiveGoal[]
 }
 
-export function InteractiveGoals_registerRefs(rs: RpcSessions, pos: DocumentPosition, gs: InteractiveGoals) {
+function InteractiveGoals_registerRefs(rs: RpcSessions, pos: DocumentPosition, gs: InteractiveGoals) {
     for (const g of gs.goals) InteractiveGoal_registerRefs(rs, pos, g)
 }
 
@@ -182,17 +182,4 @@ export async function getGoToLocation(rs: RpcSessions, pos: DocumentPosition, ki
     }
     const args: GetGoToLocationParams = { kind, info };
     return rs.call<LocationLink[]>(pos, 'Lean.Widget.getGoToLocation', args)
-}
-
-/** Sends an exception object to a throwable error.
- * Maps JSON Rpc errors to throwable errors.
- */
-export function mapRpcError(err : unknown) : Error {
-    if (isRpcError(err)) {
-        return new Error(`Rpc error: ${RpcErrorCode[err.code]}: ${err.message}`)
-    } else if (! (err instanceof Error)) {
-        return new Error(`Unrecognised error ${JSON.stringify(err)}`)
-    } else {
-        return err
-    }
 }

--- a/lean4-infoview/src/infoview/traceExplorer.tsx
+++ b/lean4-infoview/src/infoview/traceExplorer.tsx
@@ -43,7 +43,7 @@ function InteractiveMessageTag({pos, tag: embed, fmt}: InteractiveTagProps<MsgEm
     if ('expr' in embed)
         return <InteractiveCode pos={pos} fmt={embed.expr} />
     else if ('goal' in embed)
-        return <Goal pos={pos} goal={embed.goal} filter={{reverse: false, isType: false, isInstance: false, isHiddenAssumption: false}}/>
+        return <Goal pos={pos} goal={embed.goal} filter={{reverse: false, isType: false, isInstance: false, isHiddenAssumption: false}} index={0} />
     else if ('lazyTrace' in embed)
         return <CollapsibleTrace pos={pos} col={embed.lazyTrace[0]} cls={embed.lazyTrace[1]} msg={embed.lazyTrace[2]} />
     else

--- a/lean4-infoview/src/infoview/traceExplorer.tsx
+++ b/lean4-infoview/src/infoview/traceExplorer.tsx
@@ -32,7 +32,7 @@ function CollapsibleTrace({pos, col, cls, msg}: {pos: DocumentPosition, col: num
         inner =
             <span className="underline-hover pointer"
                 onClick={ev => {
-                    void InteractiveDiagnostics_msgToInteractive(rs, pos, { msg, indent: col }).then(t => t && setTt(t))
+                    void InteractiveDiagnostics_msgToInteractive(rs, pos, msg, col).then(t => t && setTt(t))
                     ev.stopPropagation()
                 }}>[{cls}] &gt;</span>
     }

--- a/lean4-infoview/src/infoview/util.ts
+++ b/lean4-infoview/src/infoview/util.ts
@@ -270,6 +270,16 @@ type Status = 'pending' | 'fulfilled' | 'rejected'
  * There will only ever be one in-flight promise at a time. If the deps
  * change while a promise is still in-flight, then the function will be run
  * again after the first promise has resolved.
+ *
+ * This function prevents race conditions if the requests resolve in a
+ * different order to that which they were requested in:
+ *
+ * - Request 1 is sent with, say, line=42.
+ * - Request 2 is sent with line=90.
+ * - Request 2 returns with diags=[].
+ * - Request 1 returns with diags=['error'].
+ *
+ * Without `useAsync` we would now return the diagnostics for line 42 even though we're at line 90.
  */
 export function useAsync<T>(fn : () => Promise<T>, deps : React.DependencyList = [])
   : [Status, T | undefined, unknown | undefined] {

--- a/lean4-infoview/src/infoview/util.ts
+++ b/lean4-infoview/src/infoview/util.ts
@@ -2,6 +2,8 @@
 import * as React from 'react';
 import type { DocumentUri, Position, Range, TextDocumentPositionParams } from 'vscode-languageserver-protocol';
 
+import { isRpcError, RpcErrorCode } from '@lean4/infoview-api';
+
 import { Event } from './event';
 import { EditorContext } from './contexts';
 
@@ -262,6 +264,19 @@ export function useLogicalDom(ref: React.RefObject<HTMLElement>): [LogicalDomTra
     React.useMemo(() => ({contains}), [ref]),
     React.useMemo(() => ({registerDescendant}), [parentCtx])
   ]
+}
+
+/** Sends an exception object to a throwable error.
+ * Maps JSON Rpc errors to throwable errors.
+ */
+export function mapRpcError(err : unknown) : Error {
+    if (isRpcError(err)) {
+        return new Error(`Rpc error: ${RpcErrorCode[err.code]}: ${err.message}`)
+    } else if (! (err instanceof Error)) {
+        return new Error(`Unrecognised error ${JSON.stringify(err)}`)
+    } else {
+        return err
+    }
 }
 
 type Status = 'pending' | 'fulfilled' | 'rejected'

--- a/lean4-infoview/src/infoview/util.ts
+++ b/lean4-infoview/src/infoview/util.ts
@@ -281,22 +281,8 @@ export function mapRpcError(err : unknown) : Error {
 
 type Status = 'pending' | 'fulfilled' | 'rejected'
 
-/** This hook will run the given promise function whenever the deps change.
- * There will only ever be one in-flight promise at a time. If the deps
- * change while a promise is still in-flight, then the function will be run
- * again after the first promise has resolved.
- *
- * This function prevents race conditions if the requests resolve in a
- * different order to that which they were requested in:
- *
- * - Request 1 is sent with, say, line=42.
- * - Request 2 is sent with line=90.
- * - Request 2 returns with diags=[].
- * - Request 1 returns with diags=['error'].
- *
- * Without `useAsync` we would now return the diagnostics for line 42 even though we're at line 90.
- */
-export function useAsync<T>(fn : () => Promise<T>, deps : React.DependencyList = [])
+
+function useAsyncThrottled<T>(fn : () => Promise<T>, deps : React.DependencyList = [])
   : [Status, T | undefined, unknown | undefined] {
     const [result, setResult] = React.useState<T | undefined>(undefined)
     const [error, setError] = React.useState<unknown | undefined>(undefined)
@@ -335,7 +321,68 @@ export function useAsync<T>(fn : () => Promise<T>, deps : React.DependencyList =
       })
     }, [...deps, trig])
     return [status.current, result, error]
+}
+
+function useAsyncUnthrottled<T>(fn : () => Promise<T>, deps : React.DependencyList = []) : [Status, T | undefined, unknown | undefined] {
+  const idCount = React.useRef(0)
+  const latestResolved = React.useRef(0)
+  const [status, setStatus] = React.useState<Status>('pending')
+  const [error, setError] = React.useState<unknown>(undefined)
+  const [result, setResult] = React.useState<T | undefined>(undefined)
+  React.useEffect(() => {
+    idCount.current += 1
+    const taskId = idCount.current
+    setStatus('pending')
+    setError(undefined)
+    fn().then(result => {
+      if (latestResolved.current > taskId) {
+        return
+      }
+      setStatus('fulfilled')
+      setResult(result)
+      latestResolved.current = taskId
+    }, (err : any) => {
+      if (latestResolved.current > taskId) {
+        return
+      }
+      setStatus('rejected')
+      setError(err)
+      latestResolved.current = taskId
+    })
+  }, deps)
+  return [status, result, error]
+}
+
+/** This React hook will run the given promise function `fn` whenever the deps change
+ * and use it to update the status and result when the promise resolves.
+ *
+ * This function prevents race conditions if the requests resolve in a
+ * different order to that which they were requested in:
+ *
+ * - Request 1 is sent with, say, line=42.
+ * - Request 2 is sent with line=90.
+ * - Request 2 returns with diags=[].
+ * - Request 1 returns with diags=['error'].
+ *
+ * Without `useAsync` we would now return the diagnostics for line 42 even though we're at line 90.
+ *
+ * There is a 'throttled' and 'unthrottled' version of this function:
+ * - in _throttled_ `throttle = true`:
+ *   There will only ever be one in-flight promise at a time. If the deps
+ *   change while a promise is still in-flight, then `fn` will be run
+ *   again after the first promise has resolved.
+ * - in _unthrottled_ `throttle = false`:
+ *   `fn` will be fired as soon as the dependencies change. Each invocation of
+ *   `fn` is time ordered. If an earlier invocation resolves after a
+ *   later invocation (as happens in above example), then this result is discarded.
+ */
+export function useAsync<T>(fn : () => Promise<T>, deps : React.DependencyList = [], throttle = false): [Status, T | undefined, unknown | undefined] {
+  if (throttle) {
+    return useAsyncThrottled(fn, deps)
+  } else {
+    return useAsyncUnthrottled(fn, deps)
   }
+}
 
 /** `intersperse([x,y,z], a) ≡ [x,a,y,a,z]` */
 function intersperse<T>(items : T[], sep : T) : T[] {

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -606,7 +606,7 @@ export class InfoProvider implements Disposable {
     private async handleInsertText(text: string, kind: TextInsertKind, uri?: Uri, pos?: Position) {
         let editor: TextEditor | undefined
         if (uri) {
-           editor = window.visibleTextEditors.find(e => e.document.uri.path === uri.path);
+           editor = window.visibleTextEditors.find(e => e.document.uri.toString() === uri.toString());
         } else {
             editor = window.activeTextEditor;
             if (!editor) { // sometimes activeTextEditor is null.

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -606,7 +606,7 @@ export class InfoProvider implements Disposable {
     private async handleInsertText(text: string, kind: TextInsertKind, uri?: Uri, pos?: Position) {
         let editor: TextEditor | undefined
         if (uri) {
-           editor = window.visibleTextEditors.find(e => e.document.uri === uri);
+           editor = window.visibleTextEditors.find(e => e.document.uri.path === uri.path);
         } else {
             editor = window.activeTextEditor;
             if (!editor) { // sometimes activeTextEditor is null.


### PR DESCRIPTION
This is a set of refactors that me and @vtec234 made while working on user widgets and context suggestions.

- some docstrings
- refactor InteractiveHypothesis => InteractiveHypothesisBundle
- refactor: extract HypothesisBundle render to own component.
- introduce a `useAsync` hook for use with rpcs
- refactor TypePopupContents
- InteractiveGoal and InteractiveHypothesisBundle have mvarId? and fvarIds? fields
- helper function mapRpcError
- helper enum RpcErrorCode
- new override of useEventResult
- fix a bug in handleInsertText where it was doing reference eq instead of string eq.

Co-authored-by: @Vtec234