### PR TITLE
feat: hook up markdown rendering in InfoView

### DIFF
--- a/lean4-infoview/package-lock.json
+++ b/lean4-infoview/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@vscode/codicons": "0.0.28",
+				"marked": "^4.0.17",
 				"react-fast-compare": "^3.2.0",
 				"tachyons": "^4.12.0",
 				"vscode-languageserver-protocol": "^3.17.0-next"
@@ -20,6 +21,7 @@
 				"@rollup/plugin-replace": "^4.0.0",
 				"@rollup/plugin-typescript": "^8.3.2",
 				"@rollup/plugin-url": "^6.1.0",
+				"@types/marked": "^4.0.3",
 				"@types/react": "^17.0.39",
 				"@types/react-dom": "^17.0.13",
 				"react-popper": "^2.2.5",
@@ -191,6 +193,12 @@
 			"version": "0.0.39",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
 			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"dev": true
+		},
+		"node_modules/@types/marked": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.3.tgz",
+			"integrity": "sha512-HnMWQkLJEf/PnxZIfbm0yGJRRZYYMhb++O9M36UCTA9z53uPvVoSlAwJr3XOpDEryb7Hwl1qAx/MV6YIW1RXxg==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -565,6 +573,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/marked": {
+			"version": "4.0.17",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+			"integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/merge-stream": {
@@ -1056,6 +1075,12 @@
 			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
 			"dev": true
 		},
+		"@types/marked": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.3.tgz",
+			"integrity": "sha512-HnMWQkLJEf/PnxZIfbm0yGJRRZYYMhb++O9M36UCTA9z53uPvVoSlAwJr3XOpDEryb7Hwl1qAx/MV6YIW1RXxg==",
+			"dev": true
+		},
 		"@types/node": {
 			"version": "17.0.21",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
@@ -1367,6 +1392,11 @@
 			"requires": {
 				"semver": "^6.0.0"
 			}
+		},
+		"marked": {
+			"version": "4.0.17",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+			"integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA=="
 		},
 		"merge-stream": {
 			"version": "2.0.0",

--- a/lean4-infoview/package.json
+++ b/lean4-infoview/package.json
@@ -25,13 +25,15 @@
     "rollup": "^2.74.0",
     "rollup-plugin-css-only": "^3.1.0",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "^4.6.2"
+    "typescript": "^4.6.2",
+    "@types/marked": "^4.0.3"
   },
   "dependencies": {
     "@lean4/infoview-api": "^0.1.0",
     "@vscode/codicons": "0.0.28",
     "react-fast-compare": "^3.2.0",
     "tachyons": "^4.12.0",
-    "vscode-languageserver-protocol": "^3.17.0-next"
+    "vscode-languageserver-protocol": "^3.17.0-next",
+    "marked": "^4.0.17"
   }
 }

--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -90,6 +90,14 @@ select {
     border-color: var(--vscode-dropdown-border);
     border-width: 1px;
     border-style: solid;
+	max-width: calc(70%);
+	box-sizing: border-box;
+}
+
+@media (max-width: 500px) {
+	.tooltip {
+		max-width: 100vw;
+	}
 }
 
 .tooltip-arrow,

--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -135,3 +135,7 @@ select {
     color: var(--vscode-editorWidget-foreground);
     background: var(--vscode-editorWidget-background);
 }
+
+.hover-div {
+    overflow: hidden; font-size: 14px; line-height: 1.35714;
+}

