### PR TITLE
test: update lakefile format

### DIFF
--- a/vscode-lean4/test/test-fixtures/multi/test/lakefile.lean
+++ b/vscode-lean4/test/test-fixtures/multi/test/lakefile.lean
@@ -1,6 +1,16 @@
 import Lake
 open Lake DSL
 
-package Test {
+package test {
   -- add configuration options here
+}
+
+
+lean_lib Test {
+  -- add library configuration options here
+}
+
+@[defaultTarget]
+lean_exe test {
+  root := `Main
 }

--- a/vscode-lean4/test/test-fixtures/simple/lakefile.lean
+++ b/vscode-lean4/test/test-fixtures/simple/lakefile.lean
@@ -4,3 +4,13 @@ open Lake DSL
 package test {
   -- add configuration options here
 }
+
+
+lean_lib Test {
+  -- add library configuration options here
+}
+
+@[defaultTarget]
+lean_exe test {
+  root := `Main
+}


### PR DESCRIPTION
Update to new lakefile format in some test-fixtures.

PS: Very interesting that this update causes the toolchain test to fail.  Lean is no longer responding properly when lean-toolchain file is edited...

Notice that `await this.client.onReady();` is never returning after 'lean4.selectToolchain', 'leanprover/lean4:stable' - probably because the stable version can't handle this updated lake file format?