### PR TITLE
feat: add `applyEdit` to edit connection protocol

### DIFF
--- a/lean4-infoview-api/src/infoviewApi.ts
+++ b/lean4-infoview-api/src/infoviewApi.ts
@@ -1,4 +1,4 @@
-import type { DocumentUri, InitializeResult, Location, ShowDocumentParams, TextDocumentPositionParams } from 'vscode-languageserver-protocol'
+import type { DocumentUri, InitializeResult, Location, ShowDocumentParams, TextDocumentPositionParams, WorkspaceEdit } from 'vscode-languageserver-protocol'
 
 export interface EditorFsApi {
   stat(path: string): Promise<any>;
@@ -50,6 +50,9 @@ export interface EditorApi {
 
   /** Insert text into a document. When `pos` is not present, write at the current cursor location. */
   insertText(text: string, kind: TextInsertKind, pos?: TextDocumentPositionParams): Promise<void>
+
+  /** Applies the given WorkspaceEdit to the workspace. */
+  applyEdit(te : WorkspaceEdit): Promise<void>;
 
   /** Highlight a range in a document in the editor. */
   showDocument(show: ShowDocumentParams): Promise<void>;

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -3,7 +3,7 @@ import {
     commands, Disposable, DocumentSelector,
     ExtensionContext, languages, Range,
     Selection, TextEditor, TextEditorRevealType,
-    Uri, ViewColumn, WebviewPanel, window, workspace, env, Position,
+    Uri, ViewColumn, WebviewPanel, window, workspace, env, Position, WorkspaceEdit,
 } from 'vscode';
 import { EditorApi, InfoviewApi, LeanFileProgressParams, TextInsertKind,
     RpcConnectParams, RpcConnected, RpcKeepAliveParams, ServerStoppedReason, RpcErrorCode } from '@leanprover/infoview-api';
@@ -213,6 +213,10 @@ export class InfoProvider implements Disposable {
                 pos = p2cConverter.asPosition(tdpp.position);
             }
             await this.handleInsertText(text, kind, uri, pos);
+        },
+        applyEdit: async (e : ls.WorkspaceEdit) => {
+            const we = await p2cConverter.asWorkspaceEdit(e)
+            await workspace.applyEdit(we);
         },
         showDocument: async (show) => {
             void this.revealEditorSelection(


### PR DESCRIPTION
The input is a `WorkspaceEdit` which empowers the infoview to be able to edit the document and workspace in any way.