### PR TITLE
fix: Ensure large tooltip popups are not clipped and stay within the inforview viewport

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,8 @@ module.exports = {
     },
     "extends": [
         "plugin:@typescript-eslint/recommended",
-        "plugin:@typescript-eslint/recommended-requiring-type-checking"
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+        "plugin:react-hooks/recommended"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {

--- a/lean4-infoview/package-lock.json
+++ b/lean4-infoview/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
+        "@leanprover/infoview-api": "~0.2.1",
         "@vscode/codicons": "^0.0.32",
         "es-module-shims": "^1.6.2",
         "marked": "^4.2.2",
@@ -17,6 +18,7 @@
         "vscode-languageserver-protocol": "^3.17.2"
       },
       "devDependencies": {
+        "@floating-ui/react": "^0.20.1",
         "@rollup/plugin-commonjs": "^23.0.2",
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-replace": "^5.0.1",
@@ -29,7 +31,6 @@
         "current-release": "npm:@leanprover/infoview@^0.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-popper": "^2.3.0",
         "rollup": "^3.3.0",
         "rollup-plugin-css-only": "^4.3.0",
         "typescript": "^4.9.4"
@@ -38,7 +39,6 @@
     "../lean4-infoview-api": {
       "name": "@leanprover/infoview-api",
       "version": "0.2.1",
-      "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^4.9.4",
@@ -78,6 +78,49 @@
       "version": "3.17.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.2.tgz",
+      "integrity": "sha512-FaO9KVLFnxknZaGWGmNtjD2CVFuc0u4yeGEofoyXO2wgRA7fLtkngT6UB0vtWQWuhH3iMTZZ/Y89CMeyGfn8pA==",
+      "dev": true
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.3.tgz",
+      "integrity": "sha512-lK9cZUrHSJLMVAdCvDqs6Ug8gr0wmqksYiaoj/bxj2gweRQkSuhg2/V6Jswz2KiQ0RAULbqw1oQDJIMpQ5GfGA==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.2.2"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.20.1.tgz",
+      "integrity": "sha512-JHTHJ+/YsIxNFH8uJDFa5OyI6dSUZcle6wAFe0zRTjgWD+rkACfBBoJtx2itTtn7C4a7xAz4jgxdEQcMel194g==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/react-dom": "^1.3.0",
+        "aria-hidden": "^1.1.3",
+        "tabbable": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
+      "integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -134,16 +177,6 @@
     "node_modules/@leanprover/infoview-api": {
       "resolved": "../lean4-infoview-api",
       "link": true
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.6",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "23.0.3",
@@ -355,6 +388,18 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+      "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/balanced-match": {
@@ -648,20 +693,6 @@
       "version": "3.2.0",
       "license": "MIT"
     },
-    "node_modules/react-popper": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "dev": true,
@@ -756,6 +787,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
+      "integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg==",
+      "dev": true
+    },
     "node_modules/tachyons": {
       "version": "4.12.0",
       "license": "MIT"
@@ -776,6 +813,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "dev": true
     },
     "node_modules/typescript": {
       "version": "4.9.4",
@@ -809,14 +852,6 @@
       "version": "3.17.2",
       "license": "MIT"
     },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "dev": true,
@@ -824,6 +859,41 @@
     }
   },
   "dependencies": {
+    "@floating-ui/core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.2.tgz",
+      "integrity": "sha512-FaO9KVLFnxknZaGWGmNtjD2CVFuc0u4yeGEofoyXO2wgRA7fLtkngT6UB0vtWQWuhH3iMTZZ/Y89CMeyGfn8pA==",
+      "dev": true
+    },
+    "@floating-ui/dom": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.3.tgz",
+      "integrity": "sha512-lK9cZUrHSJLMVAdCvDqs6Ug8gr0wmqksYiaoj/bxj2gweRQkSuhg2/V6Jswz2KiQ0RAULbqw1oQDJIMpQ5GfGA==",
+      "dev": true,
+      "requires": {
+        "@floating-ui/core": "^1.2.2"
+      }
+    },
+    "@floating-ui/react": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.20.1.tgz",
+      "integrity": "sha512-JHTHJ+/YsIxNFH8uJDFa5OyI6dSUZcle6wAFe0zRTjgWD+rkACfBBoJtx2itTtn7C4a7xAz4jgxdEQcMel194g==",
+      "dev": true,
+      "requires": {
+        "@floating-ui/react-dom": "^1.3.0",
+        "aria-hidden": "^1.1.3",
+        "tabbable": "^6.0.1"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
+      "integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
+      "dev": true,
+      "requires": {
+        "@floating-ui/dom": "^1.2.1"
+      }
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.3.2",
       "dev": true,
@@ -889,11 +959,6 @@
           "dev": true
         }
       }
-    },
-    "@popperjs/core": {
-      "version": "2.11.6",
-      "dev": true,
-      "peer": true
     },
     "@rollup/plugin-commonjs": {
       "version": "23.0.3",
@@ -1002,6 +1067,15 @@
     "acorn": {
       "version": "8.8.1",
       "dev": true
+    },
+    "aria-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+      "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -1193,14 +1267,6 @@
     "react-fast-compare": {
       "version": "3.2.0"
     },
-    "react-popper": {
-      "version": "2.3.0",
-      "dev": true,
-      "requires": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      }
-    },
     "resolve": {
       "version": "1.22.1",
       "dev": true,
@@ -1255,6 +1321,12 @@
       "version": "1.0.0",
       "dev": true
     },