--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -139,3 +139,164 @@ select {
 .hover-div {
     overflow: hidden; font-size: 14px; line-height: 1.35714;
 }
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+ /* from github.com/microsoft/vscode/src/vs/base/browser/ui/hover/hover.css */
+ .monaco-hover {
+	cursor: default;
+	overflow: hidden;
+	z-index: 50;
+	user-select: text;
+	-webkit-user-select: text;
+	-ms-user-select: text;
+	box-sizing: initial;
+	line-height: 1.5em;
+}
+
+.monaco-hover.hidden {
+	display: none;
+}
+
+.monaco-hover a:hover {
+	cursor: pointer;
+}
+
+.monaco-hover .hover-contents:not(.html-hover-contents) {
+	padding: 4px 8px;
+}
+
+.monaco-hover .markdown-hover > .hover-contents:not(.code-hover-contents) {
+	/* max-width: 500px; */
+	word-wrap: break-word;
+}
+
+.monaco-hover .markdown-hover > .hover-contents:not(.code-hover-contents) hr {
+	/* min-width: 100%; */
+}
+
+.monaco-hover p,
+.monaco-hover .code,
+.monaco-hover ul {
+	margin: 8px 0;
+}
+
+.monaco-hover code {
+	font-family: var(--monaco-monospace-font);
+}
+
+.monaco-hover hr {
+	box-sizing: border-box;
+	border-left: 0px;
+	border-right: 0px;
+	margin-top: 4px;
+	margin-bottom: 4px;
+	margin-left: -18px;
+	margin-right: -18px;
+	height: 1px;
+    /* bugbug: this needs to be themed, as per line 330 of
+    github.com/microsoft/vscode/src/vs/editor/contrib/hover/browser/hover.ts */
+    border-bottom: 0px solid rgba(69, 69, 69, 0.5);
+    border-top: 1px solid rgba(69, 69, 69, 0.5);
+}
+
+.monaco-hover p:first-child,
+.monaco-hover .code:first-child,
+.monaco-hover ul:first-child {
+	margin-top: 0;
+}
+
+.monaco-hover p:last-child,
+.monaco-hover .code:last-child,
+.monaco-hover ul:last-child {
+	margin-bottom: 0;
+}
+
+/* MarkupContent Layout */
+.monaco-hover ul {
+	padding-left: 20px;
+}
+.monaco-hover ol {
+	padding-left: 20px;
+}
+
+.monaco-hover li > p {
+	margin-bottom: 0;
+}
+
+.monaco-hover li > ul {
+	margin-top: 0;
+}
+
+.monaco-hover code {
+	border-radius: 3px;
+	padding: 0 0.4em;
+}
+
+.monaco-hover .monaco-tokenized-source {
+	white-space: pre-wrap;
+}
+
+.monaco-hover .hover-row.status-bar {
+	font-size: 12px;
+	line-height: 22px;
+}
+
+.monaco-hover .hover-row.status-bar .actions {
+	display: flex;
+	padding: 0px 8px;
+}
+
+.monaco-hover .hover-row.status-bar .actions .action-container {
+	margin-right: 16px;
+	cursor: pointer;
+}
+
+.monaco-hover .hover-row.status-bar .actions .action-container .action .icon {
+	padding-right: 4px;
+}
+
+.monaco-hover .markdown-hover .hover-contents .codicon {
+	color: inherit;
+	font-size: inherit;
+	vertical-align: middle;
+}
+
+.monaco-hover .hover-contents a.code-link:hover,
+.monaco-hover .hover-contents a.code-link {
+	color: inherit;
+}
+
+.monaco-hover .hover-contents a.code-link:before {
+	content: '(';
+}
+
+.monaco-hover .hover-contents a.code-link:after {
+	content: ')';
+}
+
+.monaco-hover .hover-contents a.code-link > span {
+	text-decoration: underline;
+	/** Hack to force underline to show **/
+	border-bottom: 1px solid transparent;
+	text-underline-position: under;
+}
+
+/** Spans in markdown hovers need a margin-bottom to avoid looking cramped: https://github.com/microsoft/vscode/issues/101496 **/
+.monaco-hover .markdown-hover .hover-contents:not(.code-hover-contents):not(.html-hover-contents) span {
+	margin-bottom: 4px;
+	display: inline-block;
+}
+
+.monaco-hover-content .action-container a {
+	-webkit-user-select: none;
+	user-select: none;
+}
+
+.monaco-hover-content .action-container.disabled {
+	pointer-events: none;
+	opacity: 0.4;
+	cursor: default;
+}

--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -197,17 +197,17 @@ select {
 
 .monaco-hover hr {
 	box-sizing: border-box;
-	border-left: 0px;
-	border-right: 0px;
+	border-left: -8px;
+	border-right: -8px;
 	margin-top: 4px;
 	margin-bottom: 4px;
 	margin-left: -18px;
 	margin-right: -18px;
 	height: 1px;
-    /* bugbug: this needs to be themed, as per line 330 of
-    github.com/microsoft/vscode/src/vs/editor/contrib/hover/browser/hover.ts */
-    border-bottom: 0px solid rgba(69, 69, 69, 0.5);
-    border-top: 1px solid rgba(69, 69, 69, 0.5);
+    border-bottom-width: 0px;
+    border-top-width: 1px;
+	border-top-style: solid;
+	border-top-color: var(--vscode-editorWidget-border);
 }
 
 .monaco-hover p:first-child,

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -82,7 +82,7 @@ function TypePopupContents({ pos, info, redrawTooltip }: TypePopupContentsProps)
   // We let the tooltip know to redo its layout whenever our contents change.
   React.useEffect(() => redrawTooltip(), [ip, err, redrawTooltip])
 
-  return <div className="monaco-hover-content hover-div hover-row markdown-hover">
+  return <div className="monaco-hover monaco-hover-content hover-div hover-row markdown-hover">
     {ip && <>
       <div className="font-code tl pre-wrap">
       {ip.exprExplicit && <InteractiveCode pos={pos} fmt={ip.exprExplicit} />} : {ip.type && <InteractiveCode pos={pos} fmt={ip.type} />}

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -104,8 +104,7 @@ function renderMarkdown(doc: string){
 
 		// Remove markdown escapes. Workaround for https://github.com/chjj/marked/issues/829
 		if (href === text) { // raw link case
-
-			text = removeMarkdownEscapes(text as string);
+			text = removeMarkdownEscapes(text);
 		}
 
 		title = typeof title === 'string' ? escapeDoubleQuotes(removeMarkdownEscapes(title)) : '';
@@ -125,7 +124,7 @@ function renderMarkdown(doc: string){
 
   renderer.code = (code, lang) => {
     const id : string = lang ? lang : '';
-    const formatted = renderCodeBlock(id, code as string);
+    const formatted = renderCodeBlock(id, code);
 		return `<div class="font-code tl pre-wrap" data-code="${id}">${formatted}</div>`;
 	}
 

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -74,7 +74,7 @@ function removeMarkdownEscapes(text: string): string {
 
 function renderCodeBlock(lang: string, code: string) : string {
   // todo: render Lean code blocks using the lean syntax.json
-  return code;
+  return `<div>${code}</div>`
 }
 
 function renderMarkdown(doc: string){
@@ -126,7 +126,7 @@ function renderMarkdown(doc: string){
   renderer.code = (code, lang) => {
     const id : string = lang ? lang : '';
     const formatted = renderCodeBlock(id, code as string);
-		return `<div class="code" data-code="${id}">${escape(formatted)}</div>`;
+		return `<div class="font-code tl pre-wrap" data-code="${id}">${formatted}</div>`;
 	}
 
   const markedOptions: marked.MarkedOptions = {}
@@ -141,11 +141,12 @@ function renderMarkdown(doc: string){
   // todo: vscode also has lots of post render sanitization and hooking up of href clicks and so on.
   // See https://github.com/microsoft/vscode/blob/main/src/vs/base/browser/markdownRenderer.ts
 
-  // TODO: also need to provide all the vscode CSS styles here since the popup is not inheriting those.
+  // TODO: also need to provide all the vscode CSS styles that are relevant to all HTML tags that
+  // can be returned by the markdown parser, like lists and tables.
 
   const renderedMarkdown = marked.parse(doc, markedOptions);
-  // return <div dangerouslySetInnerHTML={{ __html: renderedMarkdown }} />
-  return <div>{ renderedMarkdown } </div>
+  return <div dangerouslySetInnerHTML={{ __html: renderedMarkdown }} />
+  // return <div>{ renderedMarkdown } </div>
 }
 
 /** Shows `explicitValue : itsType` and a docstring if there is one. */
@@ -163,7 +164,9 @@ function TypePopupContents({ pos, info, redrawTooltip }: TypePopupContentsProps)
 
   return <>
     {ip && <>
+      <div className="font-code tl pre-wrap">
       {ip.exprExplicit && <InteractiveCode pos={pos} fmt={ip.exprExplicit} />} : {ip.type && <InteractiveCode pos={pos} fmt={ip.type} />}
+      </div>
       {ip.doc && <hr />}
       {ip.doc && ip.doc && renderMarkdown(ip.doc)}
     </>}
@@ -175,7 +178,7 @@ function TypePopupContents({ pos, info, redrawTooltip }: TypePopupContentsProps)
 /** Tagged spans can be hovered over to display extra info stored in the associated `SubexprInfo`. */
 function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<SubexprInfo>) {
   const mkTooltip = React.useCallback((redrawTooltip: () => void) =>
-    <div className="font-code tl pre-wrap">
+    <div>
       <TypePopupContents pos={pos} info={ct}
         redrawTooltip={redrawTooltip} />
     </div>, [pos.uri, pos.line, pos.character, ct.info])

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -79,24 +79,6 @@ function renderCodeBlock(lang: string, code: string) : string {
 
 function renderMarkdown(doc: string){
   const renderer = new marked.Renderer();
-  renderer.image = (href: string, title: string, text: string) => {
-		let dimensions: string[] = [];
-		let attributes: string[] = [];
-		if (href) {
-			({ href, dimensions } = parseHrefAndDimensions(href));
-			attributes.push(`src="${escapeDoubleQuotes(href)}"`);
-		}
-		if (text) {
-			attributes.push(`alt="${escapeDoubleQuotes(text)}"`);
-		}
-		if (title) {
-			attributes.push(`title="${escapeDoubleQuotes(title)}"`);
-		}
-		if (dimensions.length) {
-			attributes = attributes.concat(dimensions);
-		}
-		return '<img ' + attributes.join(' ') + '>';
-	};
 	renderer.link = (href, title, text): string => {
 		if (typeof href !== 'string') {
 			return '';
@@ -117,9 +99,6 @@ function renderMarkdown(doc: string){
 			.replace(/"/g, '&quot;')
 			.replace(/'/g, '&#39;');
 		return `<a href="${href}" title="${title || href}">${text}</a>`;
-	};
-	renderer.paragraph = (text): string => {
-		return `<p>${text}</p>`;
 	};
 
   renderer.code = (code, lang) => {
@@ -144,8 +123,8 @@ function renderMarkdown(doc: string){
   // can be returned by the markdown parser, like lists and tables.
 
   const renderedMarkdown = marked.parse(doc, markedOptions);
-  return <div dangerouslySetInnerHTML={{ __html: renderedMarkdown }} />
-  // return <div>{ renderedMarkdown } </div>
+  // return <div dangerouslySetInnerHTML={{ __html: renderedMarkdown }} />
+  return <div>{ renderedMarkdown } </div>
 }
 
 /** Shows `explicitValue : itsType` and a docstring if there is one. */

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -41,7 +41,7 @@ interface TypePopupContentsProps {
 
 function renderCodeBlock(lang: string, code: string) : string {
   // todo: render Lean code blocks using the lean syntax.json
-  return `<div>${code}</div>`
+  return `<div class="font-code tl pre-wrap">${code}</div>`
 }
 
 function renderMarkdown(doc: string){
@@ -49,7 +49,7 @@ function renderMarkdown(doc: string){
   renderer.code = (code, lang) => {
     const id : string = lang ? lang : '';
     const formatted = renderCodeBlock(id, code);
-		return `<div class="font-code tl pre-wrap" data-code="${id}">${formatted}</div>`;
+		return `<div data-code="${id}">${formatted}</div>`;
 	}
 
   const markedOptions: marked.MarkedOptions = {}
@@ -63,11 +63,9 @@ function renderMarkdown(doc: string){
   // todo: vscode also has lots of post render sanitization and hooking up of href clicks and so on.
   // see https://github.com/microsoft/vscode/blob/main/src/vs/base/browser/markdownRenderer.ts
 
-  // TODO: also need to provide all the vscode CSS styles that are relevant to all HTML tags that
-  // can be returned by the markdown parser, like lists and tables.
-
   const renderedMarkdown = marked.parse(doc, markedOptions);
   return <div dangerouslySetInnerHTML={{ __html: renderedMarkdown }} />
+  // handy for debugging:
   // return <div>{ renderedMarkdown } </div>
 }
 
@@ -84,7 +82,7 @@ function TypePopupContents({ pos, info, redrawTooltip }: TypePopupContentsProps)
   // We let the tooltip know to redo its layout whenever our contents change.
   React.useEffect(() => redrawTooltip(), [ip, err, redrawTooltip])
 
-  return <>
+  return <div className="monaco-hover-content hover-div hover-row markdown-hover">
     {ip && <>
       <div className="font-code tl pre-wrap">
       {ip.exprExplicit && <InteractiveCode pos={pos} fmt={ip.exprExplicit} />} : {ip.type && <InteractiveCode pos={pos} fmt={ip.type} />}
@@ -94,7 +92,7 @@ function TypePopupContents({ pos, info, redrawTooltip }: TypePopupContentsProps)
     </>}
     {err && <>Error: {mapRpcError(err).message}</>}
     {(!ip && !err) && <>Loading..</>}
-  </>
+  </div>
 }
 
 /** Tagged spans can be hovered over to display extra info stored in the associated `SubexprInfo`. */

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -67,8 +67,8 @@ function renderMarkdown(doc: string){
   // can be returned by the markdown parser, like lists and tables.
 
   const renderedMarkdown = marked.parse(doc, markedOptions);
-  // return <div dangerouslySetInnerHTML={{ __html: renderedMarkdown }} />
-  return <div>{ renderedMarkdown } </div>
+  return <div dangerouslySetInnerHTML={{ __html: renderedMarkdown }} />
+  // return <div>{ renderedMarkdown } </div>
 }
 
 /** Shows `explicitValue : itsType` and a docstring if there is one. */

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -67,8 +67,8 @@ function renderMarkdown(doc: string){
   // can be returned by the markdown parser, like lists and tables.
 
   const renderedMarkdown = marked.parse(doc, markedOptions);
-  return <div dangerouslySetInnerHTML={{ __html: renderedMarkdown }} />
-  // return <div>{ renderedMarkdown } </div>
+  // return <div dangerouslySetInnerHTML={{ __html: renderedMarkdown }} />
+  return <div>{ renderedMarkdown } </div>
 }
 
 /** Shows `explicitValue : itsType` and a docstring if there is one. */

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -98,10 +98,9 @@ function TypePopupContents({ pos, info, redrawTooltip }: TypePopupContentsProps)
 /** Tagged spans can be hovered over to display extra info stored in the associated `SubexprInfo`. */
 function InteractiveCodeTag({pos, tag: ct, fmt}: InteractiveTagProps<SubexprInfo>) {
   const mkTooltip = React.useCallback((redrawTooltip: () => void) =>
-    <div>
-      <TypePopupContents pos={pos} info={ct}
+    <TypePopupContents pos={pos} info={ct}
         redrawTooltip={redrawTooltip} />
-    </div>, [pos.uri, pos.line, pos.character, ct.info])
+    , [pos.uri, pos.line, pos.character, ct.info])
 
   // We mimick the VSCode ctrl-hover and ctrl-click UI for go-to-definition
   const rs = React.useContext(RpcContext)

--- a/lean4-infoview/src/infoview/tooltips.tsx
+++ b/lean4-infoview/src/infoview/tooltips.tsx
@@ -9,7 +9,7 @@ import { forwardAndUseRef, LogicalDomContext, useLogicalDom } from './util'
 /** Tooltip contents should call `redrawTooltip` whenever their layout changes. */
 export type MkTooltipContentFn = (redrawTooltip: () => void) => React.ReactNode
 
-const TooltipPlacementContext = React.createContext<Popper.Placement>('top')
+const TooltipPlacementContext = React.createContext<Popper.Placement>('auto')
 
 export const Tooltip = forwardAndUseRef<HTMLDivElement,
   React.HTMLProps<HTMLDivElement> &
@@ -197,8 +197,14 @@ export const WithTooltipOnHover =
   React.useEffect(() => {
     const onClickAnywhere = (e: Event) => {
       if (e.target instanceof Node && !logicalDom.contains(e.target)) {
-        clearTimeout()
-        setState('hide')
+        if (e.target instanceof Element && e.target.tagName === 'HTML'){
+          // then user might be clicking in a scrollbar, otherwise
+          // e.target would be 'BODY' so we do not want to hide the popup
+          // so user can scroll and read it all.
+        } else {
+          clearTimeout()
+          setState('hide')
+        }
       }
     }
 

--- a/lean4-infoview/src/infoview/tooltips.tsx
+++ b/lean4-infoview/src/infoview/tooltips.tsx
@@ -9,7 +9,7 @@ import { forwardAndUseRef, LogicalDomContext, useLogicalDom } from './util'
 /** Tooltip contents should call `redrawTooltip` whenever their layout changes. */
 export type MkTooltipContentFn = (redrawTooltip: () => void) => React.ReactNode
 
-const TooltipPlacementContext = React.createContext<Popper.Placement>('auto')
+const TooltipPlacementContext = React.createContext<Popper.Placement>('top')
 
 export const Tooltip = forwardAndUseRef<HTMLDivElement,
   React.HTMLProps<HTMLDivElement> &
@@ -200,7 +200,8 @@ export const WithTooltipOnHover =
         if (e.target instanceof Element && e.target.tagName === 'HTML'){
           // then user might be clicking in a scrollbar, otherwise
           // e.target would be 'BODY' so we do not want to hide the popup
-          // so user can scroll and read it all.
+          // so user can scroll and read it all otherwise popup disappears
+          // when you click on the scrollbar!
         } else {
           clearTimeout()
           setState('hide')


### PR DESCRIPTION
Beginnings of a markdown rendering for infoview.

Related work items:
- [popup scrolling](https://github.com/leanprover/vscode-lean4/issues/210)
- [code block formatting](https://github.com/leanprover/vscode-lean4/issues/211)
- [Figure out if we want to do anything fun with hyperlinks in tooltips](https://github.com/leanprover/vscode-lean4/issues/212)

This version currently converts this
```lean
/--
This is a **cool** function, it can:
- slice bread
- make toast
- spread marmalade
- set a timer

Example usage:

let pt := { x : 1, y := 2 }

See code at [Foo.lean](http://github.com/leanprover/lean4).
-/
structure Point where
  x : Float
  y : Float
  deriving Repr
```

We see this comparison, with editor hover widget on the left and the infoview hover widget on the right:

![image](https://user-images.githubusercontent.com/18707114/177655054-27c8208c-d223-4c7e-b7e5-82eb06fcd72a.png)
