### PR TITLE
feat: Stop server command

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ The format below is: "`lean4.commandName` (command name): description", where `l
 * `lean4.restartServer` (Lean 4: Restart Server): restart the Lean 4 Language Server.
 Useful if you built new `.olean` files in your workspace.
 
+* `lean4.stopServer` (Lean 4: Stop Server): stop the Lean 4 Language Server.
+
 * `lean4.restartFile` (Lean 4: Restart File): restarts the Lean server for a single file.
 Useful if the server crashes.
 As a side-effect this command will also recompile all dependencies.

--- a/vscode-lean4/package-lock.json
+++ b/vscode-lean4/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lean4",
-	"version": "0.0.100",
+	"version": "0.0.101",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lean4",
-			"version": "0.0.100",
+			"version": "0.0.101",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"axios": "~0.24.0",

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -160,6 +160,12 @@
 				"description": "Restart the Lean server (for all files)."
 			},
 			{
+				"command": "lean4.stopServer",
+				"category": "Lean 4",
+				"title": "Stop Server",
+				"description": "Stop the Lean server (for all files)."
+			},
+			{
 				"command": "lean4.restartFile",
 				"category": "Lean 4",
 				"title": "Restart File",
@@ -334,6 +340,10 @@
 				},
 				{
 					"command": "lean4.restartServer",
+					"when": "editorLangId == lean4"
+				},
+				{
+					"command": "lean4.stopServer",
 					"when": "editorLangId == lean4"
 				},
 				{

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -50,7 +50,8 @@ export class LeanClientProvider implements Disposable {
         this.subscriptions.push(
             commands.registerCommand('lean4.restartFile', () => this.restartFile()),
             commands.registerCommand('lean4.refreshFileDependencies', () => this.restartFile()),
-            commands.registerCommand('lean4.restartServer', () => this.restartActiveClient())
+            commands.registerCommand('lean4.restartServer', () => this.restartActiveClient()),
+            commands.registerCommand('lean4.stopServer', () => this.stopActiveClient())
         );
 
         workspace.onDidOpenTextDocument((document) => this.didOpenEditor(document));
@@ -138,6 +139,10 @@ export class LeanClientProvider implements Disposable {
         if (window.activeTextEditor && this.activeClient && window.activeTextEditor.document.languageId ==='lean4') {
             void this.activeClient.restartFile(window.activeTextEditor.document);
         }
+    }
+
+    private stopActiveClient() {
+        void this.activeClient?.stop();
     }
 
     private restartActiveClient() {


### PR DESCRIPTION
This adds a "Lean 4: Stop server" command.

It's not ideal, as it generates a pop-up saying "Lean server printed an error: Watchdog error: Got `shutdown` request, expected an `exit` notification". If someone knows how to avoid this please let me know or make the change!