### PR TITLE
Rename "goals accomplished" as "no goals"

### DIFF
--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -116,7 +116,7 @@ interface GoalsProps {
 
 export function Goals({ goals, filter }: GoalsProps) {
     if (goals.goals.length === 0) {
-        return <>Goals accomplished 🎉</>
+        return <>No goals</>
     } else {
         return <>
             {goals.goals.map((g, i) => <Goal key={i} goal={g} filter={filter} index={i} />)}


### PR DESCRIPTION
At the moment, the Lean 4 VS Code extension reports "Goals accomplished 🎉" if the goal list is empty, as it did in Lean 3. 
 However, far more often than in Lean 3, the phrase is an inappropriate descriptor of the situation.  For example:
````lean
example : True := by
  exact h
````
With the cursor after `h`, one has two messages displayed, "Goals accomplished" and "unknown identifier 'h'".  (In Lean 3, there is no "Goals accomplished" message on this example.)

See [#1970](https://github.com/leanprover/lean4/issues/1970) for a full description of the issue and some proposed fixes -- I hope the Lean 4 devs will take this on!

In the short term, however, it seems worthwhile changing the message to something less confusing.  I propose here changing the message to "no goals".

Update: Unfortunately I don't know how to fix the broken Windows build.