### PR TITLE
fix: font size in tooltips

### DIFF
--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -84,7 +84,6 @@ select {
     @extend .mtk1;
     background: var(--vscode-editorWidget-background);
     padding: 4px 8px;
-    font-size: 13px;
     border-radius: 4px;
     box-shadow: 1px 1px 5px var(--vscode-widget-shadow);
     border-color: var(--vscode-dropdown-border);
@@ -145,7 +144,8 @@ select {
 }
 
 .hover-div {
-    overflow: hidden; font-size: 14px; line-height: 1.35714;
+    overflow: hidden;
+    line-height: 1.35714;
 }
 
 /*---------------------------------------------------------------------------------------------

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -64,7 +64,7 @@ function renderMarkdown(doc: string){
   // see https://github.com/microsoft/vscode/blob/main/src/vs/base/browser/markdownRenderer.ts
 
   const renderedMarkdown = marked.parse(doc, markedOptions);
-  return <div dangerouslySetInnerHTML={{ __html: renderedMarkdown }} />
+  return <div className="markdown-hover" dangerouslySetInnerHTML={{ __html: renderedMarkdown }} />
   // handy for debugging:
   // return <div>{ renderedMarkdown } </div>
 }
@@ -82,13 +82,13 @@ function TypePopupContents({ pos, info, redrawTooltip }: TypePopupContentsProps)
   // We let the tooltip know to redo its layout whenever our contents change.
   React.useEffect(() => redrawTooltip(), [ip, err, redrawTooltip])
 
-  return <div className="monaco-hover monaco-hover-content hover-div hover-row markdown-hover">
+  return <div className="monaco-hover monaco-hover-content hover-div hover-row">
     {ip && <>
       <div className="font-code tl pre-wrap">
       {ip.exprExplicit && <InteractiveCode pos={pos} fmt={ip.exprExplicit} />} : {ip.type && <InteractiveCode pos={pos} fmt={ip.type} />}
       </div>
       {ip.doc && <hr />}
-      {ip.doc && ip.doc && renderMarkdown(ip.doc)}
+      {ip.doc && renderMarkdown(ip.doc)}
     </>}
     {err && <>Error: {mapRpcError(err).message}</>}
     {(!ip && !err) && <>Loading..</>}


### PR DESCRIPTION
I noticed that markdown fonts look out of place on a high DPI screen. This is a quick fix for that which removes hardcoded font-sizes, so that we default to `--vscode-font-size` that the webview already puts on `body`.