### PR TITLE
feat: shortcut for notation `HImp.himp`

### DIFF
--- a/vscode-lean4/src/abbreviation/abbreviations.json
+++ b/vscode-lean4/src/abbreviation/abbreviations.json
@@ -445,6 +445,8 @@
     "to_s": "→ₛ",
     "r_s": "→ₛ",
     "simplefunc": "→ₛ",
+    "heyting": "⇨",
+    "himp": "⇨",
 
     "covers": "⋖",
     "covby": "⋖",


### PR DESCRIPTION
[`HImp.himp`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/Heyting/Basic.html#HImp)