### PR TITLE
fix: do not hide assumptions in goal embeds

### DIFF
--- a/lean4-infoview/src/infoview/traceExplorer.tsx
+++ b/lean4-infoview/src/infoview/traceExplorer.tsx
@@ -113,7 +113,7 @@ function InteractiveMessageTag({tag: embed}: InteractiveTagProps<MsgEmbed>): JSX
     if ('expr' in embed)
         return <InteractiveCode fmt={embed.expr} />
     else if ('goal' in embed)
-        return <Goal goal={embed.goal} filter={{reverse: false, showType: false, showInstance: false, showHiddenAssumption: false, showLetValue: false}} />
+        return <Goal goal={embed.goal} filter={{reverse: false, showType: true, showInstance: true, showHiddenAssumption: true, showLetValue: true}} />
     else if ('lazyTrace' in embed)
         return <LazyTrace col={embed.lazyTrace[0]} cls={embed.lazyTrace[1]} msg={embed.lazyTrace[2]} />
     else if ('trace' in embed)


### PR DESCRIPTION
I think this was just an oversight in the initial implementation, but posting it as a PR for visibility.
```lean
example : Nat → Nat :=
  fun _ => _
         --^ check out the error here
```
The error shows that we cannot fill in the placeholder `x✝: Nat ⊢ Nat`.  However we hide the `x✝` in goal embeds in the vscode extension.  It is shown just fine on the command-line and in neovim.

So to make it consistent with both the tactic state display and the other editors, this PR disables the hiding in this special case.