### PR TITLE
Add setting to specify the path to the Lake executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ This extension contributes the following settings (for a complete list, open the
 
 * `lean4.toolchainPath`: specifies the location  of the Lean toolchain to be used when starting the Lean language server. Most users (i.e. those using `elan`) should not ever need to change this. If you are bundling Lean and `vscode-lean` with [Portable mode VS Code](https://code.visualstudio.com/docs/editor/portable), you might find it useful to specify a relative path to Lean. This can be done by starting this setting string with `%extensionPath%`; the extension will replace this with the absolute path of the extension folder. For example, with the default directory setup in Portable mode, `%extensionPath%/../../../lean` will point to `lean` in the same folder as the VS Code executable / application.
 
+* `lean4.lakePath`: specifies the location of the Lake executable to be used when starting the Lean language server (when possible). If left unspecified, the extension defaults to the Lake executable bundled with the Lean toolchain. Most users thus do not need to use this setting. It is only really helpful if you are building a Lake executable from the source and wish to use it with this extension.
+
 * `lean4.serverEnv`: specifies any Environment variables to add to the Lean 4 language server environment.  Note that when opening a [remote folder](https://code.visualstudio.com/docs/remote/ssh) using VS Code the Lean 4 language server will be running on that remote machine.
 
 * `lean4.serverEnvPaths`: specifies any additional paths to add to the Lean 4 language server environment PATH variable.

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -89,6 +89,12 @@
 					"default": true,
 					"markdownDescription": "Enable Lake server when possible."
 				},
+				"lean4.lakePath": {
+					"type": "string",
+					"default": "",
+					"markdownDescription": "Path to Lake. Leave this blank to use the Lake from the toolchain.",
+					"scope": "machine-overridable"
+				},
 				"lean4.serverArgs": {
 					"type": "array",
 					"default": [],

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -48,6 +48,10 @@ export function toolchainPath(): string {
     return workspace.getConfiguration('lean4').get('toolchainPath', '')
 }
 
+export function lakePath(): string {
+    return workspace.getConfiguration('lean4').get('lakePath', '')
+}
+
 export function lakeEnabled(): boolean {
     return workspace.getConfiguration('lean4').get('enableLake', false)
 }

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -16,7 +16,7 @@ import {
 } from 'vscode-languageclient/node'
 import * as ls from 'vscode-languageserver-protocol'
 
-import { toolchainPath, addServerEnvPaths, serverArgs, serverLoggingEnabled, serverLoggingPath, getElaborationDelay, lakeEnabled } from './config'
+import { toolchainPath, lakePath, addServerEnvPaths, serverArgs, serverLoggingEnabled, serverLoggingPath, getElaborationDelay, lakeEnabled } from './config'
 import { assert } from './utils/assert'
 import { LeanFileProgressParams, LeanFileProgressProcessingInfo } from '@lean4/infoview-api';
 import { LocalStorageService} from './utils/localStorage'
@@ -124,7 +124,8 @@ export class LeanClient implements Disposable {
             env.LEAN_SERVER_LOG_DIR = serverLoggingPath()
         }
 
-        let executable = (this.toolchainPath) ? join(this.toolchainPath, 'bin', 'lake') : 'lake';
+        let executable = lakePath() ||
+            (this.toolchainPath ? join(this.toolchainPath, 'bin', 'lake') : 'lake');
 
         // check if the lake process will start (skip it on scheme: 'untitled' files)
         let useLake = lakeEnabled() && this.folderUri && this.folderUri.scheme === 'file';


### PR DESCRIPTION
This is a very selfish addition, but one I desperately need in order to test `lake serve` without needing to setup a custom Lean toolchain on every rebuild.