### PR TITLE
fix: Confusing error messages when importing a file with errors

### DIFF
--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -140,6 +140,8 @@ export function InfoDisplay(props0: InfoDisplayProps) {
     const hasGoals = status !== 'error' && goals;
     const hasTermGoal = status !== 'error' && termGoal;
     const hasMessages = status !== 'error' && messages.length !== 0;
+    const isRpcErr = error && error.includes('Rpc error')
+
     const sortClasses = 'link pointer mh2 dim codicon fr ' + (goalFilters.reverse ? 'codicon-arrow-up ' : 'codicon-arrow-down ');
     const sortButton = <a className={sortClasses} title="reverse list" onClick={e => {
         setGoalFilters(s => {
@@ -182,7 +184,7 @@ export function InfoDisplay(props0: InfoDisplayProps) {
     <Details initiallyOpen>
         <InfoStatusBar {...props} triggerUpdate={triggerDisplayUpdate} isPaused={isPaused} setPaused={setPaused} copyGoalToComment={copyGoalToComment} />
         <div className="ml1">
-            {hasError &&
+            {hasError && !isRpcErr &&
                 <div className="error" key="errors">
                     Error updating:{' '}{error}.
                     <a className="link pointer dim" onClick={e => { e.preventDefault(); void triggerDisplayUpdate(); }}>{' '}Try again.</a>


### PR DESCRIPTION
Fix for issue #239 Confusing error messages when importing a file with errors.

This fix includes an extra rule for RPC errors, they can be confusing to the user (such as outdated session or Rpc error: InvalidParams: Incorrect position (for bad or problem imports).

The idea is just to show the error that is displayed in the messages part as seen below:

![image](https://user-images.githubusercontent.com/40707114/184433055-5ca73bfb-70d3-45b8-8a84-27af9c1daff6.png)
