### PR TITLE
feat: select subexpressions on contextmenu event

### DIFF
--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -166,6 +166,19 @@ function InteractiveCodeTag({tag: ct, fmt}: InteractiveTagProps<SubexprInfo>) {
           })
         } else if (!e.shiftKey) next(e)
       }}
+      onContextMenu={e => {
+        // Mark the event as seen so that parent handlers skip it.
+        // We cannot use `stopPropagation` as that prevents the VSC context menu from showing up.
+        if ('_InteractiveCodeTagSeen' in e) return
+        (e as any)['_InteractiveCodeTagSeen'] = {}
+        if (!(e.target instanceof Node)) return
+        if (!e.currentTarget.contains(e.target)) return
+        // Select the pretty-printed code.
+        const sel = window.getSelection()
+        if (!sel) return
+        sel.removeAllRanges()
+        sel.selectAllChildren(e.currentTarget)
+      }}
     >
       <SelectableLocation
         setHoverState={setHoverState}

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -170,7 +170,7 @@ function InteractiveCodeTag({tag: ct, fmt}: InteractiveTagProps<SubexprInfo>) {
         // Mark the event as seen so that parent handlers skip it.
         // We cannot use `stopPropagation` as that prevents the VSC context menu from showing up.
         if ('_InteractiveCodeTagSeen' in e) return
-        (e as any)['_InteractiveCodeTagSeen'] = {}
+        (e as any)._InteractiveCodeTagSeen = {}
         if (!(e.target instanceof Node)) return
         if (!e.currentTarget.contains(e.target)) return
         // Select the pretty-printed code.


### PR DESCRIPTION
Fixes #311. This is a stopgap that I didn't think through very much, but seems to work.

https://github.com/leanprover/vscode-lean4/assets/13901751/7228926d-1bb9-4c7b-81bb-52b1e25900ad