### PR TITLE
feat: bring back inaccessible names highlighting

### DIFF
--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -7,9 +7,15 @@ interface HypProps {
     hyp: InteractiveHypothesisBundle
 }
 
+
+/** Returns true if `h` is inaccessible according to Lean's default name rendering. */
+function isInaccessibleName(h: string): boolean {
+    return h.indexOf('✝') >= 0;
+}
+
 export function Hyp({ hyp : h }: HypProps) {
     const names = InteractiveHypothesisBundle_accessibleNames(h).map((n, i) =>
-            <span className="mr1" key={i}>{n}</span>
+            <span className={'mr1 ' + (isInaccessibleName(n) ? 'goal-inaccessible' : '')} key={i}>{n}</span>
         )
     return <div>
         <strong className="goal-hyp">{names}</strong>
@@ -55,15 +61,11 @@ export interface GoalFilterState {
     isHiddenAssumption: boolean
 }
 
-function isHiddenAssumption(h: InteractiveHypothesisBundle) {
-    return h.names.every(n => n.indexOf('✝') >= 0);
-}
-
 function getFilteredHypotheses(hyps: InteractiveHypothesisBundle[], filter: GoalFilterState): InteractiveHypothesisBundle[] {
     return hyps.filter(h =>
         (!h.isInstance || filter.isInstance) &&
         (!h.isType || filter.isType) &&
-        (filter.isHiddenAssumption || !isHiddenAssumption(h)));
+        (filter.isHiddenAssumption || !h.names.every(isInaccessibleName)));
 }
 
 interface GoalProps {

--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -23,13 +23,17 @@ html,body {
 .goal-vdash { color: #569cd6; }
 .goal-case { color: #a1df90; }
 .goal-hyp { color: #ffcc00; }
-.goal-inaccessible { color: #808080 }
+.goal-inaccessible {
+    color: var(--vscode-editor-foreground);
+    opacity: 0.7;
+    font-style: italic;
+    font-weight: normal;
+}
 
 .vscode-light .goal-goals { color: #367cb6; }
 .vscode-light .goal-vdash { color: #367cb6; }
 .vscode-light .goal-case { color: #1f7a1f; }
 .vscode-light .goal-hyp { color: #cc7a00; }
-.vscode-light .goal-inaccessible { color: #777; }
 
 /* Used to denote text highlighted by the pretty-print expression widget. */
 .highlightable {


### PR DESCRIPTION
As discussed in https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/De-emphasizing.20inaccessible.20hypothesis.20names

![image](https://user-images.githubusercontent.com/109126/187432947-ab0d60a7-c9e0-404a-89a0-1503f22a9122.png)

![image](https://user-images.githubusercontent.com/109126/187433005-2dc9dd63-2575-4115-baed-2cdb2016b742.png)

![image](https://user-images.githubusercontent.com/109126/187433080-d3982572-bd19-489e-b65a-6084bcab5d2e.png)