### PR TITLE
feat: configurable output autofocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This extension contributes the following settings (for a complete list, open the
 
 ### Server settings
 
-* `lean4.toolchainPath`: specifies the location  of the Lean toolchain to be used when starting the Lean language server. Most users (i.e. those using `elan`) should not ever need to change this. If you are bundling Lean and `vscode-lean` with [Portable mode VS Code](https://code.visualstudio.com/docs/editor/portable), you might find it useful to specify a relative path to Lean. This can be done by starting this setting string with `%extensionPath%`; the extension will replace this with the absolute path of the extension folder. For example, with the default directory setup in Portable mode, `%extensionPath%/../../../lean` will point to `lean` in the same folder as the VS Code executable / application.
+* `lean4.toolchainPath`: specifies the location of the Lean toolchain to be used when starting the Lean language server. Most users (i.e. those using `elan`) should not ever need to change this. If you are bundling Lean and `vscode-lean` with [Portable mode VS Code](https://code.visualstudio.com/docs/editor/portable), you might find it useful to specify a relative path to Lean. This can be done by starting this setting string with `%extensionPath%`; the extension will replace this with the absolute path of the extension folder. For example, with the default directory setup in Portable mode, `%extensionPath%/../../../lean` will point to `lean` in the same folder as the VS Code executable / application.
 
 * `lean4.lakePath`: specifies the location of the Lake executable to be used when starting the Lean language server (when possible). If left unspecified, the extension defaults to the Lake executable bundled with the Lean toolchain. Most users thus do not need to use this setting. It is only really helpful if you are building a Lake executable from the source and wish to use it with this extension.
 
@@ -172,6 +172,8 @@ commands sent to the Lean 4 language server. The default is `false`.
 
 * `lean4.serverLogging.path`: if `serverLogging.enabled` is true this provides the
 name of the relative path to the store the logs.
+
+* `lean4.autofocusOutput`: if `true`, automatically show the Output panel when the Lean 4 server prints a new message.
 
 ### Input / editing settings
 

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -115,6 +115,11 @@
 					"description": "Path to the directory where Lean 4 server log files are stored.",
 					"scope": "machine-overridable"
 				},
+				"lean4.autofocusOutput": {
+					"type": "boolean",
+					"default": false,
+					"description": "Automatically show the Output panel when the Lean 4 server prints a new message."
+				},
 				"lean4.infoViewAllErrorsOnLine": {
 					"type": "boolean",
 					"default": true,

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -162,7 +162,7 @@ export function serverLoggingPath(): string {
     return workspace.getConfiguration('lean4.serverLogging').get('path', '.')
 }
 
-export function autofocusOutput(): boolean {
+export function shouldAutofocusOutput(): boolean {
     return workspace.getConfiguration('lean4').get('autofocusOutput', false)
 }
 

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -162,6 +162,10 @@ export function serverLoggingPath(): string {
     return workspace.getConfiguration('lean4.serverLogging').get('path', '.')
 }
 
+export function autofocusOutput(): boolean {
+    return workspace.getConfiguration('lean4').get('autofocusOutput', false)
+}
+
 export function getInfoViewStyle(): string {
     return workspace.getConfiguration('lean4').get('infoViewStyle', '');
 }

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -16,7 +16,7 @@ import {
 } from 'vscode-languageclient/node'
 import * as ls from 'vscode-languageserver-protocol'
 
-import { toolchainPath, lakePath, addServerEnvPaths, serverArgs, serverLoggingEnabled, serverLoggingPath, getElaborationDelay, lakeEnabled } from './config'
+import { toolchainPath, lakePath, addServerEnvPaths, serverArgs, serverLoggingEnabled, serverLoggingPath, autofocusOutput, getElaborationDelay, lakeEnabled } from './config'
 import { assert } from './utils/assert'
 import { LeanFileProgressParams, LeanFileProgressProcessingInfo } from '@leanprover/infoview-api';
 import { LocalStorageService} from './utils/localStorage'
@@ -340,7 +340,7 @@ export class LeanClient implements Disposable {
         // Reveal the standard error output channel when the server prints something to stderr.
         // The vscode-languageclient library already takes care of writing it to the output channel.
         (this.client as any)._serverProcess.stderr.on('data', () => {
-            this.client?.outputChannel.show(true);
+            if (autofocusOutput()) this.client?.outputChannel.show(true);
         });
 
         this.restartedEmitter.fire(undefined)

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -16,7 +16,7 @@ import {
 } from 'vscode-languageclient/node'
 import * as ls from 'vscode-languageserver-protocol'
 
-import { toolchainPath, lakePath, addServerEnvPaths, serverArgs, serverLoggingEnabled, serverLoggingPath, autofocusOutput, getElaborationDelay, lakeEnabled } from './config'
+import { toolchainPath, lakePath, addServerEnvPaths, serverArgs, serverLoggingEnabled, serverLoggingPath, shouldAutofocusOutput, getElaborationDelay, lakeEnabled } from './config'
 import { assert } from './utils/assert'
 import { LeanFileProgressParams, LeanFileProgressProcessingInfo } from '@leanprover/infoview-api';
 import { LocalStorageService} from './utils/localStorage'
@@ -340,7 +340,7 @@ export class LeanClient implements Disposable {
         // Reveal the standard error output channel when the server prints something to stderr.
         // The vscode-languageclient library already takes care of writing it to the output channel.
         (this.client as any)._serverProcess.stderr.on('data', () => {
-            if (autofocusOutput()) this.client?.outputChannel.show(true);
+            if (shouldAutofocusOutput()) this.client?.outputChannel.show(true);
         });
 
         this.restartedEmitter.fire(undefined)


### PR DESCRIPTION
As discussed in [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/VSCode.20Disable.20Output.20auto-focus/near/291145653), this PR makes the extension's behavior of automatically focusing the Output panel on new messages configurable by the user. I also defaulted the option to `false`, because as @Vtec234 [mentions](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/VSCode.20Disable.20Output.20auto-focus/near/291236099), this feature is generally undesired and primarily useful when debugging the server (which should be rare).