### PR TITLE
test: add some logging to help debug random test failures.

### DIFF
--- a/vscode-lean4/package-lock.json
+++ b/vscode-lean4/package-lock.json
@@ -39,7 +39,7 @@
 				"webpack-cli": "^4.9.1"
 			},
 			"engines": {
-				"vscode": "^1.61.0"
+				"vscode": "^1.70.0"
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -555,12 +555,17 @@ export class InfoProvider implements Disposable {
         // by listening to notifications.  Send these notifications when the infoview starts
         // so that it has up-to-date information.
         if (client?.initializeResult) {
+            logger.log('[InfoProvider] initInfoView!')
             await this.webviewPanel?.api.serverStopped(undefined); // clear any server stopped state
             await this.webviewPanel?.api.serverRestarted(client.initializeResult);
             await this.sendDiagnostics(client);
             await this.sendProgress(client);
             await this.sendPosition();
             await this.sendConfig();
+        } else if (client == null) {
+            logger.log('[InfoProvider] initInfoView got null client.')
+        } else {
+            logger.log('[InfoProvider] initInfoView got undefined client.initializeResult')
         }
     }
 

--- a/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
+++ b/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
@@ -3,8 +3,8 @@ import * as os from 'os';
 import { suite } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { initLean4Untitled, waitForInfoviewHtml, closeAllEditors, waitForActiveClientRunning,
-         getAltBuildVersion, assertStringInInfoview, copyFolder, extractPhrase } from '../utils/helpers';
+import { initLean4Untitled, waitForInfoviewHtml, closeAllEditors, waitForActiveClientRunning, assertActiveClient,
+         getAltBuildVersion, assertStringInInfoview, copyFolder, extractPhrase, restartLeanServer } from '../utils/helpers';
 import { getDefaultElanPath } from '../../../src/config'
 import { batchExecute } from '../../../src/utils/batch'
 import { logger } from '../../../src/utils/logger'
@@ -25,8 +25,11 @@ suite('Lean4 Bootstrap Test Suite', () => {
 
         // give it a extra long timeout in case test machine is really slow.
         logger.log('Wait for elan install of Lean nightly build...')
-        await waitForActiveClientRunning(lean.exports.clientProvider, 600);
-		await waitForInfoviewHtml(info, '4.0.0-nightly-', 600);
+        await waitForActiveClientRunning(lean.exports.clientProvider, 500);
+        const client = assertActiveClient(lean.exports.clientProvider);
+        // wait 60 seconds, if nothing then kick it with a restart server command, and try that up to 5 times
+        // and if it times out at 300 seconds then waitForInfoviewHtml prints the contents of the InfoView so we can see what happened.
+		await waitForInfoviewHtml(info, '4.0.0-nightly-', 5, 60000, false, () => restartLeanServer(client));
 
         logger.log('Lean installation is complete.')
 

--- a/vscode-lean4/test/test-fixtures/multi/foo/lean-toolchain
+++ b/vscode-lean4/test/test-fixtures/multi/foo/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-07-03
+leanprover/lean4:nightly-2022-10-03


### PR DESCRIPTION
See [failure]( https://github.com/leanprover/vscode-lean4/actions/runs/3254321730/jobs/5346015206)

## log analysis

The `[LeanClient] running, started in 655 ms` means we reached the point where the LeanClient fires the `restarted` event, which is great, and even better the InfoView got that event and printed `[InfoProvider] got client restarted event`. The InfoView is supposed to call `clearRpcSessions` and `onClientRestarted`which calls `initInfoView` and that is supposed to trigger all the infoview updating.  But what if `if (client?.initializeResult) {` failed? then it would silently hang forever showing "Waiting for lean server to start".  We should change the test to print the contents of the infoview so we can confirm what is there. There is no race condition, the `this.running = true` is set to true before raising the restarted event in both code paths.  We should add a logging message to initInfoView to report when the initializationResult is undefined.  

This PR together adds these 2 new logging events...