### PR TITLE
fix: update lake manifest parsing for manifest version 7

### DIFF
--- a/vscode-lean4/src/utils/manifest.ts
+++ b/vscode-lean4/src/utils/manifest.ts
@@ -15,15 +15,8 @@ export interface Manifest {
     directGitDependencies: DirectGitDependency[]
 }
 
-export function parseAsManifest(jsonString: string): Manifest | undefined {
-    let parsedJson: any
-    try {
-        parsedJson = JSON.parse(jsonString)
-    } catch (e) {
-        return undefined
-    }
-
-    const schema = z.object({
+function parseVersion1To6Manifest(parsedJson: any) {
+    const version1To6ManifestSchema = z.object({
         packagesDir: z.string(),
         packages: z.array(
             z.union([
@@ -42,7 +35,8 @@ export function parseAsManifest(jsonString: string): Manifest | undefined {
             ])
         )
     })
-    const result = schema.safeParse(parsedJson)
+
+    const result = version1To6ManifestSchema.safeParse(parsedJson)
     if (!result.success) {
         return undefined
     }
@@ -57,17 +51,84 @@ export function parseAsManifest(jsonString: string): Manifest | undefined {
             continue // Inherited Git packages are not direct dependencies
         }
 
-        const inputRev: string | null | undefined = pkg.git['inputRev?']
-
         manifest.directGitDependencies.push({
             name: pkg.git.name,
             uri: Uri.parse(pkg.git.url),
             revision: pkg.git.rev,
-            inputRevision: inputRev ? inputRev : 'master' // Lake also always falls back to master
+            inputRevision: pkg.git['inputRev?'] ?? 'master' // Lake also always falls back to master
         })
     }
 
     return manifest
+}
+
+function parseVersion7ToNManifest(parsedJson: any) {
+    const version7ToNManifestSchema = z.object({
+        packagesDir: z.string(),
+        packages: z.array(
+            z.union([
+                z.object({
+                    type: z.literal('git'),
+                    name: z.string(),
+                    url: z.string().url(),
+                    rev: z.string(),
+                    inherited: z.boolean(),
+                    inputRev: z.optional(z.nullable(z.string()))
+                }),
+                z.object({
+                    type: z.literal('path')
+                })
+            ])
+
+        )
+    })
+
+    const result = version7ToNManifestSchema.safeParse(parsedJson)
+    if (!result.success) {
+        return undefined
+    }
+
+    const manifest: Manifest = { packagesDir: result.data.packagesDir, directGitDependencies: [] }
+
+    for (const pkg of result.data.packages) {
+        if (pkg.type !== 'git') {
+            continue
+        }
+        if (pkg.inherited) {
+            continue // Inherited Git packages are not direct dependencies
+        }
+
+        manifest.directGitDependencies.push({
+            name: pkg.name,
+            uri: Uri.parse(pkg.url),
+            revision: pkg.rev,
+            inputRevision: pkg.inputRev ?? 'master' // Lake also always falls back to master
+        })
+    }
+
+    return manifest
+}
+
+export function parseAsManifest(jsonString: string): Manifest | undefined {
+    let parsedJson: any
+    try {
+        parsedJson = JSON.parse(jsonString)
+    } catch (e) {
+        return undefined
+    }
+
+    const versionSchema = z.object({ version: z.number().int().nonnegative() })
+    const versionResult = versionSchema.safeParse(parsedJson)
+    if (!versionResult.success) {
+        return undefined
+    }
+    const version = versionResult.data.version
+
+    if (version <= 6) {
+        return parseVersion1To6Manifest(parsedJson)
+    } else {
+        return parseVersion7ToNManifest(parsedJson)
+    }
 }
 
 export type ManifestReadError = string


### PR DESCRIPTION
"Update Dependency" was broken because of this since [v4.3.0-rc2](https://github.com/leanprover/lean4/releases/tag/v4.3.0-rc2).