### PR TITLE
fix: Failed to start language server: popup is too generic

### DIFF
--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -166,7 +166,10 @@ export class LeanInstaller implements Disposable {
         } else {
             const outputItem = 'Go to output';
             const outPrompt = 'See output window for more information';
-            window.showErrorMessage(outPrompt, outputItem)
+            const outItem = await window.showErrorMessage(outPrompt, outputItem)
+            if (outItem === outputItem) {
+                this.outputChannel.show(true);
+            }
         }
         const item = await window.showErrorMessage(prompt, installItem, selectItem)
         if (item === installItem) {

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -155,14 +155,14 @@ export class LeanInstaller implements Disposable {
         // user changes the Lean: Executable Path.
         const installItem = 'Install Lean using Elan';
         const selectItem = 'Select Lean Toolchain';
-        const outputItem = 'Go to output';
         let prompt = 'Failed to start \'lean\' language server'
         if (path){
             prompt += ` from ${path}`
         }
 
         this.promptingInstallEmitter.fire(uri);
-        const item = await window.showErrorMessage(prompt, installItem, selectItem, outputItem)
+        this.outputChannel.show(true);
+        const item = await window.showErrorMessage(prompt, installItem, selectItem)
         if (item === installItem) {
             try {
                 const result = await this.installElan();
@@ -172,8 +172,6 @@ export class LeanInstaller implements Disposable {
             }
         } else if (item === selectItem){
             void this.selectToolchain(uri);
-        } else if (item === outputItem) {
-            this.outputChannel.show(true);
         }
     }
 

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -155,7 +155,7 @@ export class LeanInstaller implements Disposable {
         // user changes the Lean: Executable Path.
         const installItem = 'Install Lean using Elan';
         const selectItem = 'Select Lean Toolchain';
-        const outputItem = 'See the output';
+        const outputItem = 'Go to output';
         let prompt = 'Failed to start \'lean\' language server'
         if (path){
             prompt += ` from ${path}`

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -155,13 +155,14 @@ export class LeanInstaller implements Disposable {
         // user changes the Lean: Executable Path.
         const installItem = 'Install Lean using Elan';
         const selectItem = 'Select Lean Toolchain';
+        const outputItem = 'See the output';
         let prompt = 'Failed to start \'lean\' language server'
         if (path){
             prompt += ` from ${path}`
         }
 
         this.promptingInstallEmitter.fire(uri);
-        const item = await window.showErrorMessage(prompt, installItem, selectItem)
+        const item = await window.showErrorMessage(prompt, installItem, selectItem, outputItem)
         if (item === installItem) {
             try {
                 const result = await this.installElan();
@@ -171,6 +172,8 @@ export class LeanInstaller implements Disposable {
             }
         } else if (item === selectItem){
             void this.selectToolchain(uri);
+        } else if (item == outputItem) {
+            this.outputChannel.show(true);
         }
     }
 

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -172,7 +172,7 @@ export class LeanInstaller implements Disposable {
             }
         } else if (item === selectItem){
             void this.selectToolchain(uri);
-        } else if (item == outputItem) {
+        } else if (item === outputItem) {
             this.outputChannel.show(true);
         }
     }

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -1,5 +1,5 @@
 import { window, TerminalOptions, OutputChannel, commands, Disposable, EventEmitter, ProgressLocation, Uri } from 'vscode'
-import { toolchainPath, addServerEnvPaths, getLeanExecutableName, getPowerShellPath } from '../config'
+import { toolchainPath, addServerEnvPaths, getLeanExecutableName, getPowerShellPath, shouldAutofocusOutput } from '../config'
 import { batchExecute } from './batch'
 import { LocalStorageService} from './localStorage'
 import { readLeanVersion, findLeanPackageRoot, isCoreLean4Directory } from './projectInfo';
@@ -161,7 +161,13 @@ export class LeanInstaller implements Disposable {
         }
 
         this.promptingInstallEmitter.fire(uri);
-        this.outputChannel.show(true);
+        if (shouldAutofocusOutput()) {
+            this.outputChannel.show(true);
+        } else {
+            const outputItem = 'Go to output';
+            const outPrompt = 'See output window for more information';
+            window.showErrorMessage(outPrompt, outputItem)
+        }
         const item = await window.showErrorMessage(prompt, installItem, selectItem)
         if (item === installItem) {
             try {


### PR DESCRIPTION
This fix adds a button to see the output (it redirects you to the output section inside VSCode)  to know the problem when restarting the server. Issue #181 
Before:

![image](https://user-images.githubusercontent.com/40707114/181647347-3c9e704a-2e09-4952-994e-a4df26a747cc.png)


So I have two possible solutions:
   1.- Show a button to activate output section inside VSCode (included in this PR)
![image](https://user-images.githubusercontent.com/40707114/181645867-1f462c5f-5102-4ec5-b284-03fb42adbd0a.png)

   2.- Automatically activate outputChannel (NOT included in this PR):
i.e.
By default, in Azure section:
![image](https://user-images.githubusercontent.com/40707114/181647131-e9f5fc0a-589f-4fd9-a339-2c54f8a3c9a8.png)

But after detecting the failure (Going to Output section and displaying the error message): 
![image](https://user-images.githubusercontent.com/40707114/181647299-d09bf292-3935-499a-9d2d-ec6344c1ffbb.png)



@Kha and @lovettchris let me know your thoughts.



*UPDATE: This PR contains 2nd solution.*

Final solution : 

After checking CR comments, the output message stays like this:
![image](https://user-images.githubusercontent.com/40707114/181836225-1fd75bb3-defd-4e77-9bd0-e39baf0c670b.png)
Based on: https://github.com/leanprover/vscode-lean4/pull/229