### PR TITLE
Update lean toolchain after `lake update`

### DIFF
--- a/vscode-lean4/src/projectoperations.ts
+++ b/vscode-lean4/src/projectoperations.ts
@@ -168,7 +168,7 @@ export class ProjectOperationProvider implements Disposable {
             await this.tryFetchingCache(lakeRunner)
 
             const localToolchainPath: string = join(activeClient.folderUri.fsPath, 'lean-toolchain')
-            const dependencyToolchainPath: string = join(activeClient.folderUri.fsPath, 'lake-packages', dependencyChoice.name, 'lean-toolchain')
+            const dependencyToolchainPath: string = join(activeClient.folderUri.fsPath, manifestResult.packagesDir, dependencyChoice.name, 'lean-toolchain')
             const dependencyToolchainResult: string | 'DoNotUpdate' | 'Cancelled' = await this.determineDependencyToolchain(localToolchainPath, dependencyToolchainPath, dependencyChoice.name)
             if (dependencyToolchainResult === 'Cancelled') {
                 return

--- a/vscode-lean4/src/utils/manifest.ts
+++ b/vscode-lean4/src/utils/manifest.ts
@@ -11,6 +11,7 @@ export interface DirectGitDependency {
 }
 
 export interface Manifest {
+    packagesDir: string
     directGitDependencies: DirectGitDependency[]
 }
 
@@ -23,6 +24,7 @@ export function parseAsManifest(jsonString: string): Manifest | undefined {
     }
 
     const schema = z.object({
+        packagesDir: z.string(),
         packages: z.array(
             z.union([
                 z.object({
@@ -45,7 +47,7 @@ export function parseAsManifest(jsonString: string): Manifest | undefined {
         return undefined
     }
 
-    const manifest: Manifest = { directGitDependencies: [] }
+    const manifest: Manifest = { packagesDir: result.data.packagesDir, directGitDependencies: [] }
 
     for (const pkg of result.data.packages) {
         if (!('git' in pkg)) {


### PR DESCRIPTION
This PR adjusts the `Project: Update Dependency` command so that it updates the toolchain *after* running `lake update`. This was prompted by the introduction of a post-update hook in leanprover-community/mathlib4#8243 that automatically updates the toolchain.

With the post-update hook and asking to update the toolchain before running `lake update`, a user decision of "Do not update the toolchain" would be ignored for projects downstream of Mathlib, as the post-update hook will update the toolchain regardless of the user choice. Asking to update the toolchain (if it changed) after `lake update` ensures users do not see a misleading dialog.

One caveat is that this means that we will now run `lake update` with the Lean version of the project itself, not the Lean version of its dependency.

Another change induced by switching the order of operations is that we can now read the toolchain from `lake-packages` instead of fetching it from `raw.githubusercontent.com`.