### PR TITLE
fix: issue# 216 about powershell execution policy.

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -54,37 +54,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: |
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
-      - name: Setup elan toolchain on Linux or macOS
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-        run: |
-          curl -O --location https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh
-          chmod u+x elan-init.sh
-          ./elan-init.sh -y --default-toolchain leanprover/lean4:nightly
-          echo "Checking location $HOME/.elan/bin..."
-          ls -al $HOME/.elan/bin
-          elan --version
-          mkdir master
-          cp -r $HOME/.elan//toolchains/leanprover--lean4---nightly/* master
-          elan toolchain link master master
-
       - name: Set path to elan on Windows
         shell: pwsh
         if: matrix.os == 'windows-latest'
         run: |
           echo "$HOME\.elan\bin" >> $env:GITHUB_PATH
-      - name: Setup elan toolchain on Windows
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: |
-          curl -O --location https://raw.githubusercontent.com/leanprover/elan/master/elan-init.ps1
-          .\elan-init.ps1 -NoPrompt 1 -DefaultToolchain leanprover/lean4:nightly
-          echo "Checking location $HOME\.elan\bin..."
-          dir "$HOME\.elan\bin"
-          elan --version
-          mkdir master
-          xcopy /q /s "$HOME\.elan\toolchains\leanprover--lean4---nightly\*.*" master
-          elan toolchain link master master
-
       - name: Install 'leanprover/lean4:stable' version
         run: |
           elan toolchain install leanprover/lean4:stable

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -59,10 +59,6 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           echo "$HOME\.elan\bin" >> $env:GITHUB_PATH
-      - name: Install 'leanprover/lean4:stable' version
-        run: |
-          elan toolchain install leanprover/lean4:stable
-          elan toolchain list
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1.0
         with:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,22 @@
             },
         },
         {
+            "name": "Extension Tests - bootstrap tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}/vscode-lean4",
+                "--extensionTestsPath=${workspaceFolder}/vscode-lean4/out/test/suite/index"
+            ],
+            "env": {
+                "TEST_FOLDER": "bootstrap"
+            },
+            "cwd": "${workspaceFolder}/vscode-lean4/out/",
+            "outFiles": ["${workspaceFolder}/vscode-lean4/out/test/suite/**/*.js"],
+            "preLaunchTask": "watchTest"
+        },
+        {
             "name": "Extension Tests - lean3",
             "type": "extensionHost",
             "request": "launch",

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -116,6 +116,11 @@ export function removeElanPath() : string {
     return result;
 }
 
+export function getPowerShellPath() : string {
+    const windir = process.env.windir
+    return `${windir}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`
+}
+
 export function toolchainPath(): string {
     return workspace.getConfiguration('lean4').get('toolchainPath', '')
 }

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -188,6 +188,18 @@ export function getLeanExecutableName(): string {
     return 'lean'
 }
 
+export function isRunningTest() : boolean {
+    return typeof(process.env.TEST_FOLDER) === 'string';
+}
+
+export function getTestFolder() : string {
+    return typeof(process.env.TEST_FOLDER) === 'string' ? process.env.TEST_FOLDER : '';
+}
+
+export function isElanDisabled() : boolean {
+    return typeof(process.env.DISABLE_ELAN) === 'string';
+}
+
 /**
  * The literal 'production' or 'development', depending on the build.
  * Should be turned into a string literal by build tools.

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -57,6 +57,10 @@ export function addDefaultElanPath() : void {
 }
 
 function findToolchainBin(root:string) : string{
+    console.log(`Looking for toolchains in ${root}`)
+    if (!fs.existsSync(root)) {
+        return '';
+    }
     const toolchains = fs.readdirSync(path.join(root, '..', 'toolchains'));
     for(const toolchain of toolchains) {
         if (toolchain.indexOf('leanprover--lean4') >= 0){
@@ -77,7 +81,7 @@ export function addToolchainBinPath(elanPath: string){
 export function findProgramInPath(name: string) : string {
     if (fs.existsSync(name)) {
         return name;
-     }
+    }
     const extensions : string[] = [];
     if (process.platform === 'win32') {
        extensions.push('.exe')

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -42,15 +42,19 @@ export function addServerEnvPaths(input_env: NodeJS.ProcessEnv): NodeJS.ProcessE
     return env
 }
 
-export function addDefaultElanPath() : void {
-    const paths = getEnvPath();
+export function getDefaultElanPath() : string {
     let elanPath = ''
     if (process.platform === 'win32') {
         elanPath = process.env.USERPROFILE + '\\.elan\\bin';
     } else {
         elanPath = process.env.HOME + '/.elan/bin';
     }
+    return elanPath;
+}
 
+export function addDefaultElanPath() : void {
+    const paths = getEnvPath();
+    const elanPath = getDefaultElanPath();
     if (paths.indexOf(elanPath) < 0) {
         setEnvPath(paths + path.delimiter + elanPath);
     }

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -75,6 +75,9 @@ export function addToolchainBinPath(elanPath: string){
 }
 
 export function findProgramInPath(name: string) : string {
+    if (fs.existsSync(name)) {
+        return name;
+     }
     const extensions : string[] = [];
     if (process.platform === 'win32') {
        extensions.push('.exe')

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -7,7 +7,7 @@ import { LocalStorageService} from './utils/localStorage'
 import { LeanInstaller } from './utils/leanInstaller'
 import { LeanpkgService } from './utils/leanpkg';
 import { LeanClientProvider } from './utils/clientProvider';
-import { addDefaultElanPath, removeElanPath, addToolchainBinPath} from './config';
+import { addDefaultElanPath, removeElanPath, addToolchainBinPath, isElanDisabled} from './config';
 import { dirname, basename } from 'path';
 import { findLeanPackageVersionInfo } from './utils/projectInfo';
 import { Exports } from './exports';
@@ -40,7 +40,7 @@ function getLeanDocument() : TextDocument | undefined {
 export async function activate(context: ExtensionContext): Promise<Exports> {
 
     // for unit test that tests behavior when there is no elan installed.
-    if (process.env.DISABLE_ELAN) {
+    if (isElanDisabled()) {
         const elanRoot = removeElanPath();
         if (elanRoot){
             addToolchainBinPath(elanRoot);

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -40,7 +40,7 @@ function getLeanDocument() : TextDocument | undefined {
 export async function activate(context: ExtensionContext): Promise<Exports> {
 
     // for unit test that tests behavior when there is no elan installed.
-    if (typeof(process.env.DISABLE_ELAN) === 'string') {
+    if (process.env.DISABLE_ELAN) {
         const elanRoot = removeElanPath();
         if (elanRoot){
             addToolchainBinPath(elanRoot);

--- a/vscode-lean4/src/utils/batch.ts
+++ b/vscode-lean4/src/utils/batch.ts
@@ -1,7 +1,6 @@
 import { OutputChannel } from 'vscode'
 import { spawn } from 'child_process';
 import { findProgramInPath } from '../config'
-import * as fs from 'fs';
 
 export async function batchExecute(
     executablePath: string,

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -150,7 +150,7 @@ export class LeanInstaller implements Disposable {
             // no prompt, just do it!
             console.log('Installing Lean via Elan during testing')
             await this.installElan();
-            if (typeof(process.env.DISABLE_ELAN) === 'string') {
+            if (process.env.DISABLE_ELAN) {
                 addToolchainBinPath(getDefaultElanPath());
             } else {
                 addDefaultElanPath();

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -5,7 +5,7 @@ import { LocalStorageService} from './localStorage'
 import { readLeanVersion, findLeanPackageRoot, isCoreLean4Directory } from './projectInfo';
 import { join, dirname } from 'path';
 import { fileExists } from './fsHelper'
-import { addDefaultElanPath, getDefaultElanPath, addToolchainBinPath} from '../config';
+import { addDefaultElanPath, getDefaultElanPath, addToolchainBinPath, isRunningTest, isElanDisabled()} from '../config';
 
 export class LeanVersion {
     version: string;
@@ -146,11 +146,11 @@ export class LeanInstaller implements Disposable {
     async showInstallOptions(uri: Uri) : Promise<void> {
         let path  = this.localStorage.getLeanPath();
         if (!path ) path  = toolchainPath();
-        if (process.env.TEST_FOLDER){
+        if (isRunningTest()){
             // no prompt, just do it!
             console.log('Installing Lean via Elan during testing')
             await this.installElan();
-            if (process.env.DISABLE_ELAN) {
+            if (isElanDisabled()) {
                 addToolchainBinPath(getDefaultElanPath());
             } else {
                 addDefaultElanPath();

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -486,7 +486,6 @@ export class LeanInstaller implements Disposable {
             const terminal = window.createTerminal(terminalOptions);
             terminal.show();
 
-            const thisObject = this;
             // We register a listener, to restart the Lean extension once elan has finished.
             const result = new Promise<boolean>(function(resolve, reject) {
                 window.onDidCloseTerminal(async (t) => {

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -5,7 +5,7 @@ import { LocalStorageService} from './localStorage'
 import { readLeanVersion, findLeanPackageRoot, isCoreLean4Directory } from './projectInfo';
 import { join, dirname } from 'path';
 import { fileExists } from './fsHelper'
-import { addDefaultElanPath, getDefaultElanPath, addToolchainBinPath, isRunningTest, isElanDisabled()} from '../config';
+import { addDefaultElanPath, getDefaultElanPath, addToolchainBinPath, isRunningTest, isElanDisabled } from '../config';
 
 export class LeanVersion {
     version: string;

--- a/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
+++ b/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
@@ -1,0 +1,110 @@
+import * as assert from 'assert';
+import * as os from 'os';
+import { suite } from 'mocha';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { initLean4Untitled, waitForActiveEditor, waitForInfoviewHtml, closeAllEditors,
+         gotoDefinition, assertStringInInfoview, copyFolder } from '../utils/helpers';
+import { getDefaultElanPath } from '../../../src/config'
+import { batchExecute } from '../../../src/utils/batch'
+
+suite('Lean4 Bootstrap Test Suite', () => {
+
+    test('Install elan on demand', async () => {
+
+        console.log(`=================== Install elan on demand ===================`);
+        void vscode.window.showInformationMessage('Running tests: ' + __dirname);
+
+        // this will wait up to 60 seconds to do full elan lean install, so test machines better
+        // be able to do that.
+        const lean = await initLean4Untitled('#eval Lean.versionString');
+        const info = lean.exports.infoProvider;
+        assert(info, 'No InfoProvider export');
+
+        await assertStringInInfoview(info, '4.0.0-nightly-');
+
+        // test goto definition to lean toolchain works
+        await waitForActiveEditor();
+        let editor = vscode.window.activeTextEditor;
+        assert(editor !== undefined, 'no active editor');
+        await gotoDefinition(editor, 'versionString');
+
+        // check infoview is working in this new editor, it should be showing the expected type
+        // for the versionString function we just jumped to.
+        const html = await waitForInfoviewHtml(info, 'Expected type');
+
+        const expected = path.join('.elan', 'toolchains', 'leanprover--lean4---nightly', 'src', 'lean');
+        editor = vscode.window.activeTextEditor;
+        assert(editor !== undefined, 'no active editor');
+        assert(editor.document.uri.fsPath.indexOf(expected) > 0,
+            `Active text editor is not located in ${expected}`);
+
+        // make sure lean client is started in the right place.
+        const clients = lean.exports.clientProvider;
+        assert(clients, 'No LeanClientProvider export');
+        clients.getClients().forEach((client) => {
+            const leanRoot = client.getWorkspaceFolder();
+            if (leanRoot.indexOf('leanprover--lean4---nightly') > 0){
+                assert(leanRoot.endsWith('leanprover--lean4---nightly'),
+                    'Lean client is not rooted in the \'leanprover--lean4---nightly\' folder');
+            }
+        });
+
+        // make sure test is always run in predictable state, which is no file or folder open
+        await closeAllEditors();
+
+    }).timeout(60000);
+
+    test('Install stable build on demand', async () => {
+
+        console.log(`=================== Install stable build on demand ===================`);
+        void vscode.window.showInformationMessage('Running tests: ' + __dirname);
+
+        // this will wait up to 60 seconds to do full elan lean install, so test machines better
+        // be able to do that.
+        const lean = await initLean4Untitled('#eval Lean.versionString');
+        const info = lean.exports.infoProvider;
+        assert(info, 'No InfoProvider export');
+
+        await assertStringInInfoview(info, '4.0.0-nightly-');
+
+        // install table build which is also needed by subsequent tests.
+		await vscode.commands.executeCommand('lean4.selectToolchain', 'leanprover/lean4:stable');
+		await waitForInfoviewHtml(info, '4.0.0, commit', 60);
+		await vscode.commands.executeCommand('lean4.selectToolchain', 'reset');
+
+        // make sure test is always run in predictable state, which is no file or folder open
+        await closeAllEditors();
+
+    }).timeout(60000);
+
+    test('Create linked toolchain named master', async () => {
+
+        console.log(`=================== Create linked toolchain named master ===================`);
+        void vscode.window.showInformationMessage('Running tests: ' + __dirname);
+
+        const elanRoot = getDefaultElanPath()
+        const nightly = path.join(elanRoot, '..', 'toolchains', 'leanprover--lean4---nightly')
+        const master = path.join(os.tmpdir(), 'lean4', 'toolchains', 'master')
+        copyFolder(nightly, master);
+
+        await batchExecute('elan', ['toolchain', 'link', 'master', master], null, undefined);
+
+        // this will wait up to 60 seconds to do full elan lean install, so test machines better
+        // be able to do that.
+        const lean = await initLean4Untitled('#eval Lean.versionString');
+        const info = lean.exports.infoProvider;
+        assert(info, 'No InfoProvider export');
+
+		await vscode.commands.executeCommand('lean4.selectToolchain', 'leanprover/lean4:stable');
+		await waitForInfoviewHtml(info, '4.0.0, commit', 60);
+		await vscode.commands.executeCommand('lean4.selectToolchain', 'master');
+        await assertStringInInfoview(info, '4.0.0-nightly-');
+		await vscode.commands.executeCommand('lean4.selectToolchain', 'reset');
+
+        // make sure test is always run in predictable state, which is no file or folder open
+        await closeAllEditors();
+
+    }).timeout(60000);
+
+}).timeout(60000);

--- a/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
+++ b/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
@@ -22,7 +22,7 @@ suite('Lean4 Bootstrap Test Suite', () => {
         assert(info, 'No InfoProvider export');
 
         // give it a extra long timeout in case test machine is really slow.
-		await waitForInfoviewHtml(info, '4.0.0-nightly-', 300);
+		await waitForInfoviewHtml(info, '4.0.0-nightly-', 600);
 
         // test goto definition to lean toolchain works
         await waitForActiveEditor();
@@ -54,7 +54,7 @@ suite('Lean4 Bootstrap Test Suite', () => {
         // make sure test is always run in predictable state, which is no file or folder open
         await closeAllEditors();
 
-    }).timeout(300000); // give it 5 minutes to install lean in case test machine is really slow.
+    }).timeout(600000); // give it 5 minutes to install lean in case test machine is really slow.
 
     test('Install stable build on demand', async () => {
 
@@ -67,19 +67,19 @@ suite('Lean4 Bootstrap Test Suite', () => {
         const info = lean.exports.infoProvider;
         assert(info, 'No InfoProvider export');
 
-        await assertStringInInfoview(info, '4.0.0-nightly-');
+		await waitForInfoviewHtml(info, '4.0.0-nightly-', 60);
 
         // install table build which is also needed by subsequent tests.
 		await vscode.commands.executeCommand('lean4.selectToolchain', 'leanprover/lean4:stable');
 
         // give it a extra long timeout in case test machine is really slow.
-		await waitForInfoviewHtml(info, '4.0.0, commit', 300);
+		await waitForInfoviewHtml(info, '4.0.0, commit', 600);
 		await vscode.commands.executeCommand('lean4.selectToolchain', 'reset');
 
         // make sure test is always run in predictable state, which is no file or folder open
         await closeAllEditors();
 
-    }).timeout(300000);
+    }).timeout(600000);
 
     test('Create linked toolchain named master', async () => {
 

--- a/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
+++ b/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
@@ -12,7 +12,7 @@ suite('Lean4 Bootstrap Test Suite', () => {
 
     test('Install elan on demand', async () => {
 
-        console.log(`=================== Install elan on demand ===================`);
+        console.log('=================== Install elan on demand ===================');
         void vscode.window.showInformationMessage('Running tests: ' + __dirname);
 
         // this will wait up to 60 seconds to do full elan lean install, so test machines better
@@ -57,7 +57,7 @@ suite('Lean4 Bootstrap Test Suite', () => {
 
     test('Install stable build on demand', async () => {
 
-        console.log(`=================== Install stable build on demand ===================`);
+        console.log('=================== Install stable build on demand ===================');
         void vscode.window.showInformationMessage('Running tests: ' + __dirname);
 
         // this will wait up to 60 seconds to do full elan lean install, so test machines better
@@ -80,7 +80,7 @@ suite('Lean4 Bootstrap Test Suite', () => {
 
     test('Create linked toolchain named master', async () => {
 
-        console.log(`=================== Create linked toolchain named master ===================`);
+        console.log('=================== Create linked toolchain named master ===================');
         void vscode.window.showInformationMessage('Running tests: ' + __dirname);
 
         const elanRoot = getDefaultElanPath()

--- a/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
+++ b/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
@@ -21,7 +21,8 @@ suite('Lean4 Bootstrap Test Suite', () => {
         const info = lean.exports.infoProvider;
         assert(info, 'No InfoProvider export');
 
-        await assertStringInInfoview(info, '4.0.0-nightly-');
+        // give it a extra long timeout in case test machine is really slow.
+		await waitForInfoviewHtml(info, '4.0.0-nightly-', 300);
 
         // test goto definition to lean toolchain works
         await waitForActiveEditor();
@@ -53,7 +54,7 @@ suite('Lean4 Bootstrap Test Suite', () => {
         // make sure test is always run in predictable state, which is no file or folder open
         await closeAllEditors();
 
-    }).timeout(60000);
+    }).timeout(300000); // give it 5 minutes to install lean in case test machine is really slow.
 
     test('Install stable build on demand', async () => {
 
@@ -70,13 +71,15 @@ suite('Lean4 Bootstrap Test Suite', () => {
 
         // install table build which is also needed by subsequent tests.
 		await vscode.commands.executeCommand('lean4.selectToolchain', 'leanprover/lean4:stable');
-		await waitForInfoviewHtml(info, '4.0.0, commit', 60);
+
+        // give it a extra long timeout in case test machine is really slow.
+		await waitForInfoviewHtml(info, '4.0.0, commit', 300);
 		await vscode.commands.executeCommand('lean4.selectToolchain', 'reset');
 
         // make sure test is always run in predictable state, which is no file or folder open
         await closeAllEditors();
 
-    }).timeout(60000);
+    }).timeout(300000);
 
     test('Create linked toolchain named master', async () => {
 
@@ -97,14 +100,15 @@ suite('Lean4 Bootstrap Test Suite', () => {
         assert(info, 'No InfoProvider export');
 
 		await vscode.commands.executeCommand('lean4.selectToolchain', 'leanprover/lean4:stable');
-		await waitForInfoviewHtml(info, '4.0.0, commit', 60);
+		await assertStringInInfoview(info, '4.0.0, commit');
 		await vscode.commands.executeCommand('lean4.selectToolchain', 'master');
-        await assertStringInInfoview(info, '4.0.0-nightly-');
+        // sometimes a copy of lean launches more slowly (especially on Windows).
+        await waitForInfoviewHtml(info, '4.0.0-nightly-', 300);
 		await vscode.commands.executeCommand('lean4.selectToolchain', 'reset');
 
         // make sure test is always run in predictable state, which is no file or folder open
         await closeAllEditors();
 
-    }).timeout(60000);
+    }).timeout(300000);
 
 }).timeout(60000);

--- a/vscode-lean4/test/suite/index/index.ts
+++ b/vscode-lean4/test/suite/index/index.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as Mocha from 'mocha';
 import * as glob from 'glob';
+import { isElanDisabled, getTestFolder } from '../../../src/config'
 
 export function run(testsRoot: string, cb: (error: any, failures?: number) => void): void {
     // Create the mocha test
@@ -12,13 +13,13 @@ export function run(testsRoot: string, cb: (error: any, failures?: number) => vo
         // workaround for https://github.com/microsoft/vscode-test/issues/134
         testsRoot = testsRoot.toLowerCase();
     }
-    const folder = process.env.TEST_FOLDER;
+    const folder = getTestFolder();
     if (folder) {
         testsRoot = path.resolve(testsRoot, '..', folder)
     }
     console.log('>>>>>>>>> testsRoot=' + testsRoot);
 
-    if (process.env.DISABLE_ELAN) {
+    if (isElanDisabled()) {
         console.log('>>>>>>>>> running without elan');
     }
 

--- a/vscode-lean4/test/suite/index/index.ts
+++ b/vscode-lean4/test/suite/index/index.ts
@@ -18,7 +18,7 @@ export function run(testsRoot: string, cb: (error: any, failures?: number) => vo
     }
     console.log('>>>>>>>>> testsRoot=' + testsRoot);
 
-    if (typeof(process.env.DISABLE_ELAN) === 'string') {
+    if (process.env.DISABLE_ELAN) {
         console.log('>>>>>>>>> running without elan');
     }
 

--- a/vscode-lean4/test/suite/simple/simple.test.ts
+++ b/vscode-lean4/test/suite/simple/simple.test.ts
@@ -2,12 +2,13 @@ import * as assert from 'assert';
 import { suite } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { isElanDisabled } from '../../../src/config'
 import { initLean4Untitled, waitForActiveEditor, waitForInfoviewHtml, closeAllEditors,
     extractPhrase, gotoDefinition, assertStringInInfoview, initLean4 } from '../utils/helpers';
 
 function getElanMode(){
     let mode = ''
-    if (process.env.DISABLE_ELAN) {
+    if (isElanDisabled()) {
         mode = ' no elan '
     }
     return mode;

--- a/vscode-lean4/test/suite/simple/simple.test.ts
+++ b/vscode-lean4/test/suite/simple/simple.test.ts
@@ -7,7 +7,7 @@ import { initLean4Untitled, waitForActiveEditor, waitForInfoviewHtml, closeAllEd
 
 function getElanMode(){
     let mode = ''
-    if (typeof(process.env.DISABLE_ELAN) === 'string') {
+    if (process.env.DISABLE_ELAN) {
         mode = ' no elan '
     }
     return mode;

--- a/vscode-lean4/test/suite/utils/helpers.ts
+++ b/vscode-lean4/test/suite/utils/helpers.ts
@@ -403,7 +403,6 @@ export function copyFolder(source: string, target: string) {
         const targetFile = path.join(target, file);
         const stats = fs.lstatSync(sourceFile);
         if (stats.isFile()) {
-            console.log(`Copying ${sourceFile}`)
             fs.copyFileSync(sourceFile, targetFile);
         }
         else if (stats.isDirectory()){

--- a/vscode-lean4/test/suite/utils/helpers.ts
+++ b/vscode-lean4/test/suite/utils/helpers.ts
@@ -1,12 +1,14 @@
 import * as assert from 'assert';
 import { basename } from 'path';
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 import { InfoProvider } from '../../../src/infoview';
 import { LeanClient} from '../../../src/leanclient';
 import { DocViewProvider } from '../../../src/docview';
 import { LeanClientProvider } from '../../../src/utils/clientProvider'
 import { Exports } from '../../../src/exports';
 import cheerio = require('cheerio');
+import path = require('path');
 
 export function sleep(ms : number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -28,7 +30,7 @@ export async function initLean4(fileName: string) : Promise<vscode.Extension<Exp
     const doc = await vscode.workspace.openTextDocument(fileName);
     await vscode.window.showTextDocument(doc, options);
 
-    const lean = await waitForActiveExtension('leanprover.lean4');
+    const lean = await waitForActiveExtension('leanprover.lean4', 60);
     assert(lean, 'Lean extension not loaded');
     assert(lean.exports.isLean4Project);
     assert(lean.isActive);
@@ -69,7 +71,7 @@ export async function initLean4Untitled(contents: string) : Promise<vscode.Exten
         builder.insert(new vscode.Position(0, 0), contents);
     });
 
-    const lean = await waitForActiveExtension('leanprover.lean4');
+    const lean = await waitForActiveExtension('leanprover.lean4', 60);
     assert(lean, 'Lean extension not loaded');
 
     console.log(`Found lean package version: ${lean.packageJSON.version}`);
@@ -374,3 +376,32 @@ export async function clickInfoViewButton(info: InfoProvider, name: string) : Pr
     }
 }
 
+export function mkdirs(fullPath: string){
+    const parts = fullPath.split(path.sep);
+    let newPath = ''
+    parts.forEach((p) => {
+        newPath = newPath ? path.join(newPath, p) : p;
+        if (!fs.existsSync(newPath)){
+            fs.mkdirSync(newPath);
+        }
+    });
+}
+
+export function copyFolder(source: string, target: string) {
+    if (!fs.existsSync(target)){
+        mkdirs(target);
+    }
+    const files = fs.readdirSync(source);
+    for(const file of files) {
+        const sourceFile = path.join(source, file);
+        const targetFile = path.join(target, file);
+        const stats = fs.lstatSync(sourceFile);
+        if (stats.isFile()) {
+            console.log(`Copying ${sourceFile}`)
+            fs.copyFileSync(sourceFile, targetFile);
+        }
+        else if (stats.isDirectory()){
+            copyFolder(sourceFile, targetFile);
+        }
+    }
+}

--- a/vscode-lean4/test/suite/utils/helpers.ts
+++ b/vscode-lean4/test/suite/utils/helpers.ts
@@ -378,10 +378,16 @@ export async function clickInfoViewButton(info: InfoProvider, name: string) : Pr
 
 export function mkdirs(fullPath: string){
     const parts = fullPath.split(path.sep);
-    let newPath = ''
+    // on windows the parts[0] is the drive letter, e.g. "c:"
+    // on other platforms parts[0] is empty string, but we want to start with '/'
+    let newPath = parts[0];
+    parts.splice(0, 1);
+    if (!newPath) {
+        newPath = '/'
+    }
     parts.forEach((p) => {
-        newPath = newPath ? path.join(newPath, p) : p;
-        if (!fs.existsSync(newPath)){
+        newPath = path.join(newPath, p);
+        if (newPath && !fs.existsSync(newPath)){
             fs.mkdirSync(newPath);
         }
     });


### PR DESCRIPTION
Fixes #216 

PowerShell by default has execution policy set to Restricted, meaning it will not run random powershell scripts.  This causes `elan-init.ps1` to fail during bootstrapping which is not ideal.  This fix temporarily changes the powershell execution policy to RemoteSigned so that the script can run, then restores the policy to what it was before after  `elan-init.ps1` completes.

This also fixes a recent regression that was causing: "waiting for lean server to start..." to happen in the case where the `lean` version check failed - it was caching the fact that it fails and didn't clear the cache after installing elan.