### PR TITLE
fix: Confusing error messages when importing a file with errors

### DIFF
--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -140,6 +140,8 @@ export function InfoDisplay(props0: InfoDisplayProps) {
     const hasGoals = status !== 'error' && goals;
     const hasTermGoal = status !== 'error' && termGoal;
     const hasMessages = status !== 'error' && messages.length !== 0;
+    const isRpcErr = error && error.includes('Rpc error')
+
     const sortClasses = 'link pointer mh2 dim codicon fr ' + (goalFilters.reverse ? 'codicon-arrow-up ' : 'codicon-arrow-down ');
     const sortButton = <a className={sortClasses} title="reverse list" onClick={e => {
         setGoalFilters(s => {
@@ -182,7 +184,7 @@ export function InfoDisplay(props0: InfoDisplayProps) {
     <Details initiallyOpen>
         <InfoStatusBar {...props} triggerUpdate={triggerDisplayUpdate} isPaused={isPaused} setPaused={setPaused} copyGoalToComment={copyGoalToComment} />
         <div className="ml1">
-            {hasError &&
+            {hasError && !isRpcErr &&
                 <div className="error" key="errors">
                     Error updating:{' '}{error}.
                     <a className="link pointer dim" onClick={e => { e.preventDefault(); void triggerDisplayUpdate(); }}>{' '}Try again.</a>


### PR DESCRIPTION
Regression error fix. 

Fix for issue https://github.com/leanprover/vscode-lean4/issues/239 Confusing error messages when importing a file with errors.

This fix includes an extra rule for RPC errors, they can be confusing to the user (such as outdated session or Rpc error: InvalidParams: Incorrect position (for bad or problem imports).

The error IS an Invalid Params error (because we are passing invalid params from and import) just we need to re-categorize it in this case and avoid confusing messages (since it can be confused as an invalid position of the lean file)

- B.lean:
![image](https://user-images.githubusercontent.com/40707114/184732574-0c8e17db-e125-43b0-be76-94d42514f0ef.png)

- A.lean:
![image](https://user-images.githubusercontent.com/40707114/184732541-228f44aa-0fae-4adf-88ae-d0bef6d45d5a.png)

**Before:**
![image](https://user-images.githubusercontent.com/40707114/184732773-8bd3ccc8-d65d-4df9-ad37-7f0065b599eb.png)


**After**

![image](https://user-images.githubusercontent.com/40707114/184732494-0a7c7a45-c7ed-4d8b-8b67-90d64a09cbcf.png)