+    "tabbable": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
+      "integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg==",
+      "dev": true
+    },
     "tachyons": {
       "version": "4.12.0"
     },
@@ -1267,6 +1339,12 @@
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       }
+    },
+    "tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "dev": true
     },
     "typescript": {
       "version": "4.9.4",
@@ -1286,13 +1364,6 @@
     },
     "vscode-languageserver-types": {
       "version": "3.17.2"
-    },
-    "warning": {
-      "version": "4.0.3",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/lean4-infoview/package-lock.json
+++ b/lean4-infoview/package-lock.json
@@ -18,7 +18,7 @@
         "vscode-languageserver-protocol": "^3.17.2"
       },
       "devDependencies": {
-        "@floating-ui/react": "^0.20.1",
+        "@floating-ui/react": "^0.24.1",
         "@rollup/plugin-commonjs": "^23.0.2",
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-replace": "^5.0.1",
@@ -80,27 +80,27 @@
       "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.2.tgz",
-      "integrity": "sha512-FaO9KVLFnxknZaGWGmNtjD2CVFuc0u4yeGEofoyXO2wgRA7fLtkngT6UB0vtWQWuhH3iMTZZ/Y89CMeyGfn8pA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==",
       "dev": true
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.3.tgz",
-      "integrity": "sha512-lK9cZUrHSJLMVAdCvDqs6Ug8gr0wmqksYiaoj/bxj2gweRQkSuhg2/V6Jswz2KiQ0RAULbqw1oQDJIMpQ5GfGA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.8.tgz",
+      "integrity": "sha512-XLwhYV90MxiHDq6S0rzFZj00fnDM+A1R9jhSioZoMsa7G0Q0i+Q4x40ajR8FHSdYDE1bgjG45mIWe6jtv9UPmg==",
       "dev": true,
       "dependencies": {
-        "@floating-ui/core": "^1.2.2"
+        "@floating-ui/core": "^1.2.6"
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.20.1.tgz",
-      "integrity": "sha512-JHTHJ+/YsIxNFH8uJDFa5OyI6dSUZcle6wAFe0zRTjgWD+rkACfBBoJtx2itTtn7C4a7xAz4jgxdEQcMel194g==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.24.1.tgz",
+      "integrity": "sha512-qjCKUZDEz/4bnJmu4gn66TqsoX912/re8JGEi3pXazsphmyh327l0UpTgpBAT3WkNbnzAH7Adt3wKlLMNtfupw==",
       "dev": true,
       "dependencies": {
-        "@floating-ui/react-dom": "^1.3.0",
+        "@floating-ui/react-dom": "^2.0.0",
         "aria-hidden": "^1.1.3",
         "tabbable": "^6.0.1"
       },
@@ -110,12 +110,12 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
-      "integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.0.tgz",
+      "integrity": "sha512-Ke0oU3SeuABC2C4OFu2mSAwHIP5WUiV98O9YWoHV4Q5aT6E9k06DV0Khi5uYspR8xmmBk08t8ZDcz3TR3ARkEg==",
       "dev": true,
       "dependencies": {
-        "@floating-ui/dom": "^1.2.1"
+        "@floating-ui/dom": "^1.2.7"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -788,9 +788,9 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
-      "integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.2.tgz",
+      "integrity": "sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ==",
       "dev": true
     },
     "node_modules/tachyons": {
@@ -860,38 +860,38 @@
   },
   "dependencies": {
     "@floating-ui/core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.2.tgz",
-      "integrity": "sha512-FaO9KVLFnxknZaGWGmNtjD2CVFuc0u4yeGEofoyXO2wgRA7fLtkngT6UB0vtWQWuhH3iMTZZ/Y89CMeyGfn8pA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==",
       "dev": true
     },
     "@floating-ui/dom": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.3.tgz",
-      "integrity": "sha512-lK9cZUrHSJLMVAdCvDqs6Ug8gr0wmqksYiaoj/bxj2gweRQkSuhg2/V6Jswz2KiQ0RAULbqw1oQDJIMpQ5GfGA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.8.tgz",
+      "integrity": "sha512-XLwhYV90MxiHDq6S0rzFZj00fnDM+A1R9jhSioZoMsa7G0Q0i+Q4x40ajR8FHSdYDE1bgjG45mIWe6jtv9UPmg==",
       "dev": true,
       "requires": {
-        "@floating-ui/core": "^1.2.2"
+        "@floating-ui/core": "^1.2.6"
       }
     },
     "@floating-ui/react": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.20.1.tgz",
-      "integrity": "sha512-JHTHJ+/YsIxNFH8uJDFa5OyI6dSUZcle6wAFe0zRTjgWD+rkACfBBoJtx2itTtn7C4a7xAz4jgxdEQcMel194g==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.24.1.tgz",
+      "integrity": "sha512-qjCKUZDEz/4bnJmu4gn66TqsoX912/re8JGEi3pXazsphmyh327l0UpTgpBAT3WkNbnzAH7Adt3wKlLMNtfupw==",
       "dev": true,
       "requires": {
-        "@floating-ui/react-dom": "^1.3.0",
+        "@floating-ui/react-dom": "^2.0.0",
         "aria-hidden": "^1.1.3",
         "tabbable": "^6.0.1"
       }
     },
     "@floating-ui/react-dom": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
