### PR TITLE
feat: preserve pins when cursor position is undefined

### DIFF
--- a/lean4-infoview/src/infoview/main.tsx
+++ b/lean4-infoview/src/infoview/main.tsx
@@ -62,16 +62,13 @@ function Main(props: {}) {
     } else if (serverStoppedResult){
         ret = <p>{serverStoppedResult}
         </p>
-    } else if (!curUri) {
-        ret = <p>Click somewhere in the Lean file to enable the infoview.</p>
     } else {
-        ret =
-            (<div className="ma1">
-                <Infos />
-                <div className="mv2">
-                    <AllMessages uri={curUri} />
-                </div>
-            </div>)
+        ret = <div className="ma1">
+            <Infos />
+            {curUri && <div className="mv2">
+                <AllMessages uri={curUri} />
+            </div>}
+        </div>
     }
 
     return (


### PR DESCRIPTION
When we close a Lean file, the cursor position temporarily becomes `undefined` and clears all pins. This is fixed here by keeping the `Infos` component alive for as long as the server is running and adapting it to handle the `undefined` case.