### PR TITLE
fix: show error message box for panics

### DIFF
--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -11,6 +11,7 @@ import {
     LanguageClient,
     LanguageClientOptions,
     PublishDiagnosticsParams,
+    RevealOutputChannelOn,
     ServerOptions,
     State
 } from 'vscode-languageclient/node'
@@ -219,6 +220,7 @@ export class LeanClient implements Disposable {
 
         const clientOptions: LanguageClientOptions = {
             outputChannel: this.outputChannel,
+            revealOutputChannelOn: RevealOutputChannelOn.Never, // contrary to the name, this disables the message boxes
             documentSelector: [documentSelector],
             workspaceFolder: this.workspaceFolder,
             initializationOptions: {


### PR DESCRIPTION
After #229 panics were silently ignored when `autofocusOutput` is set to false, which is the default value.  This PR shows an error message box on stderr output if `autofocusOutput` is false.