### PR TITLE
avoid returning promises in `useEffect`

### DIFF
--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -409,7 +409,7 @@ function InfoAux(props: InfoProps) {
         setDisplayProps(newProps)
     });
 
-    React.useEffect(() => void triggerUpdate(), [pos.uri, pos.line, pos.character, lspDiags, serverIsProcessing]);
+    React.useEffect(() => { void triggerUpdate() }, [pos.uri, pos.line, pos.character, lspDiags, serverIsProcessing]);
 
     return (
         <InfoDisplay {...props} {...displayProps} triggerUpdate={triggerUpdate} />

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -76,7 +76,7 @@ function TypePopupContents({ info, redrawTooltip }: TypePopupContentsProps) {
     [rs, info.info, info.subexprPos])
 
   // We let the tooltip know to redo its layout whenever our contents change.
-  React.useEffect(() => redrawTooltip(), [interactive.state, (interactive as any)?.value, (interactive as any)?.error, redrawTooltip])
+  React.useEffect(() => { void redrawTooltip() }, [interactive.state, (interactive as any)?.value, (interactive as any)?.error, redrawTooltip])
 
   return <div className="tooltip-code-content">
     {interactive.state === 'resolved' ? <>

--- a/lean4-infoview/src/infoview/messages.tsx
+++ b/lean4-infoview/src/infoview/messages.tsx
@@ -120,7 +120,7 @@ export function AllMessages({uri: uri0}: { uri: DocumentUri }) {
 
     // Fetch interactive diagnostics when we're entering the paused state
     // (if they haven't already been fetched before)
-    React.useEffect(() => void (isPaused && iDiags()), [iDiags, isPaused]);
+    React.useEffect(() => { if (isPaused) { void iDiags() } }, [iDiags, isPaused]);
 
     const setOpenRef = React.useRef<React.Dispatch<React.SetStateAction<boolean>>>();
     useEvent(ec.events.requestedAction, act => {
@@ -150,7 +150,7 @@ export function AllMessages({uri: uri0}: { uri: DocumentUri }) {
 /** We factor out the body of {@link AllMessages} which lazily fetches its contents only when expanded. */
 function AllMessagesBody({uri, messages}: {uri: DocumentUri, messages: () => Promise<InteractiveDiagnostic[]>}) {
     const [msgs, setMsgs] = React.useState<InteractiveDiagnostic[] | undefined>(undefined)
-    React.useEffect(() => void messages().then(setMsgs), [messages])
+    React.useEffect(() => { void messages().then(setMsgs) }, [messages])
     if (msgs === undefined) return <>Loading messages...</>
     else return <MessagesList uri={uri} messages={msgs}/>
 }
@@ -200,6 +200,6 @@ export function useMessagesForFile(rs: RpcSessionAtPos, uri: DocumentUri, line?:
             }
         }
     }
-    React.useEffect(() => void updateDiags(), [uri, line, rs, lspDiags.get(uri)])
+    React.useEffect(() => { void updateDiags() }, [uri, line, rs, lspDiags.get(uri)])
     return diags;
 }


### PR DESCRIPTION
I am working on a web version of Lean 4 and ran into the issue that some of the `useEffect` functions accidentally return a promise. The issue is described in some detail here: https://medium.com/geekculture/react-uncaught-typeerror-destroy-is-not-a-function-192738a6e79b. I am not sure why this is not an issue in the VSCode webview, but it is an issue in the browser.