### PR TITLE
fix: RPC race condition

### DIFF
--- a/vscode-lean4/src/rpc.ts
+++ b/vscode-lean4/src/rpc.ts
@@ -42,6 +42,8 @@ export class Rpc {
         const {seqNum, name, args, result, exception}: any = msg
         if (seqNum === undefined) return
         if (name !== undefined) {
+            // It's important that we wait on `initPromise` here. Otherwise we may try to invoke
+            // a method before `register` is called.
             return void this.initPromise.then(async () => {
                 try {
                     const fn = this.methods[name]


### PR DESCRIPTION
It looks like we had a long-standing bug in the infoview RPC channel wherein method calls could start coming in from the other side before we get a chance to call `rpc.register`. This became much more observable when I messed with some other code but it's a potential source of some occurrences of the `Waiting for Lean server to start..` bug.