### PR TITLE
Assorted minor quality improvements #2

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -421,74 +421,74 @@
 				"command": "lean4.restartFile",
 				"key": "ctrl+shift+x",
 				"mac": "cmd+shift+x",
-				"when": "editorTextFocus && editorLangId == lean4"
+				"when": "lean4.isLeanFeatureSetActive"
 			},
 			{
 				"command": "lean4.toggleInfoview",
 				"key": "ctrl+shift+enter",
 				"mac": "cmd+shift+enter",
-				"when": "editorTextFocus && editorLangId == lean4"
+				"when": "lean4.isLeanFeatureSetActive"
 			},
 			{
 				"command": "lean4.displayList",
 				"key": "ctrl+shift+alt+enter",
 				"mac": "cmd+shift+alt+enter",
-				"when": "editorTextFocus && editorLangId == lean4"
+				"when": "lean4.isLeanFeatureSetActive"
 			}
 		],
 		"menus": {
 			"commandPalette": [
 				{
 					"command": "lean4.restartServer",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.stopServer",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.restartFile",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.refreshFileDependencies",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.input.convert",
-					"when": "editorLangId == lean4 && lean4.input.isActive"
+					"when": "lean4.isLeanFeatureSetActive && lean4.input.isActive"
 				},
 				{
 					"command": "lean4.displayGoal",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.toggleInfoview",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.displayList",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.infoView.copyToComment",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.infoView.toggleStickyPosition",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.infoView.toggleUpdating",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.infoView.toggleExpectedType",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.docView.showAllAbbreviations",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.docView.open"
@@ -522,19 +522,19 @@
 				},
 				{
 					"command": "lean4.project.build",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.project.clean",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.project.updateDependency",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				},
 				{
 					"command": "lean4.project.fetchCache",
-					"when": "editorLangId == lean4"
+					"when": "lean4.isLeanFeatureSetActive"
 				}
 			],
 			"editor/title": [

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -8,6 +8,7 @@ import { checkParentFoldersForLeanProject, findLeanPackageRoot, isValidLeanProje
 import { isFileInFolder } from './fsHelper';
 import { logger } from './logger'
 import { addDefaultElanPath, getDefaultElanPath, addToolchainBinPath, isElanDisabled, isRunningTest, shouldShowInvalidProjectWarnings } from '../config'
+import { displayErrorWithOutput } from './errors';
 
 // This class ensures we have one LeanClient per workspace folder.
 export class LeanClientProvider implements Disposable {
@@ -357,6 +358,7 @@ export class LeanClientProvider implements Disposable {
                     // as a result of UI options shown by testLeanVersion.
                     await client.start();
                 } else {
+                    void displayErrorWithOutput('Cannot determine Lean version: ' + versionInfo.error)
                     logger.log(`[ClientProvider] skipping client.start because of versionInfo error: ${versionInfo?.error}`);
                 }
             }


### PR DESCRIPTION
* Ensure that "Restart File" (Ctrl+Shift+X) does not open the extensions menu anymore when in a Lean 4 context
* Make "Toggle Infoview" and "Toggle All Messages" keybindings work when not focusing the editor window
* Ensure that commands displayed in command pallette are independent of focused part of VS Code
* Fix Lean server crashing with bad error message when no default toolchain is set because it was uninstalled in the past