### PR TITLE
Still start language client when project folder is invalid

### DIFF
--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -198,9 +198,9 @@ export class LeanClientProvider implements Disposable {
                 return
             }
 
-            await this.checkIsValidProjectFolder(client.folderUri)
-
             await client.openLean4Document(document)
+
+            await this.checkIsValidProjectFolder(client.folderUri)
         } catch (e) {
             logger.log(`[ClientProvider] ### Error opening document: ${e}`);
         }


### PR DESCRIPTION
When the client would report an error that the project folder is invalid and suggest a parent folder to open, the client wouldn't open the file until the dialog is dismissed. This fixes the issue.