### PR TITLE
feat: useAsyncWithTrigger

### DIFF
--- a/lean4-infoview/src/components.tsx
+++ b/lean4-infoview/src/components.tsx
@@ -19,18 +19,18 @@ export { InteractiveCode, InteractiveCodeProps } from './infoview/interactiveCod
 export function InteractiveMessageData({ msg }: { msg: MessageData }) {
     const rs = React.useContext(RpcContext)
 
-    const [status, tt, error] = useAsync(
+    const interactive = useAsync(
         () => InteractiveDiagnostics_msgToInteractive(rs, msg, 0),
         [rs, msg]
     )
 
-    if (tt) {
-        return <InteractiveMessage fmt={tt} />
-    } else if (status === 'pending') {
+    if (interactive.state === 'resolved') {
+        return <InteractiveMessage fmt={interactive.value} />
+    } else if (interactive.state === 'loading') {
         return <>...</>
     } else {
         return <div>Failed to display message:
-            {error && <span>{mapRpcError(error).message}</span>}
+            {<span>{mapRpcError(interactive.error).message}</span>}
         </div>
     }
 }

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -71,23 +71,23 @@ function TypePopupContents({ info, redrawTooltip }: TypePopupContentsProps) {
   // When `err` is defined we show the error,
   // otherwise if `ip` is defined we show its contents,
   // otherwise a 'loading' message.
-  const [_, ip, err] = useAsync(
+  const interactive = useAsync(
     () => InteractiveDiagnostics_infoToInteractive(rs, info.info),
     [rs, info.info, info.subexprPos])
 
   // We let the tooltip know to redo its layout whenever our contents change.
-  React.useEffect(() => redrawTooltip(), [ip, err, redrawTooltip])
+  React.useEffect(() => redrawTooltip(), [interactive.state, (interactive as any)?.value, (interactive as any)?.error, redrawTooltip])
 
   return <div className="tooltip-code-content">
-    {ip && <>
+    {interactive.state === 'resolved' ? <>
       <div className="font-code tl pre-wrap">
-      {ip.exprExplicit && <InteractiveCode fmt={ip.exprExplicit} />} : {ip.type && <InteractiveCode fmt={ip.type} />}
+      {interactive.value.exprExplicit && <InteractiveCode fmt={interactive.value.exprExplicit} />} : {
+        interactive.value.type && <InteractiveCode fmt={interactive.value.type} />}
       </div>
-      {ip.doc && <hr />}
-      {ip.doc && <Markdown contents={ip.doc}/>}
-    </>}
-    {err && <>Error: {mapRpcError(err).message}</>}
-    {(!ip && !err) && <>Loading..</>}
+      {interactive.value.doc && <><hr /><Markdown contents={interactive.value.doc}/></>}
+    </> :
+    interactive.state === 'rejected' ? <>Error: {mapRpcError(interactive.error).message}</> :
+    <>Loading..</>}
   </div>
 }
 

--- a/lean4-infoview/src/infoview/userWidget.tsx
+++ b/lean4-infoview/src/infoview/userWidget.tsx
@@ -23,10 +23,11 @@ interface UserWidgetProps {
 export function UserWidget({ pos, widget }: UserWidgetProps) {
     const rs = React.useContext(RpcContext);
     const hash = widget.javascriptHash
-    const [status, component, error] = useAsync(
+    const component = useAsync(
         async () => {
             if (componentCache.has(hash)) {
-                return componentCache.get(hash)
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                return componentCache.get(hash)!
             }
             const code = await Widget_getWidgetSource(rs, pos, hash)
             const component = dynamicallyLoadComponent(hash, code.sourcetext)
@@ -38,10 +39,10 @@ export function UserWidget({ pos, widget }: UserWidgetProps) {
     const componentProps = { pos, ...widget.props }
 
     return (
-        <React.Suspense fallback={`Loading widget: ${widget.id} ${status}.`}>
+        <React.Suspense fallback={`Loading widget: ${widget.id} ${component.state}.`}>
             <ErrorBoundary>
-                {component && <div>{React.createElement(component, componentProps)}</div>}
-                {error && <div>{mapRpcError(error).message}</div>}
+                {component.state === 'resolved' && <div>{React.createElement(component.value, componentProps)}</div>}
+                {component.state === 'rejected' && <div>{mapRpcError(component.error).message}</div>}
             </ErrorBoundary>
         </React.Suspense>
     )

--- a/lean4-infoview/src/infoview/util.ts
+++ b/lean4-infoview/src/infoview/util.ts
@@ -290,78 +290,48 @@ export function mapRpcError(err : unknown) : Error {
   }
 }
 
-type Status = 'pending' | 'fulfilled' | 'rejected'
+export type AsyncState<T> =
+  { state: 'loading' } |
+  { state: 'resolved', value: T } |
+  { state: 'rejected', error: any }
 
+export type AsyncWithTriggerState<T> =
+  { state: 'notStarted' } | AsyncState<T>
 
-function useAsyncThrottled<T>(fn : () => Promise<T>, deps : React.DependencyList = [])
-  : [Status, T | undefined, unknown | undefined] {
-    const [result, setResult] = React.useState<T | undefined>(undefined)
-    const [error, setError] = React.useState<unknown | undefined>(undefined)
-    // state that is used to trigger the effect
-    const [trig, setTrig] = React.useState(0)
-    // true when fn should be re-run after resolution of current promise.
-    const retrig = React.useRef(false)
-    const init = React.useRef(true)
-    const status = React.useRef<Status>('pending')
+export function useAsyncWithTrigger<T>(fn: () => Promise<T>, deps: React.DependencyList = []): [AsyncWithTriggerState<T>, () => void] {
+  const asyncState = React.useRef<AsyncWithTriggerState<T>>({state: 'notStarted'})
+  const asyncStateDeps = React.useRef<React.DependencyList>([])
+  const tick = React.useRef(0)
+  const [_, setUpdate] = React.useState(0)
 
-    React.useEffect(function () {
-      if (status.current === 'pending' && !init.current) {
-        // A task is already in flight, rather than
-        // spawning a task for each trigger of the effect,
-        // we mark that the effect should be retriggered and run again
-        // at the end of the promise.
-        retrig.current = true
-        return
+  const trigger = React.useCallback(() => {
+    if (asyncState.current.state === 'loading' || asyncState.current.state === 'resolved')
+      return;
+
+    tick.current += 1
+    asyncState.current = { state: 'loading' }
+    setUpdate(tick.current)
+
+    tick.current += 1
+    const startTick = tick.current
+    const set = (state: AsyncWithTriggerState<T>) => {
+      if (tick.current === startTick) {
+        asyncState.current = state
+        setUpdate(tick.current)
       }
-      init.current = false
-      status.current = 'pending'
-      setError(undefined)
-      fn().then(result => {
-          status.current = 'fulfilled'
-          setResult(result)
-          setError(undefined)
-      }, (err : any) => {
-          status.current = 'rejected'
-          setError(err)
-      }).finally(() => {
-        if (retrig.current) {
-          retrig.current = false
-          // note we can't call `go` directly, because `fn` may have changed and deps may have changed.
-          setTrig(trig + 1)
-        }
-      })
-    }, [...deps, trig])
-    return [status.current, result, error]
-}
+    }
+    fn().then(
+      value => set({state: 'resolved', value}),
+      error => set({state: 'rejected', error}),
+    )
+  }, deps);
 
-function useAsyncUnthrottled<T>(fn : () => Promise<T>, deps : React.DependencyList = []) : [Status, T | undefined, unknown | undefined] {
-  const idCount = React.useRef(0)
-  const latestResolved = React.useRef(0)
-  const [status, setStatus] = React.useState<Status>('pending')
-  const [error, setError] = React.useState<unknown>(undefined)
-  const [result, setResult] = React.useState<T | undefined>(undefined)
-  React.useEffect(() => {
-    idCount.current += 1
-    const taskId = idCount.current
-    setStatus('pending')
-    setError(undefined)
-    fn().then(result => {
-      if (latestResolved.current > taskId) {
-        return
-      }
-      setStatus('fulfilled')
-      setResult(result)
-      latestResolved.current = taskId
-    }, (err : any) => {
-      if (latestResolved.current > taskId) {
-        return
-      }
-      setStatus('rejected')
-      setError(err)
-      latestResolved.current = taskId
-    })
-  }, deps)
-  return [status, result, error]
+  if (!asyncStateDeps.current.every((d, i) => Object.is(d, deps[i]))) {
+    tick.current += 1
+    asyncState.current = {state: 'notStarted'}
+    asyncStateDeps.current = deps
+  }
+  return [asyncState.current, trigger]
 }
 
 /** This React hook will run the given promise function `fn` whenever the deps change
@@ -377,21 +347,15 @@ function useAsyncUnthrottled<T>(fn : () => Promise<T>, deps : React.DependencyLi
  *
  * Without `useAsync` we would now return the diagnostics for line 42 even though we're at line 90.
  *
- * There is a 'throttled' and 'unthrottled' version of this function:
- * - in _throttled_ `throttle = true`:
- *   There will only ever be one in-flight promise at a time. If the deps
- *   change while a promise is still in-flight, then `fn` will be run
- *   again after the first promise has resolved.
- * - in _unthrottled_ `throttle = false`:
- *   `fn` will be fired as soon as the dependencies change. Each invocation of
- *   `fn` is time ordered. If an earlier invocation resolves after a
- *   later invocation (as happens in above example), then this result is discarded.
+ * When the deps change, the function immediately returns `{ state: 'loading' }`.
  */
-export function useAsync<T>(fn : () => Promise<T>, deps : React.DependencyList = [], throttle = false): [Status, T | undefined, unknown | undefined] {
-  if (throttle) {
-    return useAsyncThrottled(fn, deps)
+export function useAsync<T>(fn: () => Promise<T>, deps: React.DependencyList = []): AsyncState<T> {
+  const [state, trigger] = useAsyncWithTrigger(fn, deps)
+  if (state.state === 'notStarted') {
+    trigger()
+    return {state: 'loading'}
   } else {
-    return useAsyncUnthrottled(fn, deps)
+    return state
   }
 }
 


### PR DESCRIPTION
Extends `useAsync` with lazy loading.  It also fixes the nasty race condition with changing deps where the `useAsync` return value claimed to be fulfilled but was out-of-date.  E.g., this means that we use the props meant for a different widget, or send RPC objects to the wrong session.