### PR TITLE
Update Documentation View

### DIFF
--- a/vscode-lean4/package-lock.json
+++ b/vscode-lean4/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lean4",
-	"version": "0.0.110",
+	"version": "0.0.111",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lean4",
-			"version": "0.0.110",
+			"version": "0.0.111",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"axios": "~0.24.0",

--- a/vscode-lean4/src/docview.ts
+++ b/vscode-lean4/src/docview.ts
@@ -224,9 +224,11 @@ export class DocViewProvider implements Disposable {
             }
 
             const books : any = {
-                'Theorem Proving in Lean': mkCommandUri('lean4.docView.open', 'https://leanprover.github.io/theorem_proving_in_lean4/introduction.html'),
+                'Theorem Proving in Lean': mkCommandUri('lean4.docView.open', 'https://lean-lang.org/theorem_proving_in_lean4/introduction.html'),
+                'Functional Programming in Lean': mkCommandUri('lean4.docView.open', 'https://lean-lang.org/functional_programming_in_lean/'),
                 'Mathematics in Lean': mkCommandUri('lean4.docView.open', 'https://leanprover-community.github.io/mathematics_in_lean/'),
-                'Reference Manual': mkCommandUri('lean4.docView.open', 'https://leanprover.github.io/lean4/doc/'),
+                'The Mechanics of Proof': mkCommandUri('lean4.docView.open', 'https://hrmacbeth.github.io/math2001/'),
+                'Reference Manual': mkCommandUri('lean4.docView.open', 'https://lean-lang.org/lean4/doc/'),
                 'Abbreviations Cheatsheet': mkCommandUri('lean4.docView.showAllAbbreviations'),
                 'Example': mkCommandUri('lean4.openExample', 'https://github.com/leanprover/lean4-samples/raw/main/HelloWorld/Main.lean'),
 


### PR DESCRIPTION
```
- Update existing documentation links to point to `lean-lang.org`
- Add new doc links:
  - Functional Programming in Lean
  - The Mechanics of Proof
```

These links are from the [Lean docs](https://lean-lang.org/documentation/) website.