### PR TITLE
Add opt-in dependency builds when opening files

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -64,6 +64,11 @@
 					"default": true,
 					"markdownDescription": "Enable eager replacement of abbreviations that uniquely identify a symbol."
 				},
+				"lean4.automaticallyBuildDependencies": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Enable automatically building dependencies when opening a file."
+				},
 				"lean4.serverEnv": {
 					"type": "object",
 					"default": {},

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -67,7 +67,7 @@
 				"lean4.automaticallyBuildDependencies": {
 					"type": "boolean",
 					"default": false,
-					"markdownDescription": "Enable automatically building dependencies when opening a file."
+					"markdownDescription": "Enable automatically building dependencies when opening a file. This is the default for Lean 4 versions before 4.2.0."
 				},
 				"lean4.serverEnv": {
 					"type": "object",

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -67,7 +67,7 @@
 				"lean4.automaticallyBuildDependencies": {
 					"type": "boolean",
 					"default": false,
-					"markdownDescription": "Enable automatically building dependencies when opening a file. This is the default for Lean 4 versions before 4.2.0."
+					"markdownDescription": "Enable automatically building dependencies when opening a file. In Lean versions pre-4.2.0, dependencies are always built automatically regardless of this setting."
 				},
 				"lean4.serverEnv": {
 					"type": "object",

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -146,6 +146,10 @@ export function serverEnv(): object {
     return workspace.getConfiguration('lean4').get('serverEnv', {})
 }
 
+export function automaticallyBuildDependencies(): boolean {
+    return workspace.getConfiguration('lean4').get('automaticallyBuildDependencies', false)
+}
+
 export function serverEnvPaths(): string[] {
     return workspace.getConfiguration('lean4').get('serverEnvPaths', [])
 }

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -415,7 +415,7 @@ export class LeanClient implements Disposable {
                 version: 1,
                 text: doc.getText(),
             },
-            extraPrintPathsFlags: automaticallyBuildDependencies() ? [] : ['--no-build']
+            dependencyBuildMode: automaticallyBuildDependencies() ? 'always' : 'never'
         });
     }
 
@@ -505,12 +505,13 @@ export class LeanClient implements Disposable {
             }
         })
         void this.client?.sendNotification('textDocument/didOpen', {
-            'textDocument': {
+            textDocument: {
                 uri,
-                'languageId': 'lean4',
-                'version': 1,
-                'text': doc.getText()
-            }
+                languageId: 'lean4',
+                version: 1,
+                text: doc.getText()
+            },
+            dependencyBuildMode: automaticallyBuildDependencies() ? 'always' : 'once'
         })
         this.restartedWorkerEmitter.fire(uri)
     }

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -17,7 +17,7 @@ import {
 } from 'vscode-languageclient/node'
 import * as ls from 'vscode-languageserver-protocol'
 
-import { toolchainPath, lakePath, addServerEnvPaths, serverArgs, serverLoggingEnabled, serverLoggingPath, shouldAutofocusOutput, getElaborationDelay, lakeEnabled } from './config'
+import { toolchainPath, lakePath, addServerEnvPaths, serverArgs, serverLoggingEnabled, serverLoggingPath, shouldAutofocusOutput, getElaborationDelay, lakeEnabled, automaticallyBuildDependencies } from './config'
 import { assert } from './utils/assert'
 import { LeanFileProgressParams, LeanFileProgressProcessingInfo, ServerStoppedReason } from '@leanprover/infoview-api';
 import { batchExecute } from './utils/batch'
@@ -408,13 +408,14 @@ export class LeanClient implements Disposable {
     }
 
     notifyDidOpen(doc: TextDocument) {
-        void this.client?.sendNotification(DidOpenTextDocumentNotification.type, {
+        void this.client?.sendNotification('textDocument/didOpen', {
             textDocument: {
                 uri: doc.uri.toString(),
                 languageId: doc.languageId,
                 version: 1,
                 text: doc.getText(),
             },
+            extraPrintPathsFlags: automaticallyBuildDependencies() ? [] : ['--no-build']
         });
     }
 


### PR DESCRIPTION
This PR adds extension support for the `--no-build` flag when opening files so that dependencies are not automatically built anymore, overwriting existing oleans.

It rests on the corresponding backend change at leanprover/lean4#2665 and was originally motivated by https://github.com/leanprover/lean4/issues/2154#issuecomment-1655471667.