-      "integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.0.tgz",
+      "integrity": "sha512-Ke0oU3SeuABC2C4OFu2mSAwHIP5WUiV98O9YWoHV4Q5aT6E9k06DV0Khi5uYspR8xmmBk08t8ZDcz3TR3ARkEg==",
       "dev": true,
       "requires": {
-        "@floating-ui/dom": "^1.2.1"
+        "@floating-ui/dom": "^1.2.7"
       }
     },
     "@jridgewell/gen-mapping": {
@@ -1322,9 +1322,9 @@
       "dev": true
     },
     "tabbable": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
-      "integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.2.tgz",
+      "integrity": "sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ==",
       "dev": true
     },
     "tachyons": {

--- a/lean4-infoview/package.json
+++ b/lean4-infoview/package.json
@@ -29,7 +29,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@floating-ui/react": "^0.20.1",
+    "@floating-ui/react": "^0.24.1",
     "@rollup/plugin-commonjs": "^23.0.2",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-replace": "^5.0.1",

--- a/lean4-infoview/package.json
+++ b/lean4-infoview/package.json
@@ -29,6 +29,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@floating-ui/react": "^0.20.1",
     "@rollup/plugin-commonjs": "^23.0.2",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-replace": "^5.0.1",
@@ -41,7 +42,6 @@
     "current-release": "npm:@leanprover/infoview@^0.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-popper": "^2.3.0",
     "rollup": "^3.3.0",
     "rollup-plugin-css-only": "^4.3.0",
     "typescript": "^4.9.4"

--- a/lean4-infoview/rollup.config.js
+++ b/lean4-infoview/rollup.config.js
@@ -69,7 +69,6 @@ const configs = [ {
             'react',
             'react-dom',
             'react/jsx-runtime',
-            'react-popper'
         ],
     }, {
         output: {
@@ -90,10 +89,6 @@ const configs = [ {
         output, plugins,
         input: 'src/esm-shims/react-jsx-runtime.ts',
         external: [ 'react' ]
-    }, {
-        output, plugins,
-        input: 'src/esm-shims/react-popper.ts',
-        external: [ 'react', 'react-dom' ]
     },
 ]
 

--- a/lean4-infoview/src/esm-shims/react-popper.ts
+++ b/lean4-infoview/src/esm-shims/react-popper.ts
@@ -1,2 +1,0 @@
-/** @module See `rollup.config.js` for what this file does. */
-export * from 'react-popper';

--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -248,7 +248,7 @@ export const FilteredGoals = React.memo(({ headerChildren, goals, displayCount, 
 
     const isFiltered = !goalFilters.showInstance || !goalFilters.showType || !goalFilters.showHiddenAssumption || !goalFilters.showLetValue
     const filterButton =
-        <WithTooltipOnHover mkTooltipContent={() => filterMenu}>
+        <WithTooltipOnHover tooltipChildren={filterMenu}>
             <a className={'link pointer mh2 dim codicon ' + (isFiltered ? 'codicon-filter-filled ': 'codicon-filter ')}/>
         </WithTooltipOnHover>
 

--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -172,10 +172,10 @@ interface GoalsProps {
 
 function Goals({ goals, filter, displayCount }: GoalsProps) {
     const nGoals = goals.goals.length
+    const config = React.useContext(ConfigContext)
     if (nGoals === 0) {
         return <strong className="db2 mb2 goal-goals">No goals</strong>
     } else {
-        const config = React.useContext(ConfigContext)
         const unemphasizeCn = 'o-70 font-size-code-smaller'
         return <>
             {displayCount &&

--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -127,9 +127,6 @@ select {
 /* Style for tooltips shown in the widget view. This should *not* style the tooltip contents.
 For that, we can use more specific classes. */
 .tooltip {
-    position: absolute;
-    top: 0;
-    left: 0;
     background-color: var(--vscode-editorHoverWidget-background);
     padding: 4px 8px;
     border-radius: 4px;
@@ -141,8 +138,10 @@ For that, we can use more specific classes. */
     box-sizing: border-box;
 }
 
-.tooltip-arrow,
-.tooltip-arrow::before {
+.tooltip-arrow {
+    background: var(--vscode-editorHoverWidget-background);
+}
+/* .tooltip-arrow::before {
     position: absolute;
     width: 8px;
     height: 8px;
@@ -169,7 +168,7 @@ For that, we can use more specific classes. */
 
 .tooltip[data-popper-placement^='right'] > .tooltip-arrow {
     left: -4px;
-}
+} */
 
 /* Contents of a list of selections shown as a tooltip. */
 .tooltip-menu-content {

--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -127,6 +127,9 @@ select {
 /* Style for tooltips shown in the widget view. This should *not* style the tooltip contents.
 For that, we can use more specific classes. */
 .tooltip {
+    position: absolute;
+    top: 0;
+    left: 0;
     background-color: var(--vscode-editorHoverWidget-background);
     padding: 4px 8px;
     border-radius: 4px;
@@ -134,14 +137,8 @@ For that, we can use more specific classes. */
     border-color: var(--vscode-editorHoverWidget-border);
     border-width: 1px;
     border-style: solid;
-    max-width: calc(70%);
+    max-width: 70%;
     box-sizing: border-box;
-}
-
-@media (max-width: 500px) {
-    .tooltip {
-        max-width: 100vw;
-    }
 }
 
 .tooltip-arrow,
@@ -200,10 +197,13 @@ For that, we can use more specific classes. */
 
 /* Contents of a code tooltip showing a value, type, documentation, etc. */
 .tooltip-code-content {
-   color: var(--vscode-editorHoverWidget-foreground);
-   background: var(--vscode-editorHoverWidget-background);
-   line-height: var(--vscode-editor-line-height);
-   overflow: hidden;
+    color: var(--vscode-editorHoverWidget-foreground);
+    background: var(--vscode-editorHoverWidget-background);
+    line-height: var(--vscode-editor-line-height);
+    height: 100%;
+    max-height: 300px;
+    overflow-y: scroll;
+    overflow-x: hidden;
 }
 
 .tooltip-code-content a:hover {

--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -124,56 +124,31 @@ select {
     border-color: var(--vscode-dropdown-border);
 }
 
-/* Style for tooltips shown in the widget view. This should *not* style the tooltip contents.
-For that, we can use more specific classes. */
+/* Style for the rounded box that is the outermost div of every tooltip.
+ * We use more specific classes for styling tooltip contents. */
 .tooltip {
     background-color: var(--vscode-editorHoverWidget-background);
-    padding: 4px 8px;
     border-radius: 4px;
-    box-shadow: 1px 1px 5px var(--vscode-widget-shadow);
     border-color: var(--vscode-editorHoverWidget-border);
     border-width: 1px;
     border-style: solid;
-    max-width: 70%;
+    box-shadow: 1px 1px 5px var(--vscode-widget-shadow);
     box-sizing: border-box;
+    /* Note: max-height is set in JS. */
+    max-width: 70%;
+    /* Flexbox ensures that contents don't overflow. */
+    display: flex;
 }
 
-.tooltip-arrow {
-    background: var(--vscode-editorHoverWidget-background);
+.tooltip-content {
+    padding: 4px 8px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
 }
-/* .tooltip-arrow::before {
-    position: absolute;
-    width: 8px;
-    height: 8px;
-    z-index: -1;
-}
-
-.tooltip-arrow::before {
-    content: '';
-    transform: rotate(45deg);
-    background: var(--vscode-editorHoverWidget-background);
-}
-
-.tooltip[data-popper-placement^='top'] > .tooltip-arrow {
-    bottom: -4px;
-}
-
-.tooltip[data-popper-placement^='bottom'] > .tooltip-arrow {
-    top: -4px;
-}
-
-.tooltip[data-popper-placement^='left'] > .tooltip-arrow {
-    right: -4px;
-}
-
-.tooltip[data-popper-placement^='right'] > .tooltip-arrow {
-    left: -4px;
-} */
 
 /* Contents of a list of selections shown as a tooltip. */
 .tooltip-menu-content {
     color: var(--vscode-editorHoverWidget-foreground);
-    background: var(--vscode-editorHoverWidget-background);
 }
 
 .tooltip-menu-content .tooltip-menu-text {
@@ -185,7 +160,7 @@ For that, we can use more specific classes. */
 
 .tooltip-menu-content .tooltip-menu-icon {
     padding: 0px;
-    margin-top:6px;
+    margin-top: 6px;
 }
 
 /*---------------------------------------------------------------------------------------------
@@ -197,12 +172,7 @@ For that, we can use more specific classes. */
 /* Contents of a code tooltip showing a value, type, documentation, etc. */
 .tooltip-code-content {
     color: var(--vscode-editorHoverWidget-foreground);
-    background: var(--vscode-editorHoverWidget-background);
     line-height: var(--vscode-editor-line-height);
-    height: 100%;
-    max-height: 300px;
-    overflow-y: scroll;
-    overflow-x: hidden;
 }
 
 .tooltip-code-content a:hover {
@@ -221,8 +191,6 @@ For that, we can use more specific classes. */
     border-right: -8px;
     margin-top: 4px;
     margin-bottom: 4px;
-    margin-left: -18px;
-    margin-right: -18px;
     height: 1px;
     border-bottom-width: 0px;
     border-top-width: 1px;

--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -258,7 +258,7 @@ function InfoAux(props: InfoProps) {
         // Note: the curly braces are important. https://medium.com/geekculture/react-uncaught-typeerror-destroy-is-not-a-function-192738a6e79b
         setLspDiagsHere(diags0 => {
             const diagPred = (d: Diagnostic) =>
-                RangeHelpers.contains(d.range, pos, config.allErrorsOnLine)
+                RangeHelpers.contains(d.range, {line: pos.line, character: pos.character}, config.allErrorsOnLine)
             const newDiags = (lspDiags.get(pos.uri) || []).filter(diagPred)
             if (newDiags.length === diags0.length && newDiags.every((d, i) => d === diags0[i])) return diags0
             return newDiags
@@ -402,7 +402,7 @@ function InfoAux(props: InfoProps) {
             // The code inside `useAsyncWithTrigger` may only ever reject with a `retry` exception.
             console.warn('Unreachable code reached with error: ', state.error)
         }
-    }, [state])
+    }, [state, triggerUpdate])
 
     return <InfoDisplay kind={props.kind} onPin={props.onPin} {...displayProps} />
 }

--- a/lean4-infoview/src/infoview/infos.tsx
+++ b/lean4-infoview/src/infoview/infos.tsx
@@ -97,13 +97,13 @@ export function Infos() {
             pinKey.current += 1;
             return [ ...pinnedPositions, { ...pos, key: pinKey.current.toString() } ];
         });
-    }, []);
+    }, [setPinnedPositions]);
     const unpin = React.useCallback((pos: DocumentPosition) => {
         setPinnedPositions(pinnedPositions => {
             if (!isPinned(pinnedPositions, pos)) return pinnedPositions;
             return pinnedPositions.filter(p => !DocumentPosition.isEqual(p, pos));
         });
-    }, []);
+    }, [setPinnedPositions]);
 
     // Toggle pin at current position when the editor requests it
     useEvent(ec.events.requestedAction, act => {

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -36,7 +36,6 @@ export function InteractiveTaggedText<T>({fmt, InnerTagUi}: InteractiveTaggedTex
 
 interface TypePopupContentsProps {
   info: SubexprInfo
-  redrawTooltip: () => void
 }
 
 function Markdown({contents}: {contents: string}): JSX.Element {
@@ -67,7 +66,7 @@ function Markdown({contents}: {contents: string}): JSX.Element {
 }
 
 /** Shows `explicitValue : itsType` and a docstring if there is one. */
-function TypePopupContents({ info, redrawTooltip }: TypePopupContentsProps) {
+function TypePopupContents({ info }: TypePopupContentsProps) {
   const rs = React.useContext(RpcContext)
   // When `err` is defined we show the error,
   // otherwise if `ip` is defined we show its contents,
@@ -75,10 +74,6 @@ function TypePopupContents({ info, redrawTooltip }: TypePopupContentsProps) {
   const interactive = useAsync(
     () => InteractiveDiagnostics_infoToInteractive(rs, info.info),
     [rs, info.info])
-
-  // We ask the tooltip parent component to relayout whenever our contents change.
-  React.useEffect(() => { void redrawTooltip() },
-    [interactive.state, (interactive as any)?.value, (interactive as any)?.error, redrawTooltip])
 
   // Even when subexpressions are selectable in our parent component, it doesn't make sense
   // to select things inside the *type* of the parent, so we clear the context.
@@ -124,10 +119,6 @@ const DIFF_TAG_TO_EXPLANATION : {[K in DiffTag] : string} = {
  * can be shift-clicked to select it.
  */
 function InteractiveCodeTag({tag: ct, fmt}: InteractiveTagProps<SubexprInfo>) {
-  const mkTooltip = React.useCallback((redrawTooltip: () => void) =>
-    <TypePopupContents info={ct} redrawTooltip={redrawTooltip} />,
-    [ct.info])
-
   const rs = React.useContext(RpcContext)
   const ec = React.useContext(EditorContext)
   const [hoverState, setHoverState] = React.useState<HoverState>('off')
@@ -164,7 +155,7 @@ function InteractiveCodeTag({tag: ct, fmt}: InteractiveTagProps<SubexprInfo>) {
 
   return (
     <WithTooltipOnHover
-      mkTooltipContent={mkTooltip}
+      tooltipChildren={<TypePopupContents info={ct} />}
       onClick={(e, next) => {
         // On ctrl-click or ⌘-click, if location is known, go to it in the editor
         if (e.ctrlKey || e.metaKey) {

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -141,7 +141,7 @@ function InteractiveCodeTag({tag: ct, fmt}: InteractiveTagProps<SubexprInfo>) {
   }, [rs, ct.info, goToLoc])
   // Eagerly fetch the location as soon as the pointer enters this area so that we can show
   // an underline if a jump target is available.
-  React.useEffect(() => { if (hoverState === 'ctrlOver') void fetchGoToLoc() }, [hoverState])
+  React.useEffect(() => { if (hoverState === 'ctrlOver') void fetchGoToLoc() }, [hoverState, fetchGoToLoc])
 
   const locs = React.useContext(LocationsContext)
   const ourLoc = locs && locs.subexprTemplate && ct.subexprPos ?

--- a/lean4-infoview/src/infoview/messages.tsx
+++ b/lean4-infoview/src/infoview/messages.tsx
@@ -99,11 +99,10 @@ function lazy<T>(f: () => T): () => T {
 /** Displays all messages for the specified file. Can be paused. */
 export function AllMessages({uri: uri0}: { uri: DocumentUri }) {
     const ec = React.useContext(EditorContext);
-    const sv = React.useContext(VersionContext);
     const rs0 = useRpcSessionAtPos({ uri: uri0, line: 0, character: 0 });
     const dc = React.useContext(LspDiagnosticsContext);
     const config = React.useContext(ConfigContext);
-    const diags0 = dc.get(uri0) || [];
+    const diags0 = React.useMemo(() => dc.get(uri0) || [], [dc, uri0]);
 
     const iDiags0 = React.useMemo(() => lazy(async () => {
         try {
@@ -122,7 +121,7 @@ export function AllMessages({uri: uri0}: { uri: DocumentUri }) {
             }
         }
         return diags0.map(d => ({ ...(d as LeanDiagnostic), message: { text: d.message } }));
-    }), [sv, rs0, uri0, diags0]);
+    }), [rs0, diags0]);
     const [{ isPaused, setPaused }, [uri, rs, diags, iDiags], _] = usePausableState(false, [uri0, rs0, diags0, iDiags0]);
 
     // Fetch interactive diagnostics when we're entering the paused state

--- a/lean4-infoview/src/infoview/rpcSessions.tsx
+++ b/lean4-infoview/src/infoview/rpcSessions.tsx
@@ -18,14 +18,14 @@ export function WithRpcSessions({ children }: { children: React.ReactNode }) {
     React.useEffect(() => {
         // Clean up the sessions on unmount
         return () => sessions.dispose()
-    }, [])
+    }, [sessions])
 
     useClientNotificationEffect(
         'textDocument/didClose',
         (params: DidCloseTextDocumentParams) => {
             sessions.closeSessionForFile(params.textDocument.uri)
         },
-        []
+        [sessions]
     )
 
     // TODO: only restart files for the server that stopped

--- a/lean4-infoview/src/infoview/tooltips.tsx
+++ b/lean4-infoview/src/infoview/tooltips.tsx
@@ -167,7 +167,9 @@ export function Tooltip(props_: TooltipProps) {
         strokeWidth={1}
         stroke="var(--vscode-editorHoverWidget-border)"
       />
+      <div className='tooltip-content'>
       {mkTooltipContent(update_)}
+      </div>
     </div>
   )
 

--- a/lean4-infoview/src/infoview/tooltips.tsx
+++ b/lean4-infoview/src/infoview/tooltips.tsx
@@ -119,7 +119,7 @@ export const DetectHoverSpan =
       document.removeEventListener('keydown', onKeyDown)
       document.removeEventListener('keyup', onKeyUp)
     }
-  }, [])
+  }, [setHoverState])
 
   return <span
       {...props}

--- a/lean4-infoview/src/infoview/tooltips.tsx
+++ b/lean4-infoview/src/infoview/tooltips.tsx
@@ -3,6 +3,7 @@ import * as ReactDOM from 'react-dom'
 
 import {
   detectOverflow, useFloating, MiddlewareState, Side, Coords, SideObject,
+  flip, shift, offset, arrow, FloatingArrow
 } from '@floating-ui/react';
 
 import { forwardAndUseRef, LogicalDomContext, useLogicalDom, useOnClickOutside } from './util'
@@ -135,10 +136,11 @@ export const Tooltip = forwardAndUseRef<HTMLDivElement,
       mkTooltipContent: MkTooltipContentFn,
     }>((props_, _, setDivRef) => {
   const {reference, pointerPos, mkTooltipContent, ...props} = props_
+  const arrowRef = React.useRef(null);
 
-  const { strategy, refs, update } = useFloating({
-    strategy: 'absolute',
-    middleware: [ pointer(pointerPos), ]
+  const { refs, update, floatingStyles, context } = useFloating({
+    placement: 'top',
+    middleware: [offset(8), flip(), shift(), arrow({ element: arrowRef, })]
   })
   const update_ = React.useCallback(() => update?.(), [update])
 
@@ -151,10 +153,17 @@ export const Tooltip = forwardAndUseRef<HTMLDivElement,
         setDivRef(node)
         logicalDom.registerDescendant(node)
       }}
-      style={{ position: strategy, top: 0, left: 0}}
+      style={floatingStyles}
       className='tooltip'
       {...props}
     >
+      <FloatingArrow
+        ref={arrowRef}
+        context={context}
+        fill="var(--vscode-editorHoverWidget-background)"
+        strokeWidth={1}
+        stroke="var(--vscode-editorHoverWidget-border)"
+      />
       {mkTooltipContent(update_)}
     </div>
   )

--- a/lean4-infoview/src/infoview/tooltips.tsx
+++ b/lean4-infoview/src/infoview/tooltips.tsx
@@ -141,12 +141,14 @@ export function Tooltip(props_: TooltipProps) {
     middleware: [
       offset(8),
       shift(),
-      autoPlacement(),
+      autoPlacement({
+        padding: 10,
+      }),
       size({
         apply({availableHeight, elements}) {
-          const availHeight = Math.max(availableHeight - 10, 0)
-          elements.floating.style.maxHeight = `${Math.min(availHeight, 300)}px`
-        }
+          elements.floating.style.maxHeight = `${Math.min(availableHeight, 300)}px`
+        },
+        padding: 10
       }),
       // NOTE: `padding` should be `tooltip.borderRadius` or more so that the arrow
       // doesn't overflow the rounded corner.

--- a/lean4-infoview/src/infoview/traceExplorer.tsx
+++ b/lean4-infoview/src/infoview/traceExplorer.tsx
@@ -90,7 +90,7 @@ function CollapsibleTraceNode(traceEmbed: TraceEmbed) {
         ev.stopPropagation()
         if (!open) void fetchChildren();
         setOpen(o => !o)
-    }, [open])
+    }, [open, fetchChildren])
 
     return <div>
         <div className='pointer' onClick={onClick}><TraceLine {...traceEmbed} icon={icon} /></div>

--- a/lean4-infoview/src/infoview/util.ts
+++ b/lean4-infoview/src/infoview/util.ts
@@ -188,7 +188,7 @@ export function addUniqueKeys<T>(elems: T[], getId: (el: T) => string): Keyed<T>
   });
 }
 
-/** Like `React.forwardRef`, but also allows using the ref inside the forwarding component.
+/** Like `React.forwardRef`, but also allows reading the ref inside the forwarding component.
  * Adapted from https://itnext.io/reusing-the-ref-from-forwardref-with-react-hooks-4ce9df693dd */
 export function forwardAndUseRef<T, P>(render: (props: P, ref: React.RefObject<T>, setRef: (_: T | null) => void)
     => React.ReactElement | null): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> {
@@ -206,60 +206,86 @@ export function forwardAndUseRef<T, P>(render: (props: P, ref: React.RefObject<T
   })
 }
 
+/** Like `forwardAndUseRef`, but the ref is stored in state so that setting it triggers a render.
+ * Should only be used if re-rendering is necessary. */
+export function forwardAndUseStateRef<T, P>(render: (props: P, ref: T | null, setRef: (_: T | null) => void)
+    => React.ReactElement | null): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> {
+  return React.forwardRef<T, P>((props, ref) => {
+    const [thisRef, setThisRef] = React.useState<T | null>(null)
+    return render(props, thisRef, v => {
+      setThisRef(v)
+      if (!ref) return
+      if (typeof ref === 'function') {
+        ref(v)
+      } else {
+        ref.current = v
+      }
+    })
+  })
+}
+
 export interface LogicalDomElement {
   contains(el: Node): boolean
 }
 
 export interface LogicalDomStorage {
-  // Returns a function which disposes of the registration.
-  registerDescendant(el: HTMLElement | null): () => void
+  /** Registers a descendant in the logical DOM.
+   * Returns a function which disposes of the registration. */
+  registerDescendant(el: LogicalDomElement): () => void
 }
 
 export const LogicalDomContext = React.createContext<LogicalDomStorage>({registerDescendant: () => () => {}})
 
-/** Suppose a component B appears as a React child of the component A. For layout reasons,
- * we sometimes don't want B to appear as an actual child of A in the DOM. We may still however
- * want to carry out `contains` checks as if B were there, i.e. according to the React tree
- * structure rather than the DOM structure. While React already correctly propagates DOM events
- * up this logical tree, other functionality such as `contains` is not provided.
+/** Suppose a component B appears as a React descendant of the component A. For layout reasons,
+ * we sometimes don't want B to appear as a descendant of A in the DOM, so we use `createPortal`.
+ * We may still however want to carry out `contains` checks as if B were there, i.e. according to
+ * the React tree structure rather than the DOM structure. While React already correctly propagates
+ * DOM events up the React tree, other functionality such as `contains` is not provided. We provide
+ * it in this hook.
  *
- * This method creates a {@link LogicalDomElement} corresponding to the given {@link HTMLElement}
- * which provides the missing functionality for that element. For this to work, the element
- * must be wrapped in a {@link LogicalDomContext} set to the {@link LogicalDomStorage} returned
- * from this call.
+ * Accepts a ref to the observed {@link HTMLElement} (A in the example). Returns:
+ * - a {@link LogicalDomElement} which provides `contains` checks for that {@link HTMLElement}; and
+ * - a {@link LogicalDomStorage} which MUST be passed to a {@link LogicalDomContext} enclosing
+ *   the observed {@link HTMLElement}.
  *
- * Additionally, any component which actually introduces React-but-not-DOM children must
- * call `registerDescendant` in the {@link LogicalDomContext}. */
-export function useLogicalDom(ref: React.RefObject<HTMLElement>): [LogicalDomElement, LogicalDomStorage] {
+ * Additionally, any component which introduces a portal MUST call `registerDescendant` in the
+ * {@link LogicalDomContext} with a ref to the portalled component (B in the example). */
+export function useLogicalDomObserver(elt: React.RefObject<HTMLElement>): [LogicalDomElement, LogicalDomStorage] {
   const parentCtx = React.useContext(LogicalDomContext)
-  React.useEffect(() => {
-    if (ref.current) {
-      const h = parentCtx.registerDescendant(ref.current)
-      return () => h()
-    }
-  }, [ref, parentCtx])
-  const descendants = React.useRef<Set<Node>>(new Set())
+  const descendants = React.useRef<Set<LogicalDomElement>>(new Set())
 
-  const contains = (el: Node) => {
-    if (ref.current && ref.current.contains(el)) return true
+  // Provides a `contains` check for the children only, but not the observed element.
+  // We pass this to the parent context under the assumption that its own DOM-based
+  // `contains` check already includes the observed element.
+  const logicalChildrenElt = React.useMemo(() => ({
+    contains: (e: Node) => {
     for (const d of descendants.current) {
-      if (d.contains(el)) return true
+        if (d.contains(e)) return true
     }
     return false
   }
+  }), [])
 
-  const registerDescendant = (el: HTMLElement | null) => {
-    const h = parentCtx.registerDescendant(el)
-    if (el) descendants.current.add(el)
-    return () => {
-      if (el) descendants.current.delete(el)
-      h()
+  React.useEffect(() => parentCtx.registerDescendant(logicalChildrenElt), [parentCtx, logicalChildrenElt])
+
+  const logicalElt = React.useMemo(() => ({
+    contains: (e: Node) => {
+      if (!elt.current) return false
+      if (elt.current.contains(e)) return true
+      return logicalChildrenElt.contains(e)
     }
-  }
+  }), [elt, logicalChildrenElt])
+
+  const registerDescendant = React.useCallback((el: LogicalDomElement) => {
+    descendants.current.add(el)
+    return () => {
+      descendants.current.delete(el)
+    }
+  }, [])
 
   return [
-    React.useMemo(() => ({ contains }), [ref]),
-    React.useMemo(() => ({ registerDescendant }), [parentCtx])
+    logicalElt,
+    React.useMemo(() => ({ registerDescendant }), [registerDescendant])
   ]
 }
 

--- a/lean4-infoview/src/infoview/util.ts
+++ b/lean4-infoview/src/infoview/util.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable react-hooks/exhaustive-deps */
 import * as React from 'react';
 import type { DocumentUri, Position, Range, TextDocumentPositionParams } from 'vscode-languageserver-protocol';
 

--- a/lean4-infoview/src/loader.ts
+++ b/lean4-infoview/src/loader.ts
@@ -8,7 +8,7 @@ import type { renderInfoview } from './index';
  *
  * @param imports is the `imports` section of an [`importmap`](https://github.com/WICG/import-maps).
  * It must contain URLs for `@leanprover/infoview`, `react`, `react/jsx-runtime`, `react-dom`,
- * `react-popper`. It may include additional URLs. The listed libraries become `import`able
+ * It may include additional URLs. The listed libraries become `import`able
  * from user widgets. Note that `dist/` already includes these files, so the following works:
  * ```js
  * {
@@ -16,7 +16,6 @@ import type { renderInfoview } from './index';
  * 'react': 'https://unpkg.com/@leanprover/infoview/dist/react.production.min.js',
  * 'react/jsx-runtime': 'https://unpkg.com/@leanprover/infoview/dist/react-jsx-runtime.production.min.js',
  * 'react-dom': 'https://unpkg.com/@leanprover/infoview/dist/react-dom.production.min.js',
- * 'react-popper': 'https://unpkg.com/@leanprover/infoview/dist/react-popper.production.min.js'
  * }
  * ```
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@typescript-eslint/eslint-plugin": "^5.49.0",
         "@typescript-eslint/parser": "^5.49.0",
         "eslint": "^8.33.0",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "lerna": "^6.4.1",
         "typescript": "^4.9.4"
       }
@@ -3281,6 +3282,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-scope": {
@@ -10839,6 +10852,13 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.49.0",
     "eslint": "^8.33.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "lerna": "^6.4.1",
     "typescript": "^4.9.4"
   }

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -762,7 +762,6 @@ export class InfoProvider implements Disposable {
                     data-importmap-react="${this.getLocalPath(`dist/lean4-infoview/react${libPostfix}`)}"
                     data-importmap-react-jsx-runtime="${this.getLocalPath(`dist/lean4-infoview/react-jsx-runtime${libPostfix}`)}"
                     data-importmap-react-dom="${this.getLocalPath(`dist/lean4-infoview/react-dom${libPostfix}`)}"
-                    data-importmap-react-popper="${this.getLocalPath(`dist/lean4-infoview/react-popper${libPostfix}`)}"
                     src="${this.getLocalPath('dist/webview.js')}"></script>
             </body>
             </html>`

--- a/vscode-lean4/webview/index.ts
+++ b/vscode-lean4/webview/index.ts
@@ -16,7 +16,6 @@ if (div && script) {
         'react': script.getAttribute('data-importmap-react')!,
         'react/jsx-runtime': script.getAttribute('data-importmap-react-jsx-runtime')!,
         'react-dom': script.getAttribute('data-importmap-react-dom')!,
-        'react-popper': script.getAttribute('data-importmap-react-popper')!,
     }
     loadRenderInfoview(imports, [editorApi, div], api => rpc.register(api));
 }


### PR DESCRIPTION
# Summary
This fix resolves #280, and #210.

# Changes
- Replaced popper 2 with floating-ui.
- Update CSS for tooltip to allow for markdown comment scrolling when tooltip exceeds a certain height.
- Ensure tooltip stays within the infoview viewport by implementing custom flip logic as a floating-ui middleware. Tooltip position is based on pointer position instead of the size and position of the reference element - the element that is being hovered over. This allows for proper tooltip placement, regardless of the shape and size of the reference element. The default position of the tooltip is above and to the right of the pointer. The direction of the flip and the level of offset is based on the quadrant - within the viewport - in which the pointer was located when the hover event was triggered. Viewport quadrants are recalculated every time the hover event is triggered.

Below is a gif which exemplifies the typical behavior of the tooltip:
![input mov](https://user-images.githubusercontent.com/10223519/225145447-20c1ea70-fda3-4fd9-9db4-b0df448b91c8.gif)
