### PR TITLE
fix: line height in tooltips

### DIFF
--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -143,11 +143,6 @@ select {
     background: var(--vscode-editorWidget-background);
 }
 
-.hover-div {
-    overflow: hidden;
-    line-height: 1.35714;
-}
-
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
@@ -161,7 +156,6 @@ select {
 	-webkit-user-select: text;
 	-ms-user-select: text;
 	box-sizing: initial;
-	line-height: 1.5em;
 }
 
 .monaco-hover.hidden {
@@ -179,6 +173,7 @@ select {
 .monaco-hover .markdown-hover > .hover-contents:not(.code-hover-contents) {
 	/* max-width: 500px; */
 	word-wrap: break-word;
+	line-height: 1.5em;
 }
 
 .monaco-hover .markdown-hover > .hover-contents:not(.code-hover-contents) hr {

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -41,7 +41,7 @@ interface TypePopupContentsProps {
 
 function renderCodeBlock(lang: string, code: string) : string {
   // todo: render Lean code blocks using the lean syntax.json
-  return `<div class="font-code tl pre-wrap">${code}</div>`
+  return `<div class="code-hover-contents font-code tl pre-wrap">${code}</div>`
 }
 
 function renderMarkdown(doc: string){
@@ -49,7 +49,7 @@ function renderMarkdown(doc: string){
   renderer.code = (code, lang) => {
     const id : string = lang ? lang : '';
     const formatted = renderCodeBlock(id, code);
-		return `<div data-code="${id}">${formatted}</div>`;
+		return `<div class="hover-contents" data-code="${id}">${formatted}</div>`;
 	}
 
   const markedOptions: marked.MarkedOptions = {}
@@ -82,7 +82,7 @@ function TypePopupContents({ pos, info, redrawTooltip }: TypePopupContentsProps)
   // We let the tooltip know to redo its layout whenever our contents change.
   React.useEffect(() => redrawTooltip(), [ip, err, redrawTooltip])
 
-  return <div className="monaco-hover monaco-hover-content hover-div hover-row">
+  return <div className="monaco-hover monaco-hover-content hover-row">
     {ip && <>
       <div className="font-code tl pre-wrap">
       {ip.exprExplicit && <InteractiveCode pos={pos} fmt={ip.exprExplicit} />} : {ip.type && <InteractiveCode pos={pos} fmt={ip.type} />}


### PR DESCRIPTION
The new CSS broke the line spacing of multi-line code in tooltips:
<img width="410" alt="Screen Shot 2022-07-08 at 2 02 01 PM" src="https://user-images.githubusercontent.com/13901751/178047345-5218ee8a-b06b-42c1-9bda-83587f38a7fb.png">

This fixes the spacing.