### PR TITLE
test: Add timestamping on all console.log output.

### DIFF
--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -1,6 +1,7 @@
 import { workspace } from 'vscode'
 import * as path from 'path';
 import * as fs from 'fs'
+import { logger } from './utils/logger'
 
 // TODO: does currently not contain config options for `./abbreviation`
 // so that it is easy to keep it in sync with vscode-lean.
@@ -61,7 +62,7 @@ export function addDefaultElanPath() : void {
 }
 
 function findToolchainBin(root:string) : string{
-    console.log(`Looking for toolchains in ${root}`)
+    logger.log(`Looking for toolchains in ${root}`)
     if (!fs.existsSync(root)) {
         return '';
     }
@@ -112,7 +113,7 @@ export function removeElanPath() : string {
     for (let i = 0; i < parts.length; ) {
          const part = parts[i]
          if (part.indexOf('.elan') > 0){
-            console.log(`removing path to elan: ${part}`)
+            logger.log(`removing path to elan: ${part}`)
             result = part;
             parts.splice(i, 1);
          } else {

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -11,6 +11,7 @@ import { addDefaultElanPath, removeElanPath, addToolchainBinPath, isElanDisabled
 import { dirname, basename } from 'path';
 import { findLeanPackageVersionInfo } from './utils/projectInfo';
 import { Exports } from './exports';
+import { logger } from './utils/logger'
 
 function isLean(languageId : string) : boolean {
     return languageId === 'lean' || languageId === 'lean4';
@@ -59,7 +60,7 @@ export async function activate(context: ExtensionContext): Promise<Exports> {
     if (doc) {
         [packageUri, toolchainVersion] = await findLeanPackageVersionInfo(doc.uri);
         if (toolchainVersion && toolchainVersion.indexOf('lean:3') > 0) {
-            console.log(`Lean4 skipping lean 3 project: ${toolchainVersion}`);
+            logger.log(`Lean4 skipping lean 3 project: ${toolchainVersion}`);
             return { isLean4Project: false, version: toolchainVersion,
                 infoProvider: undefined, clientProvider: undefined, installer: undefined, docView: undefined };
         }

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -13,6 +13,7 @@ import { Rpc } from './rpc';
 import { LeanClientProvider } from './utils/clientProvider'
 import * as ls from 'vscode-languageserver-protocol'
 import { c2pConverter, p2cConverter } from './utils/converters';
+import { logger } from './utils/logger'
 
 const keepAlivePeriodMs = 10000
 
@@ -33,7 +34,7 @@ class RpcSession implements Disposable {
             try {
                 await client.sendNotification('$/lean/rpc/keepAlive', params)
             } catch (e) {
-                console.log(`failed to send keepalive for ${uri}`, e)
+                logger.log(`failed to send keepalive for ${uri}`, e)
                 if (this.keepAliveInterval) clearInterval(this.keepAliveInterval)
             }
         }, keepAlivePeriodMs)
@@ -293,14 +294,14 @@ export class InfoProvider implements Disposable {
         const folder = client.getWorkspaceFolder()
         if (this.clientsFailed.has(folder)) {
             this.clientsFailed.delete(folder) // delete from failed clients
-            console.log('Restarting server for workspace: ' + folder)
+            logger.log('Restarting server for workspace: ' + folder)
         }
         await this.initInfoView(window.activeTextEditor, client);
     }
 
     private async onClientAdded(client: LeanClient) {
 
-        console.log(`Adding client for workspace: ${client.getWorkspaceFolder()}`);
+        logger.log(`Adding client for workspace: ${client.getWorkspaceFolder()}`);
 
         this.clientSubscriptions.push(
             client.restarted(async () => {
@@ -334,7 +335,7 @@ export class InfoProvider implements Disposable {
             await this.webviewPanel?.api.serverStopped(msg);
         }
 
-        console.log(`client stopped: ${client.getWorkspaceFolder()}`)
+        logger.log(`client stopped: ${client.getWorkspaceFolder()}`)
 
         // remember this client is in a stopped state
         this.clientsFailed.set(client.getWorkspaceFolder(), msg)

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -34,7 +34,7 @@ class RpcSession implements Disposable {
             try {
                 await client.sendNotification('$/lean/rpc/keepAlive', params)
             } catch (e) {
-                logger.log(`failed to send keepalive for ${uri}`, e)
+                logger.log(`failed to send keepalive for ${uri}: ${e}`)
                 if (this.keepAliveInterval) clearInterval(this.keepAliveInterval)
             }
         }, keepAlivePeriodMs)

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -25,6 +25,7 @@ import { readLeanVersion } from './utils/projectInfo';
 import * as fs from 'fs';
 import { URL } from 'url';
 import { join } from 'path';
+import { logger } from './utils/logger'
  // @ts-ignore
 import { SemVer } from 'semver';
 import { fileExists, isFileInFolder } from './utils/fsHelper';
@@ -110,7 +111,7 @@ export class LeanClient implements Disposable {
     async restart(): Promise<void> {
         const startTime = Date.now()
 
-        console.log('Restarting Lean Language Server')
+        logger.log('Restarting Lean Language Server')
         if (this.isStarted()) {
             await this.stop()
         }
@@ -284,17 +285,17 @@ export class LeanClient implements Disposable {
             this.client.onDidChangeState(async (s) => {
                 // see https://github.com/microsoft/vscode-languageserver-node/issues/825
                 if (s.newState === State.Starting) {
-                    console.log('client starting');
+                    logger.log('client starting');
                 } else if (s.newState === State.Running) {
                     const end = Date.now()
-                    console.log('client running, started in ', end - startTime, 'ms');
+                    logger.log('client running, started in ', end - startTime, 'ms');
                     this.running = true; // may have been auto restarted after it failed.
                     if (!insideRestart) {
                         this.restartedEmitter.fire(undefined)
                     }
                 } else if (s.newState === State.Stopped) {
                     this.stoppedEmitter.fire('Lean language server has stopped. ');
-                    console.log('client has stopped or it failed to start');
+                    logger.log('client has stopped or it failed to start');
                     this.running = false;
                     if (!this.noPrompt){
                         await this.showRestartMessage();
@@ -414,7 +415,7 @@ export class LeanClient implements Disposable {
                 // this to throw an exception which then causes those tests to fail.
                 await this.client.stop();
             } catch (e) {
-                console.log(`Error stopping language client: ${e}`)
+                logger.log(`Error stopping language client: ${e}`)
             }
         }
 
@@ -511,7 +512,7 @@ export class LeanClient implements Disposable {
         const versionOptions = version ? ['+' + version, '--version'] : ['--version']
         const start = Date.now()
         const lakeVersion = await batchExecute(executable, versionOptions, this.folderUri?.fsPath, undefined);
-        console.log(`Ran '${executable} ${versionOptions.join(' ')}' in ${Date.now() - start} ms`);
+        logger.log(`Ran '${executable} ${versionOptions.join(' ')}' in ${Date.now() - start} ms`);
         const actual = this.extractVersion(lakeVersion)
         if (actual.compare('3.0.0') > 0) {
             return true;

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -288,7 +288,7 @@ export class LeanClient implements Disposable {
                     logger.log('client starting');
                 } else if (s.newState === State.Running) {
                     const end = Date.now()
-                    logger.log('client running, started in ', end - startTime, 'ms');
+                    logger.log(`client running, started in ', ${end - startTime} ms`);
                     this.running = true; // may have been auto restarted after it failed.
                     if (!insideRestart) {
                         this.restartedEmitter.fire(undefined)

--- a/vscode-lean4/src/utils/batch.ts
+++ b/vscode-lean4/src/utils/batch.ts
@@ -1,6 +1,7 @@
 import { OutputChannel } from 'vscode'
 import { spawn } from 'child_process';
 import { findProgramInPath } from '../config'
+import { logger } from './logger'
 
 export async function batchExecute(
     executablePath: string,
@@ -46,12 +47,12 @@ export async function batchExecute(
             });
 
             proc.on('close', (code) => {
-                console.log(`child process exited with code ${code}`);
+                logger.log(`child process exited with code ${code}`);
                 resolve(output)
             });
 
         } catch (e){
-            console.log(`error running ${executablePath} : ${e}`);
+            logger.log(`error running ${executablePath} : ${e}`);
             resolve(undefined);
         }
     });

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -7,6 +7,7 @@ import { LeanFileProgressProcessingInfo, RpcConnectParams, RpcKeepAliveParams } 
 import * as path from 'path';
 import { findLeanPackageRoot } from './projectInfo';
 import { isFileInFolder } from './fsHelper';
+import { logger } from './logger'
 
 // This class ensures we have one LeanClient per workspace folder.
 export class LeanClientProvider implements Disposable {
@@ -74,7 +75,7 @@ export class LeanClientProvider implements Disposable {
             const key = this.getKeyFromUri(uri);
             const path = uri.toString();
             if (this.testing.has(key)) {
-                console.log(`Blocking re-entrancy on ${path}`);
+                logger.log(`Blocking re-entrancy on ${path}`);
                 return;
             }
             // avoid re-entrancy since testLeanVersion can take a while.
@@ -90,10 +91,10 @@ export class LeanClientProvider implements Disposable {
                         await client.restart();
                     }
                 } else if (version.error) {
-                    console.log(`Lean version not ok: ${version.error}`);
+                    logger.log(`Lean version not ok: ${version.error}`);
                 }
             } catch (e) {
-                console.log(`Exception checking lean version: ${e}`);
+                logger.log(`Exception checking lean version: ${e}`);
             }
             this.testing.delete(key);
         });
@@ -164,7 +165,7 @@ export class LeanClientProvider implements Disposable {
                 await client.openLean4Document(document)
             }
         } catch (e) {
-            console.log(`### Error opening document: ${e}`);
+            logger.log(`### Error opening document: ${e}`);
         }
     }
 
@@ -243,7 +244,7 @@ export class LeanClientProvider implements Disposable {
         const cachedClient = (client !== undefined);
         if (!client && !this.pending.has(key)) {
             this.pending.set(key, true);
-            console.log('Creating LeanClient for ' + folderUri.toString());
+            logger.log('Creating LeanClient for ' + folderUri.toString());
 
             // We must create a Client before doing the long running testLeanVersion
             // so that ensureClient callers have an "optimistic" client to work with.
@@ -260,7 +261,7 @@ export class LeanClientProvider implements Disposable {
             }
             if (versionInfo && versionInfo.version && versionInfo.version !== '4') {
                 // ignore workspaces that belong to a different version of Lean.
-                console.log(`Lean4 extension ignoring workspace '${folderUri}' because it is not a Lean 4 workspace.`);
+                logger.log(`Lean4 extension ignoring workspace '${folderUri}' because it is not a Lean 4 workspace.`);
                 this.pending.delete(key);
                 this.clients.delete(key);
                 client.dispose();

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -6,6 +6,7 @@ import { readLeanVersion, findLeanPackageRoot, isCoreLean4Directory } from './pr
 import { join, dirname } from 'path';
 import { fileExists } from './fsHelper'
 import { addDefaultElanPath, getDefaultElanPath, addToolchainBinPath, isRunningTest, isElanDisabled } from '../config';
+import { logger } from './logger'
 
 export class LeanVersion {
     version: string;
@@ -148,7 +149,7 @@ export class LeanInstaller implements Disposable {
         if (!path ) path  = toolchainPath();
         if (isRunningTest()){
             // no prompt, just do it!
-            console.log('Installing Lean via Elan during testing')
+            logger.log('Installing Lean via Elan during testing')
             await this.installElan();
             if (isElanDisabled()) {
                 addToolchainBinPath(getDefaultElanPath());
@@ -188,7 +189,7 @@ export class LeanInstaller implements Disposable {
                 // this is a test codepath that short circuits the UI.
                 const selectedVersion = args as string;
                 let s = this.removeSuffix(selectedVersion);
-                console.log('selectToolchainForActiveEditor: ' + selectedVersion);
+                logger.log('selectToolchainForActiveEditor: ' + selectedVersion);
                 if (s === 'reset') {
                     s = '';
                 }
@@ -351,7 +352,7 @@ export class LeanInstaller implements Disposable {
             // Specifically, if the extension was not opened inside of a folder, it
             // looks for a global (default) installation of Lean. This way, we can support
             // single file editing.
-            console.log(`executeWithProgress ${cmd} ${options}`)
+            logger.log(`executeWithProgress ${cmd} ${options}`)
             const stdout = await this.executeWithProgress('Checking Lean setup...', cmd, options, folderPath)
             if (!stdout) {
                 result.error = 'lean not found'

--- a/vscode-lean4/src/utils/logger.ts
+++ b/vscode-lean4/src/utils/logger.ts
@@ -1,17 +1,16 @@
 import { Console } from 'console'
-const util = require('util');
 
 class Logger extends Console {
     constructor(stdout: NodeJS.WritableStream, stderr?: NodeJS.WritableStream) {
         super(stdout, stderr);
     }
 
-    log(...args : any) {
-        super.log(new Date().toLocaleTimeString(), '-', util.format(...args));
+    log(msg: string) {
+        super.log(new Date().toLocaleTimeString(), '-', msg);
     }
 
-    error(...args : any) {
-        super.error(new Date().toLocaleTimeString(), '-', util.format(...args));
+    error(msg: string) {
+        super.error(new Date().toLocaleTimeString(), '-', msg);
     }
 }
 

--- a/vscode-lean4/src/utils/logger.ts
+++ b/vscode-lean4/src/utils/logger.ts
@@ -1,0 +1,19 @@
+import { Console } from 'console'
+const util = require('util');
+
+class Logger extends Console {
+    constructor(stdout: NodeJS.WritableStream, stderr?: NodeJS.WritableStream) {
+        super(stdout, stderr);
+    }
+
+    log(...args : any) {
+        super.log(new Date().toLocaleTimeString(), '-', util.format(...args));
+    }
+
+    error(...args : any) {
+        super.error(new Date().toLocaleTimeString(), '-', util.format(...args));
+    }
+}
+
+const logger = new Logger(process.stdout, process.stderr);
+export { logger }

--- a/vscode-lean4/src/utils/logger.ts
+++ b/vscode-lean4/src/utils/logger.ts
@@ -5,12 +5,20 @@ class Logger extends Console {
         super(stdout, stderr);
     }
 
+    private static now(): string {
+		const now = new Date();
+		return String(now.getUTCHours()).padStart(2, '0')
+			+ ':' + String(now.getMinutes()).padStart(2, '0')
+			+ ':' + String(now.getUTCSeconds()).padStart(2, '0') + '.' +
+            String(now.getMilliseconds()).padStart(3, '0');
+    }
+
     log(msg: string) {
-        super.log(new Date().toLocaleTimeString(), '-', msg);
+        super.log(Logger.now(), '-', msg);
     }
 
     error(msg: string) {
-        super.error(new Date().toLocaleTimeString(), '-', msg);
+        super.error(Logger.now(), '-', msg);
     }
 }
 

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import { URL } from 'url';
 import { Uri, workspace, WorkspaceFolder } from 'vscode';
 import { fileExists } from './fsHelper';
+import { logger } from './logger'
 
 // Detect lean4 root directory (works for both lean4 repo and nightly distribution)
 
@@ -94,7 +95,7 @@ export async function findLeanPackageVersionInfo(uri: Uri) : Promise<[Uri | null
         try {
             version = await readLeanVersionFile(packageFileUri);
         } catch (err) {
-            console.log(err);
+            logger.log(err);
         }
     }
 

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -95,7 +95,7 @@ export async function findLeanPackageVersionInfo(uri: Uri) : Promise<[Uri | null
         try {
             version = await readLeanVersionFile(packageFileUri);
         } catch (err) {
-            logger.log(err);
+            logger.log(`findLeanPackageVersionInfo caught exception ${err}`);
         }
     }
 

--- a/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
+++ b/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
@@ -23,10 +23,10 @@ suite('Lean4 Bootstrap Test Suite', () => {
         assert(info, 'No InfoProvider export');
 
         // give it a extra long timeout in case test machine is really slow.
-        logger.log("Wait for elan install of Lean nightly build...")
+        logger.log('Wait for elan install of Lean nightly build...')
 		await waitForInfoviewHtml(info, '4.0.0-nightly-', 600);
 
-        logger.log("Lean installation is complete.")
+        logger.log('Lean installation is complete.')
 
         // make sure test is always run in predictable state, which is no file or folder open
         await closeAllEditors();
@@ -43,17 +43,17 @@ suite('Lean4 Bootstrap Test Suite', () => {
         const info = lean.exports.infoProvider;
         assert(info, 'No InfoProvider export');
 
-        logger.log("Wait for Lean nightly build server to start...")
+        logger.log('Wait for Lean nightly build server to start...')
 		await waitForInfoviewHtml(info, '4.0.0-nightly-', 60);
-        logger.log("Lean nightly build server is running.")
+        logger.log('Lean nightly build server is running.')
 
         // install table build which is also needed by subsequent tests.
-        logger.log("Wait for lean stable build to be installed...")
+        logger.log('Wait for lean stable build to be installed...')
 		await vscode.commands.executeCommand('lean4.selectToolchain', 'leanprover/lean4:stable');
 
         // give it a extra long timeout in case test machine is really slow.
 		await waitForInfoviewHtml(info, '4.0.0, commit', 600);
-        logger.log("Lean stable build is running.")
+        logger.log('Lean stable build is running.')
 		await vscode.commands.executeCommand('lean4.selectToolchain', 'reset');
 
         // make sure test is always run in predictable state, which is no file or folder open
@@ -66,13 +66,13 @@ suite('Lean4 Bootstrap Test Suite', () => {
         logger.log('=================== Create linked toolchain named master ===================');
         void vscode.window.showInformationMessage('Running tests: ' + __dirname);
 
-        logger.log("Create copy of nightly build in a temp master folder...")
+        logger.log('Create copy of nightly build in a temp master folder...')
         const elanRoot = getDefaultElanPath()
         const nightly = path.join(elanRoot, '..', 'toolchains', 'leanprover--lean4---nightly')
         const master = path.join(os.tmpdir(), 'lean4', 'toolchains', 'master')
         copyFolder(nightly, master);
 
-        logger.log("Use elan to link the master toolchain...")
+        logger.log('Use elan to link the master toolchain...')
         await batchExecute('elan', ['toolchain', 'link', 'master', master], null, undefined);
 
         // this will wait up to 60 seconds to do full elan lean install, so test machines better
@@ -81,14 +81,14 @@ suite('Lean4 Bootstrap Test Suite', () => {
         const info = lean.exports.infoProvider;
         assert(info, 'No InfoProvider export');
 
-        logger.log("Wait for stable lean server to start...")
+        logger.log('Wait for stable lean server to start...')
 		await vscode.commands.executeCommand('lean4.selectToolchain', 'leanprover/lean4:stable');
 		await assertStringInInfoview(info, '4.0.0, commit');
-        logger.log("Wait for master lean server to start...")
+        logger.log('Wait for master lean server to start...')
 		await vscode.commands.executeCommand('lean4.selectToolchain', 'master');
         // sometimes a copy of lean launches more slowly (especially on Windows).
         await waitForInfoviewHtml(info, '4.0.0-nightly-', 300);
-        logger.log("Linked master toolchain is running.")
+        logger.log('Linked master toolchain is running.')
 		await vscode.commands.executeCommand('lean4.selectToolchain', 'reset');
 
         // make sure test is always run in predictable state, which is no file or folder open

--- a/vscode-lean4/test/suite/docview/docview.test.ts
+++ b/vscode-lean4/test/suite/docview/docview.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import { suite } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { logger } from '../../../src/utils/logger'
 
 import { initLean4, waitForActiveEditor, waitForInfoviewHtml, closeAllEditors,
 	extractPhrase, waitForDocViewHtml, invokeHrefCommand } from '../utils/helpers';
@@ -14,7 +15,7 @@ suite('Documentation View Test Suite', () => {
 
     test('Documentation View Example Test', async () => {
         // This test opens the documentation view and selects the "Example" link.
-        console.log('=================== Documentation View Example Test ===================');
+        logger.log('=================== Documentation View Example Test ===================');
 
         void vscode.window.showInformationMessage('Running tests: ' + __dirname);
         const testsRoot = path.join(__dirname, '..', '..', '..', '..', 'test', 'test-fixtures', 'simple');
@@ -26,7 +27,7 @@ suite('Documentation View Test Suite', () => {
         const expectedVersion = 'Hello:';
         let html = await waitForInfoviewHtml(info, expectedVersion);
         const versionString = extractPhrase(html, 'Hello:', '<').trim();
-        console.log(`>>> Found "${versionString}" in infoview`)
+        logger.log(`>>> Found "${versionString}" in infoview`)
 
         await vscode.commands.executeCommand('lean4.docView.open');
 

--- a/vscode-lean4/test/suite/index/index.ts
+++ b/vscode-lean4/test/suite/index/index.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as Mocha from 'mocha';
 import * as glob from 'glob';
 import { isElanDisabled, getTestFolder } from '../../../src/config'
+import { logger } from '../../../src/utils/logger'
 
 export function run(testsRoot: string, cb: (error: any, failures?: number) => void): void {
     // Create the mocha test
@@ -17,10 +18,10 @@ export function run(testsRoot: string, cb: (error: any, failures?: number) => vo
     if (folder) {
         testsRoot = path.resolve(testsRoot, '..', folder)
     }
-    console.log('>>>>>>>>> testsRoot=' + testsRoot);
+    logger.log('>>>>>>>>> testsRoot=' + testsRoot);
 
     if (isElanDisabled()) {
-        console.log('>>>>>>>>> running without elan');
+        logger.log('>>>>>>>>> running without elan');
     }
 
     glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {

--- a/vscode-lean4/test/suite/info/info.test.ts
+++ b/vscode-lean4/test/suite/info/info.test.ts
@@ -4,12 +4,13 @@ import * as vscode from 'vscode';
 import { initLean4Untitled, assertStringInInfoview, findWord, insertText, closeActiveEditor,
     waitForInfoviewNotHtml, waitForActiveEditor, gotoDefinition, closeAllEditors, clickInfoViewButton,
     waitForInfoviewHtml } from '../utils/helpers';
+import { logger } from '../../../src/utils/logger'
 
 suite('InfoView Test Suite', () => {
 
     test('Copy to Comment', async () => {
 
-        console.log('=================== Copy to Comment ===================');
+        logger.log('=================== Copy to Comment ===================');
 
         const a = 37;
         const b = 22;
@@ -21,10 +22,10 @@ suite('InfoView Test Suite', () => {
 
         await assertStringInInfoview(info, expectedEval1);
 
-        console.log('Clicking copyToComment button in InfoView');
+        logger.log('Clicking copyToComment button in InfoView');
         await clickInfoViewButton(info, 'copy-to-comment');
 
-        console.log(`Checking editor contains ${expectedEval1}`)
+        logger.log(`Checking editor contains ${expectedEval1}`)
         const editor = vscode.window.activeTextEditor;
         assert(editor !== undefined, 'no active editor');
         await findWord(editor, expectedEval1);
@@ -35,7 +36,7 @@ suite('InfoView Test Suite', () => {
 
     test('Pinning and unpinning', async () => {
 
-        console.log('=================== Pinning and unpinning ===================');
+        logger.log('=================== Pinning and unpinning ===================');
 
         const a = 23;
         const b = 95;
@@ -49,23 +50,23 @@ suite('InfoView Test Suite', () => {
         const expectedEval1 = (a * b).toString()
         await assertStringInInfoview(info, expectedEval1);
 
-        console.log('Pin this info');
+        logger.log('Pin this info');
         await clickInfoViewButton(info, 'toggle-pinned');
 
-        console.log('Insert another couple lines and another eval')
+        logger.log('Insert another couple lines and another eval')
         await insertText(`\n\n/- add another unpinned eval -/\n#eval ${c}*${d}`)
 
-        console.log('wait for the new expression to appear')
+        logger.log('wait for the new expression to appear')
         const expectedEval2 = (c * d).toString()
         await assertStringInInfoview(info, expectedEval2);
 
-        console.log('make sure pinned expression is still there');
+        logger.log('make sure pinned expression is still there');
         await assertStringInInfoview(info, expectedEval1);
 
-        console.log('Unpin this info');
+        logger.log('Unpin this info');
         await clickInfoViewButton(info, 'toggle-pinned');
 
-        console.log('Make sure pinned eval is gone, but unpinned eval remains')
+        logger.log('Make sure pinned eval is gone, but unpinned eval remains')
         await waitForInfoviewNotHtml(info, expectedEval1);
         await assertStringInInfoview(info, expectedEval2);
 
@@ -74,7 +75,7 @@ suite('InfoView Test Suite', () => {
 
     test('Pin survives interesting edits', async () => {
 
-        console.log('=================== Pin survives interesting edits ===================');
+        logger.log('=================== Pin survives interesting edits ===================');
 
         const expectedEval = '[1, 2, 3]'
 
@@ -87,7 +88,7 @@ suite('InfoView Test Suite', () => {
         assert(info, 'No InfoProvider export');
         await waitForInfoviewHtml(info, expectedEval, 30, 1000, false);
 
-        console.log('Pin this info');
+        logger.log('Pin this info');
         await clickInfoViewButton(info, 'toggle-pinned');
 
         const firstEval = firstLine.start.with(undefined, 5)
@@ -97,18 +98,18 @@ suite('InfoView Test Suite', () => {
         const lastLine = editor.document.lineAt(5).range
         editor.selection = new vscode.Selection(lastLine.start, lastLine.start);
 
-        console.log('wait for the new expression to appear')
+        logger.log('wait for the new expression to appear')
         const expectedEval2 = '[4, 1, 2, 3]'
         await waitForInfoviewHtml(info, expectedEval2, 30, 1000, false);
 
-        console.log('make sure pinned expression is not showing an error');
+        logger.log('make sure pinned expression is not showing an error');
         await waitForInfoviewNotHtml(info, 'Incorrect position');
 
         await vscode.commands.executeCommand('undo');
         const newLastLine = editor.document.lineAt(1).range
         editor.selection = new vscode.Selection(newLastLine.start, newLastLine.start);
 
-        console.log('make sure pinned value reverts after an undo')
+        logger.log('make sure pinned value reverts after an undo')
         await waitForInfoviewHtml(info, expectedEval, 30, 1000, false);
 
         await closeAllEditors();
@@ -116,7 +117,7 @@ suite('InfoView Test Suite', () => {
 
     test('Pin survives file close', async () => {
 
-        console.log('=================== Pin survives file close ===================');
+        logger.log('=================== Pin survives file close ===================');
 
         const a = 23;
         const b = 95;
@@ -129,35 +130,35 @@ suite('InfoView Test Suite', () => {
         const expectedEval = (a * b).toString()
         await assertStringInInfoview(info, expectedEval);
 
-        console.log('Pin this info');
+        logger.log('Pin this info');
         await clickInfoViewButton(info, 'toggle-pinned');
 
-        console.log('Insert another eval')
+        logger.log('Insert another eval')
         await insertText('\n\n#eval s!"' + prefix + ': {Lean.versionString}"')
 
-        console.log('make sure output of versionString is also there');
+        logger.log('make sure output of versionString is also there');
         await assertStringInInfoview(info, prefix);
 
-        console.log('make sure pinned expression is not showing an error');
+        logger.log('make sure pinned expression is not showing an error');
         await waitForInfoviewNotHtml(info, 'Incorrect position');
 
-        console.log('and make sure pinned value is still there');
+        logger.log('and make sure pinned value is still there');
         await assertStringInInfoview(info, expectedEval);
 
-        console.log('Goto definition on versionString')
+        logger.log('Goto definition on versionString')
         let editor = await waitForActiveEditor();
 
         await gotoDefinition(editor, 'versionString');
         editor = await waitForActiveEditor('Meta.lean');
 
-        console.log('make sure pinned expression is still there');
+        logger.log('make sure pinned expression is still there');
         await assertStringInInfoview(info, expectedEval);
 
-        console.log('Close meta.lean');
+        logger.log('Close meta.lean');
         await closeActiveEditor();
         editor = await waitForActiveEditor('Untitled-1');
 
-        console.log('make sure pinned expression is still there');
+        logger.log('make sure pinned expression is still there');
         await assertStringInInfoview(info, expectedEval);
 
         await closeAllEditors();

--- a/vscode-lean4/test/suite/lean3/lean3.test.ts
+++ b/vscode-lean4/test/suite/lean3/lean3.test.ts
@@ -3,6 +3,7 @@ import { suite } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { waitForActiveExtension, waitForActiveEditor, closeAllEditors } from '../utils/helpers';
+import { logger } from '../../../src/utils/logger'
 
 suite('Lean3 Compatibility Test Suite', () => {
 
@@ -23,7 +24,7 @@ suite('Lean3 Compatibility Test Suite', () => {
         assert(lean, 'Lean extension not loaded');
         assert(!lean.exports.isLean4Project, 'Lean4 extension should not be running!');
 
-        console.log('Checking vscode commands...');
+        logger.log('Checking vscode commands...');
         const cmds = await vscode.commands.getCommands(true);
         cmds.forEach(cmd => {
             assert(cmd !== 'lean4.selectToolchain', 'Lean4 extension should not have any registered commands');

--- a/vscode-lean4/test/suite/multi/multi.test.ts
+++ b/vscode-lean4/test/suite/multi/multi.test.ts
@@ -1,8 +1,9 @@
 import * as assert from 'assert';
 import { suite } from 'mocha';
 import * as path from 'path';
+import * as fs from 'fs';
 import * as vscode from 'vscode';
-import { initLean4, assertStringInInfoview, closeAllEditors } from '../utils/helpers';
+import { initLean4, assertStringInInfoview, closeAllEditors, getAltBuildVersion } from '../utils/helpers';
 import { logger } from '../../../src/utils/logger'
 
 suite('Multi-Folder Test Suite', () => {
@@ -14,8 +15,8 @@ suite('Multi-Folder Test Suite', () => {
         await closeAllEditors();
         void vscode.window.showInformationMessage('Running tests: ' + __dirname);
 
-        const testsRoot = path.join(__dirname, '..', '..', '..', '..', 'test', 'test-fixtures', 'multi');
-        const lean = await initLean4(path.join(testsRoot, 'test', 'Main.lean'));
+        const multiRoot = path.join(__dirname, '..', '..', '..', '..', 'test', 'test-fixtures', 'multi');
+        const lean = await initLean4(path.join(multiRoot, 'test', 'Main.lean'));
 
         // verify we have a nightly build running in this folder.
         const info = lean.exports.infoProvider;
@@ -23,12 +24,13 @@ suite('Multi-Folder Test Suite', () => {
         await assertStringInInfoview(info, '4.0.0-nightly-');
 
         // Now open a file from the other project
-        const doc2 = await vscode.workspace.openTextDocument(path.join(testsRoot, 'foo', 'Foo.lean'));
+        const doc2 = await vscode.workspace.openTextDocument(path.join(multiRoot, 'foo', 'Foo.lean'));
+        const version = getAltBuildVersion();
         const options : vscode.TextDocumentShowOptions = { preview: false };
         await vscode.window.showTextDocument(doc2, options);
 
-        // verify that a different version of lean is running here (leanprover/lean4:stable)
-        await assertStringInInfoview(info, '4.0.0, commit');
+        logger.log(`wait for version ${version} to load...`);
+        await assertStringInInfoview(info, version);
 
         // Now verify we have 2 LeanClients running.
         const clients = lean.exports.clientProvider;

--- a/vscode-lean4/test/suite/multi/multi.test.ts
+++ b/vscode-lean4/test/suite/multi/multi.test.ts
@@ -3,12 +3,13 @@ import { suite } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { initLean4, assertStringInInfoview, closeAllEditors } from '../utils/helpers';
+import { logger } from '../../../src/utils/logger'
 
 suite('Multi-Folder Test Suite', () => {
 
     test('Load a multi-project workspace', async () => {
 
-        console.log('=================== Load Lean Files in a multi-project workspace ===================');
+        logger.log('=================== Load Lean Files in a multi-project workspace ===================');
         // make sure test is always run in predictable state, which is no file or folder open
         await closeAllEditors();
         void vscode.window.showInformationMessage('Running tests: ' + __dirname);

--- a/vscode-lean4/test/suite/runTest.ts
+++ b/vscode-lean4/test/suite/runTest.ts
@@ -1,16 +1,15 @@
 import * as path from 'path';
 import * as cp from 'child_process';
 
-console.log(__dirname);
-
 import { runTests, downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron';
 import * as fs from 'fs';
 import { DownloadArchitecture } from '@vscode/test-electron/out/download';
+import { logger } from '../../src/utils/logger'
 
 function clearUserWorkspaceData(vscodeTest: string) {
     const workspaceData = path.join(vscodeTest, 'user-data', 'Workspaces');
     fs.rmdir(workspaceData, { recursive: true }, (err) => {
-        console.log(`deleted user workspace data ${workspaceData} is deleted!`);
+        logger.log(`deleted user workspace data ${workspaceData} is deleted!`);
     });
 }
 

--- a/vscode-lean4/test/suite/simple/simple.test.ts
+++ b/vscode-lean4/test/suite/simple/simple.test.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import { isElanDisabled } from '../../../src/config'
 import { initLean4Untitled, waitForActiveEditor, waitForInfoviewHtml, closeAllEditors,
     extractPhrase, gotoDefinition, assertStringInInfoview, initLean4 } from '../utils/helpers';
+import { logger } from '../../../src/utils/logger'
 
 function getElanMode(){
     let mode = ''
@@ -18,7 +19,7 @@ suite('Lean4 Basics Test Suite', () => {
 
     test('Untitled Lean File', async () => {
 
-        console.log(`=================== Untitled Lean File ${getElanMode()} ===================`);
+        logger.log(`=================== Untitled Lean File ${getElanMode()} ===================`);
         void vscode.window.showInformationMessage('Running tests: ' + __dirname);
 
         const lean = await initLean4Untitled('#eval Lean.versionString');
@@ -61,7 +62,7 @@ suite('Lean4 Basics Test Suite', () => {
 
     test('Orphaned Lean File', async () => {
 
-        console.log(`=================== Orphaned Lean File ${getElanMode()} ===================`);
+        logger.log(`=================== Orphaned Lean File ${getElanMode()} ===================`);
         void vscode.window.showInformationMessage('Running tests: ' + __dirname);
 
         const testsRoot = path.join(__dirname, '..', '..', '..', '..', 'test', 'test-fixtures', 'orphan');
@@ -93,7 +94,7 @@ suite('Lean4 Basics Test Suite', () => {
     }).timeout(60000);
 
     test('Goto definition in a package folder', async () => {
-        console.log(`=================== Goto definition in a package folder  ${getElanMode()} ===================`);
+        logger.log(`=================== Goto definition in a package folder  ${getElanMode()} ===================`);
         void vscode.window.showInformationMessage('Running tests: ' + __dirname);
 
         // Test we can load file in a project folder from a package folder and also
@@ -111,7 +112,7 @@ suite('Lean4 Basics Test Suite', () => {
         let expectedVersion = 'Hello:';
         let html = await waitForInfoviewHtml(info, expectedVersion);
         const versionString = extractPhrase(html, 'Hello:', '<').trim();
-        console.log(`>>> Found "${versionString}" in infoview`)
+        logger.log(`>>> Found "${versionString}" in infoview`)
 
         const editor = await waitForActiveEditor();
         await gotoDefinition(editor, 'getLeanVersion');

--- a/vscode-lean4/test/suite/toolchains/toolchain.test.ts
+++ b/vscode-lean4/test/suite/toolchains/toolchain.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { initLean4Untitled, initLean4, waitForInfoviewHtml, closeAllEditors,
-	extractPhrase, restartLeanServer, assertStringInInfoview, resetToolchain } from '../utils/helpers';
+	extractPhrase, restartLeanServer, assertStringInInfoview, resetToolchain, getAltBuildVersion } from '../utils/helpers';
 import { logger } from '../../../src/utils/logger'
 
 // Expects to be launched with folder: ${workspaceFolder}/vscode-lean4/test/suite/simple
@@ -26,9 +26,9 @@ suite('Toolchain Test Suite', () => {
 		await assertStringInInfoview(info, '4.0.0-nightly-');
 
 		// Now switch toolchains (simple suite uses leanprover/lean4:nightly by default)
-		await vscode.commands.executeCommand('lean4.selectToolchain', 'leanprover/lean4:stable');
-
-		await assertStringInInfoview(info, '4.0.0, commit');
+		const version = getAltBuildVersion()
+		await vscode.commands.executeCommand('lean4.selectToolchain', `leanprover/lean4:${version}`);
+		await assertStringInInfoview(info, version);
 
 		await resetToolchain(lean.exports.clientProvider);
 
@@ -83,22 +83,23 @@ suite('Toolchain Test Suite', () => {
 		const info = lean.exports.infoProvider;
 		assert(info, 'No InfoProvider export');
 		const expectedVersion = '4.0.0-nightly-';
-		await waitForInfoviewHtml(info, expectedVersion);
+		const html = await waitForInfoviewHtml(info, expectedVersion);
+        const foundVersion = extractPhrase(html, expectedVersion, '\n')
 
 		await resetToolchain(lean.exports.clientProvider);
 
 		// Now switch toolchains (simple suite uses leanprover/lean4:nightly by default)
-		await vscode.commands.executeCommand('lean4.selectToolchain', 'leanprover/lean4:stable');
+		const version = getAltBuildVersion()
+		await vscode.commands.executeCommand('lean4.selectToolchain', `leanprover/lean4:${version}`);
 
-		// verify that we switched to leanprover/lean4:stable
-		const expected2 = '4.0.0, commit';
-		await waitForInfoviewHtml(info, expected2);
+		// verify that we switched to different version
+		await waitForInfoviewHtml(info, version);
 
 		// Now reset the toolchain back to nightly build.
 		await resetToolchain(lean.exports.clientProvider);
 
 		// Now make sure the reset works and we can go back to the previous nightly version.
-		await waitForInfoviewHtml(info, expectedVersion);
+		await waitForInfoviewHtml(info, foundVersion);
 
 		// make sure test is always run in predictable state, which is no file or folder open
 		await closeAllEditors();
@@ -126,36 +127,37 @@ suite('Toolchain Test Suite', () => {
 		await resetToolchain(lean.exports.clientProvider);
 
 		// verify we have a nightly build running in this folder.
-		await assertStringInInfoview(info, '4.0.0-nightly-');
+		const expectedVersion = '4.0.0-nightly-';
+		const html = await waitForInfoviewHtml(info, expectedVersion);
+        const foundVersion = extractPhrase(html, expectedVersion, '\n')
 
 		// Now edit the lean-toolchain file.
 		const toolchainFile = path.join(testsRoot, 'lean-toolchain');
 		const originalContents = fs.readFileSync(toolchainFile, 'utf8').toString();
 		assert(originalContents.trim() === 'leanprover/lean4:nightly');
-		// Switch to a stable version.
-		let expected = 'stable';
-		fs.writeFileSync(toolchainFile, 'leanprover/lean4:stable');
 
+		// Switch to a alternate version by editing the toolchain file
+		const version = getAltBuildVersion()
+		fs.writeFileSync(toolchainFile, `leanprover/lean4:${version}`);
 
 		try {
-			// verify that we switched to leanprover/lean4:stable
-			const html = await assertStringInInfoview(info, '4.0.0, commit');
+			// verify that we switched to alt version
+			const html = await assertStringInInfoview(info, version);
 
 			// check the path to lean.exe from the `eval IO.appPath`
 			const leanPath = extractPhrase(html, 'FilePath.mk', '<').trim();
 			logger.log(`Found LeanPath: ${leanPath}`)
-			assert(leanPath.indexOf(expected), `Lean Path does not contain: ${expected}`);
+			assert(leanPath.indexOf(version), `Lean Path does not contain: ${version}`);
 
-			// Find out if we have a 'master' toolchain (setup in our workflow: on-push.yml)
+			// Find out if we have a 'master' toolchain (setup by the bootstrap test)
 			// and use it if it is there
 			const toolChains = await installer.elanListToolChains(null);
 			const masterToolChain = toolChains.find(tc => tc === 'master');
 			if (masterToolChain) {
-				expected = 'master'
 				// Switch to a linked toolchain version (setup in our workflow: on-push.yml)
 				fs.writeFileSync(toolchainFile, masterToolChain);
 				// verify that we switched to the master toolchain.
-				await assertStringInInfoview(info, expected);
+				await assertStringInInfoview(info, 'master');
 			}
 
 		} finally {
@@ -164,7 +166,7 @@ suite('Toolchain Test Suite', () => {
 		}
 
 		// Now make sure the reset works and we can go back to the previous nightly version.
-		await assertStringInInfoview(info, '4.0.0-nightly-');
+		await assertStringInInfoview(info, foundVersion);
 
 		// make sure test is always run in predictable state, which is no file or folder open
 		await closeAllEditors();

--- a/vscode-lean4/test/suite/toolchains/toolchain.test.ts
+++ b/vscode-lean4/test/suite/toolchains/toolchain.test.ts
@@ -5,13 +5,14 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { initLean4Untitled, initLean4, waitForInfoviewHtml, closeAllEditors,
 	extractPhrase, restartLeanServer, assertStringInInfoview, resetToolchain } from '../utils/helpers';
+import { logger } from '../../../src/utils/logger'
 
 // Expects to be launched with folder: ${workspaceFolder}/vscode-lean4/test/suite/simple
 suite('Toolchain Test Suite', () => {
 
 	test('Untitled Select Toolchain', async () => {
 
-		console.log('=================== Untitled Select Toolchain ===================');
+		logger.log('=================== Untitled Select Toolchain ===================');
 		void vscode.window.showInformationMessage('Running tests: ' + __dirname);
 
 		const lean = await initLean4Untitled('#eval Lean.versionString');
@@ -38,7 +39,7 @@ suite('Toolchain Test Suite', () => {
 
 	test('Restart Server', async () => {
 
-		console.log('=================== Test Restart Server ===================');
+		logger.log('=================== Test Restart Server ===================');
 		void vscode.window.showInformationMessage('Running tests: ' + __dirname);
 
 		// Test we can restart the lean server
@@ -54,7 +55,7 @@ suite('Toolchain Test Suite', () => {
 			const expectedVersion = 'Hello:';
 			const html = await waitForInfoviewHtml(info, expectedVersion);
 			const versionString = extractPhrase(html, 'Hello:', '<').trim();
-			console.log(`>>> Found "${versionString}" in infoview`);
+			logger.log(`>>> Found "${versionString}" in infoview`);
 
 			// Now invoke the restart server command
 			const clients = lean.exports.clientProvider;
@@ -72,7 +73,7 @@ suite('Toolchain Test Suite', () => {
 	}).timeout(60000);
 
 	test('Select toolchain', async () => {
-		console.log('=================== Test select toolchain ===================');
+		logger.log('=================== Test select toolchain ===================');
 		void vscode.window.showInformationMessage('Running tests: ' + __dirname);
 
         const testsRoot = path.join(__dirname, '..', '..', '..', '..', 'test', 'test-fixtures', 'simple');
@@ -105,7 +106,7 @@ suite('Toolchain Test Suite', () => {
 
 	test('Edit lean-toolchain version', async () => {
 
-		console.log('=================== Test lean-toolchain edits ===================');
+		logger.log('=================== Test lean-toolchain edits ===================');
 
         const testsRoot = path.join(__dirname, '..', '..', '..', '..', 'test', 'test-fixtures', 'simple');
 
@@ -142,7 +143,7 @@ suite('Toolchain Test Suite', () => {
 
 			// check the path to lean.exe from the `eval IO.appPath`
 			const leanPath = extractPhrase(html, 'FilePath.mk', '<').trim();
-			console.log(`Found LeanPath: ${leanPath}`)
+			logger.log(`Found LeanPath: ${leanPath}`)
 			assert(leanPath.indexOf(expected), `Lean Path does not contain: ${expected}`);
 
 			// Find out if we have a 'master' toolchain (setup in our workflow: on-push.yml)

--- a/vscode-lean4/test/suite/utils/helpers.ts
+++ b/vscode-lean4/test/suite/utils/helpers.ts
@@ -261,9 +261,9 @@ export function extractPhrase(html: string, word: string, terminator: string){
     const pos = html.indexOf(word);
     if (pos >= 0){
         let endPos = html.indexOf(terminator, pos);
-        if (endPos < 0) {
-            endPos = html.indexOf('\n', pos);
-            return ''
+        const eolPos = html.indexOf('\n', pos);
+        if (eolPos > 0 && eolPos < endPos){
+            endPos = eolPos;
         }
         return html.substring(pos, endPos);
     }
@@ -410,4 +410,11 @@ export function copyFolder(source: string, target: string) {
             copyFolder(sourceFile, targetFile);
         }
     }
+}
+
+export function getAltBuildVersion(){
+    const testsRoot = path.join(__dirname, '..', '..', '..', '..', 'test');
+    const multiFoo = path.join(testsRoot, 'test-fixtures', 'multi', 'foo');
+    const toolchain = fs.readFileSync(path.join(multiFoo, 'lean-toolchain'), 'utf8').toString();
+    return toolchain.trim().split(':')[1];
 }

--- a/vscode-lean4/test/suite/utils/helpers.ts
+++ b/vscode-lean4/test/suite/utils/helpers.ts
@@ -9,6 +9,7 @@ import { LeanClientProvider } from '../../../src/utils/clientProvider'
 import { Exports } from '../../../src/exports';
 import cheerio = require('cheerio');
 import path = require('path');
+import { logger } from '../../../src/utils/logger'
 
 export function sleep(ms : number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -34,7 +35,7 @@ export async function initLean4(fileName: string) : Promise<vscode.Extension<Exp
     assert(lean, 'Lean extension not loaded');
     assert(lean.exports.isLean4Project);
     assert(lean.isActive);
-    console.log(`Found lean package version: ${lean.packageJSON.version}`);
+    logger.log(`Found lean package version: ${lean.packageJSON.version}`);
     await waitForActiveEditor(basename(fileName));
 
     const info = lean.exports.infoProvider;
@@ -64,7 +65,7 @@ export async function initLean4Untitled(contents: string) : Promise<vscode.Exten
 
     const editor = await waitForActiveEditor();
     // make it a lean4 document even though it is empty and untitled.
-    console.log('Setting lean4 language on untitled doc');
+    logger.log('Setting lean4 language on untitled doc');
     await vscode.languages.setTextDocumentLanguage(editor.document, 'lean4');
 
     await editor.edit((builder) => {
@@ -74,7 +75,7 @@ export async function initLean4Untitled(contents: string) : Promise<vscode.Exten
     const lean = await waitForActiveExtension('leanprover.lean4', 60);
     assert(lean, 'Lean extension not loaded');
 
-    console.log(`Found lean package version: ${lean.packageJSON.version}`);
+    logger.log(`Found lean package version: ${lean.packageJSON.version}`);
     const info = lean.exports.infoProvider;
 	assert(info, 'No InfoProvider export');
 
@@ -123,14 +124,14 @@ export async function resetToolchain(clientProvider: LeanClientProvider | undefi
 
 export async function waitForActiveExtension(extensionId: string, retries=30, delay=1000) : Promise<vscode.Extension<Exports> | null> {
 
-    console.log(`Waiting for extension ${extensionId} to be loaded...`);
+    logger.log(`Waiting for extension ${extensionId} to be loaded...`);
     let lean : vscode.Extension<Exports> | undefined;
     let count = 0;
     while (!lean) {
         vscode.extensions.all.forEach((e) => {
             if (e.id === extensionId){
                 lean = e;
-                console.log(`Found extension: ${extensionId}`);
+                logger.log(`Found extension: ${extensionId}`);
             }
         });
         if (!lean){
@@ -142,14 +143,14 @@ export async function waitForActiveExtension(extensionId: string, retries=30, de
         }
     }
 
-    console.log(`Waiting for extension ${extensionId} activation...`);
+    logger.log(`Waiting for extension ${extensionId} activation...`);
     count = 0
     while (!lean.isActive && count < retries){
         await sleep(delay);
         count += 1;
     }
 
-    console.log(`Extension ${extensionId} isActive=${lean.isActive}`);
+    logger.log(`Extension ${extensionId} isActive=${lean.isActive}`);
     return lean;
 }
 
@@ -162,7 +163,7 @@ export async function waitForActiveEditor(filename='', retries=30, delay=1000) :
     let editor = vscode.window.activeTextEditor
     assert(editor, 'Missing active text editor');
 
-    console.log(`Loaded document ${editor.document.uri}`);
+    logger.log(`Loaded document ${editor.document.uri}`);
 
     if (filename) {
         count = 0;
@@ -180,11 +181,11 @@ export async function waitForActiveEditor(filename='', retries=30, delay=1000) :
 export async function waitForInfoViewOpen(infoView: InfoProvider, retries=30, delay=1000) : Promise<boolean> {
     let count = 0;
     let opened = false;
-    console.log('Waiting for InfoView...');
+    logger.log('Waiting for InfoView...');
     while (count < retries){
         const isOpen = infoView.isOpen();
         if (isOpen) {
-            console.log('InfoView is open.');
+            logger.log('InfoView is open.');
             return true;
         } else if (!opened) {
             opened = true;
@@ -194,7 +195,7 @@ export async function waitForInfoViewOpen(infoView: InfoProvider, retries=30, de
         count += 1;
     }
 
-    console.log('InfoView not found.');
+    logger.log('InfoView not found.');
     return false;
 }
 
@@ -213,8 +214,8 @@ export async function waitForInfoviewHtml(infoView: InfoProvider, toFind : strin
         count += 1;
     }
 
-    console.log(`>>> infoview missing "${toFind}"`);
-    console.log(html);
+    logger.log(`>>> infoview missing "${toFind}"`);
+    logger.log(html);
     assert(false, `Missing "${toFind}" in infoview`);
 }
 
@@ -233,8 +234,8 @@ export async function waitForInfoviewNotHtml(infoView: InfoProvider, toFind : st
         count += 1;
     }
 
-    console.log(`>>> infoview still contains "${toFind}"`);
-    console.log(html);
+    logger.log(`>>> infoview still contains "${toFind}"`);
+    logger.log(html);
     assert(false, `Text "${toFind}" in infoview is not going away`);
 }
 
@@ -250,8 +251,8 @@ export async function waitForDocViewHtml(docView: DocViewProvider, toFind : stri
         count += 1;
     }
 
-    console.log('>>> docview contents:')
-    console.log(html);
+    logger.log('>>> docview contents:')
+    logger.log(html);
     assert(false, `Missing "${toFind}" in docview`);
     return html;
 }
@@ -298,7 +299,7 @@ export async function gotoDefinition(editor: vscode.TextEditor, word: string, re
 
 export async function restartLeanServer(client: LeanClient, retries=30, delay=1000) : Promise<boolean> {
     let count = 0;
-    console.log('restarting lean client ...');
+    logger.log('restarting lean client ...');
 
     const stateChanges : string[] = []
     client.stopped(() => { stateChanges.push('stopped'); });
@@ -320,7 +321,7 @@ export async function restartLeanServer(client: LeanClient, retries=30, delay=10
     const actual = stateChanges.toString();
     const expected = 'stopped,restarted'
     if (actual !== expected) {
-        console.log(`restartServer did not produce expected result: ${actual}`);
+        logger.log(`restartServer did not produce expected result: ${actual}`);
     }
     assert(actual === expected);
     return false;
@@ -343,7 +344,7 @@ export async function invokeHrefCommand(html: string, selector: string) : Promis
             const cmd = href.slice(prefix.length);
             const uri = vscode.Uri.parse(cmd);
             const query = decodeURIComponent(uri.query);
-            console.log(`Opening file : ${query}`);
+            logger.log(`Opening file : ${query}`);
             const args = JSON.parse(query);
             let arg : string = ''
             if (Array.isArray(args)){
@@ -366,11 +367,11 @@ export async function clickInfoViewButton(info: InfoProvider, name: string) : Pr
             const cmd = `document.querySelector(\'[data-id*="${name}"]\').click()`;
             await info.runTestScript(cmd);
         } catch (err){
-            console.log(`### runTestScript failed: ${err.message}`);
+            logger.log(`### runTestScript failed: ${err.message}`);
             if (retries === 0){
                 throw err;
             }
-            console.log(`### Retrying clickInfoViewButton ${name}...`)
+            logger.log(`### Retrying clickInfoViewButton ${name}...`)
             await sleep(1000);
         }
     }

--- a/vscode-lean4/test/suite/utils/helpers.ts
+++ b/vscode-lean4/test/suite/utils/helpers.ts
@@ -122,7 +122,7 @@ export async function resetToolchain(clientProvider: LeanClientProvider | undefi
     }
 }
 
-export async function waitForActiveExtension(extensionId: string, retries=30, delay=1000) : Promise<vscode.Extension<Exports> | null> {
+export async function waitForActiveExtension(extensionId: string, retries=60, delay=1000) : Promise<vscode.Extension<Exports> | null> {
 
     logger.log(`Waiting for extension ${extensionId} to be loaded...`);
     let lean : vscode.Extension<Exports> | undefined;
@@ -154,7 +154,7 @@ export async function waitForActiveExtension(extensionId: string, retries=30, de
     return lean;
 }
 
-export async function waitForActiveEditor(filename='', retries=30, delay=1000) : Promise<vscode.TextEditor> {
+export async function waitForActiveEditor(filename='', retries=60, delay=1000) : Promise<vscode.TextEditor> {
     let count = 0;
     while (!vscode.window.activeTextEditor && count < retries){
         await sleep(delay);
@@ -178,7 +178,7 @@ export async function waitForActiveEditor(filename='', retries=30, delay=1000) :
     return editor;
 }
 
-export async function waitForInfoViewOpen(infoView: InfoProvider, retries=30, delay=1000) : Promise<boolean> {
+export async function waitForInfoViewOpen(infoView: InfoProvider, retries=60, delay=1000) : Promise<boolean> {
     let count = 0;
     let opened = false;
     logger.log('Waiting for InfoView...');
@@ -199,7 +199,7 @@ export async function waitForInfoViewOpen(infoView: InfoProvider, retries=30, de
     return false;
 }
 
-export async function waitForInfoviewHtml(infoView: InfoProvider, toFind : string, retries=30, delay=1000, expand=true): Promise<string> {
+export async function waitForInfoviewHtml(infoView: InfoProvider, toFind : string, retries=60, delay=1000, expand=true): Promise<string> {
     let count = 0;
     let html = '';
     while (count < retries){
@@ -219,7 +219,7 @@ export async function waitForInfoviewHtml(infoView: InfoProvider, toFind : strin
     assert(false, `Missing "${toFind}" in infoview`);
 }
 
-export async function waitForInfoviewNotHtml(infoView: InfoProvider, toFind : string, retries=30, delay=1000, collapse=true): Promise<void> {
+export async function waitForInfoviewNotHtml(infoView: InfoProvider, toFind : string, retries=60, delay=1000, collapse=true): Promise<void> {
     let count = 0;
     let html = '';
     while (count < retries){
@@ -239,7 +239,7 @@ export async function waitForInfoviewNotHtml(infoView: InfoProvider, toFind : st
     assert(false, `Text "${toFind}" in infoview is not going away`);
 }
 
-export async function waitForDocViewHtml(docView: DocViewProvider, toFind : string, retries=30, delay=1000): Promise<string> {
+export async function waitForDocViewHtml(docView: DocViewProvider, toFind : string, retries=60, delay=1000): Promise<string> {
     let count = 0;
     let html = '';
     while (count < retries){
@@ -270,7 +270,7 @@ export function extractPhrase(html: string, word: string, terminator: string){
     return '';
 }
 
-export async function findWord(editor: vscode.TextEditor, word: string, retries=30, delay=1000) : Promise<vscode.Range> {
+export async function findWord(editor: vscode.TextEditor, word: string, retries=60, delay=1000) : Promise<vscode.Range> {
     let count = 0;
     while (retries > 0) {
             const text = editor.document.getText();
@@ -286,7 +286,7 @@ export async function findWord(editor: vscode.TextEditor, word: string, retries=
     assert(false, `word ${word} not found in editor`);
 }
 
-export async function gotoDefinition(editor: vscode.TextEditor, word: string, retries=30, delay=1000) : Promise<void> {
+export async function gotoDefinition(editor: vscode.TextEditor, word: string, retries=60, delay=1000) : Promise<void> {
     const wordRange = await findWord(editor, word, retries, delay);
 
     // The -1 is to workaround a bug in goto definition.
@@ -297,7 +297,7 @@ export async function gotoDefinition(editor: vscode.TextEditor, word: string, re
     await vscode.commands.executeCommand('editor.action.revealDefinition');
 }
 
-export async function restartLeanServer(client: LeanClient, retries=30, delay=1000) : Promise<boolean> {
+export async function restartLeanServer(client: LeanClient, retries=60, delay=1000) : Promise<boolean> {
     let count = 0;
     logger.log('restarting lean client ...');
 

--- a/vscode-lean4/test/test-fixtures/multi/foo/lakefile.lean
+++ b/vscode-lean4/test/test-fixtures/multi/foo/lakefile.lean
@@ -1,6 +1,16 @@
 import Lake
 open Lake DSL
 
-package Foo {
+package foo {
   -- add configuration options here
+}
+
+
+lean_lib Foo {
+  -- add library configuration options here
+}
+
+@[defaultTarget]
+lean_exe foo {
+  root := `Main
 }

--- a/vscode-lean4/test/test-fixtures/multi/foo/lean-toolchain
+++ b/vscode-lean4/test/test-fixtures/multi/foo/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:stable
+leanprover/lean4:nightly-2022-07-03

--- a/vscode-lean4/test/test-fixtures/multi/test/lakefile.lean
+++ b/vscode-lean4/test/test-fixtures/multi/test/lakefile.lean
@@ -1,6 +1,16 @@
 import Lake
 open Lake DSL
 
-package Test {
+package test {
   -- add configuration options here
+}
+
+
+lean_lib Test {
+  -- add library configuration options here
+}
+
+@[defaultTarget]
+lean_exe test {
+  root := `Main
 }

--- a/vscode-lean4/test/test-fixtures/multi/test/lakefile.lean
+++ b/vscode-lean4/test/test-fixtures/multi/test/lakefile.lean
@@ -1,6 +1,15 @@
 import Lake
 open Lake DSL
 
-package Test {
-  -- add configuration options here
+package test {
+  -- add package configuration options here
+}
+
+lean_lib Test {
+  -- add library configuration options here
+}
+
+@[defaultTarget]
+lean_exe test {
+  root := `Main
 }

--- a/vscode-lean4/test/test-fixtures/multi/test/lakefile.lean
+++ b/vscode-lean4/test/test-fixtures/multi/test/lakefile.lean
@@ -1,15 +1,6 @@
 import Lake
 open Lake DSL
 
-package test {
-  -- add package configuration options here
-}
-
-lean_lib Test {
-  -- add library configuration options here
-}
-
-@[defaultTarget]
-lean_exe test {
-  root := `Main
+package Test {
+  -- add configuration options here
 }

--- a/vscode-lean4/test/test-fixtures/simple/lakefile.lean
+++ b/vscode-lean4/test/test-fixtures/simple/lakefile.lean
@@ -4,3 +4,13 @@ open Lake DSL
 package test {
   -- add configuration options here
 }
+
+
+lean_lib Test {
+  -- add library configuration options here
+}
+
+@[defaultTarget]
+lean_exe test {
+  root := `Main
+}

--- a/vscode-lean4/test/test-fixtures/simple/lakefile.lean
+++ b/vscode-lean4/test/test-fixtures/simple/lakefile.lean
@@ -2,14 +2,5 @@ import Lake
 open Lake DSL
 
 package test {
-  -- add package configuration options here
-}
-
-lean_lib Test {
-  -- add library configuration options here
-}
-
-@[defaultTarget]
-lean_exe test {
-  root := `Main
+  -- add configuration options here
 }

--- a/vscode-lean4/test/test-fixtures/simple/lakefile.lean
+++ b/vscode-lean4/test/test-fixtures/simple/lakefile.lean
@@ -2,5 +2,14 @@ import Lake
 open Lake DSL
 
 package test {
-  -- add configuration options here
+  -- add package configuration options here
+}
+
+lean_lib Test {
+  -- add library configuration options here
+}
+
+@[defaultTarget]
+lean_exe test {
+  root := `Main
 }


### PR DESCRIPTION
This makes it easier to monitor relative performance and timeouts in our tests.