### PR TITLE
fix: open setup guide after installation

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -723,13 +723,12 @@
 		},
 		"walkthroughs": [
 			{
-				"id": "lean4.welcome.linux",
+				"id": "lean4.welcome",
 				"title": "Lean 4 Setup",
-				"description": "Getting started with Lean 4 on Linux\n",
-				"when": "isLinux",
+				"description": "Getting started with Lean 4\n",
 				"steps": [
 					{
-						"id": "lean4.welcome.linux.openSetupGuide",
+						"id": "lean4.welcome.openSetupGuide",
 						"title": "Re-Open Setup Guide",
 						"description": "This guide can always be re-opened by opening an empty file, clicking on the ∀-symbol in the top right and selecting 'Documentation…' > 'Setup: Show Setup Guide'.",
 						"media": {
@@ -738,143 +737,60 @@
 						}
 					},
 					{
-						"id": "lean4.welcome.linux.documentation",
+						"id": "lean4.welcome.documentation",
 						"title": "Books and Documentation",
 						"description": "Learn using Lean 4 with the resources on the right.",
 						"media": { "markdown": "./media/guide-documentation.md" }
 					},
 					{
-						"id": "lean4.welcome.linux.installDeps",
+						"id": "lean4.welcome.installDeps.linux",
 						"title": "Install Required Dependencies",
 						"description": "Install Git and curl using your package manager.",
-						"media": { "markdown": "./media/guide-installDeps-linux.md" }
+						"media": { "markdown": "./media/guide-installDeps-linux.md" },
+						"when": "isLinux"
 					},
 					{
-						"id": "lean4.welcome.linux.installElan",
-						"title": "Install Lean Version Manager",
-						"description": "Install Lean's version manager Elan.\n[Click to install](command:lean4.setup.installElan)",
-						"media": { "markdown": "./media/guide-installElan-unix.md" }
-					},
-					{
-						"id": "lean4.welcome.linux.setupProject",
-						"title": "Set Up Lean 4 Project",
-						"description": "Set up a Lean 4 project by clicking on one of the options on the right.",
-						"media": { "markdown": "./media/guide-setupProject.md" }
-					},
-					{
-						"id": "lean4.welcome.linux.vscode",
-						"title": "Using Lean 4 in VS Code",
-						"description": "Learn how to use Lean 4 together with its VS Code extension.",
-						"media": { "markdown": "./media/guide-vscode.md" }
-					},
-					{
-						"id": "lean4.welcome.linux.help",
-						"title": "Questions and Troubleshooting",
-						"description": "If you have any questions or are having trouble with any of the previous steps, please visit us on the [Lean Zulip chat](https://leanprover.zulipchat.com/) so that we can help you.",
-						"media": { "markdown": "./media/guide-help.md" }
-					}
-				]
-			},
-			{
-				"id": "lean4.welcome.mac",
-				"title": "Lean 4 Setup",
-				"description": "Getting started with Lean 4 on Mac\n",
-				"when": "isMac",
-				"steps": [
-					{
-						"id": "lean4.welcome.mac.openSetupGuide",
-						"title": "Re-Open Setup Guide",
-						"description": "This guide can always be re-opened by opening an empty file, clicking on the ∀-symbol in the top right and selecting 'Documentation…' > 'Setup: Show Setup Guide'.",
-						"media": {
-							"image": "media/open-setup-guide.png",
-							"altText": "Click on the ∀-symbol in the top right and select 'Documentation…' > 'Setup: Show Setup Guide'."
-						}
-					},
-					{
-						"id": "lean4.welcome.mac.documentation",
-						"title": "Books and Documentation",
-						"description": "Learn using Lean 4 with the resources on the right.",
-						"media": { "markdown": "./media/guide-documentation.md" }
-					},
-					{
-						"id": "lean4.welcome.mac.installDeps",
+						"id": "lean4.welcome.installDeps.mac",
 						"title": "Install Required Dependencies",
 						"description": "Install Homebrew, Git and curl.",
-						"media": { "markdown": "./media/guide-installDeps-mac.md" }
+						"media": { "markdown": "./media/guide-installDeps-mac.md" },
+						"when": "isMac"
 					},
 					{
-						"id": "lean4.welcome.mac.installElan",
-						"title": "Install Lean Version Manager",
-						"description": "Install Lean's version manager Elan.\n[Click to install](command:lean4.setup.installElan)",
-						"media": { "markdown": "./media/guide-installElan-unix.md" }
-					},
-					{
-						"id": "lean4.welcome.mac.setupProject",
-						"title": "Set Up Lean 4 Project",
-						"description": "Set up a Lean 4 project by clicking on one of the options on the right.",
-						"media": { "markdown": "./media/guide-setupProject.md" }
-					},
-					{
-						"id": "lean4.welcome.mac.vscode",
-						"title": "Using Lean 4 in VS Code",
-						"description": "Learn how to use Lean 4 together with its VS Code extension.",
-						"media": { "markdown": "./media/guide-vscode.md" }
-					},
-					{
-						"id": "lean4.welcome.mac.help",
-						"title": "Questions and Troubleshooting",
-						"description": "If you have any questions or are having trouble with any of the previous steps, please visit us on the [Lean Zulip chat](https://leanprover.zulipchat.com/) so that we can help you.",
-						"media": { "markdown": "./media/guide-help.md" }
-					}
-				]
-			},
-			{
-				"id": "lean4.welcome.windows",
-				"title": "Lean 4 Setup",
-				"description": "Getting started with Lean 4 on Windows\n",
-				"when": "isWindows",
-				"steps": [
-					{
-						"id": "lean4.welcome.windows.openSetupGuide",
-						"title": "Re-Open Setup Guide",
-						"description": "This guide can always be re-opened by opening an empty file, clicking on the ∀-symbol in the top right and selecting 'Documentation…' > 'Setup: Show Setup Guide'.",
-						"media": {
-							"image": "media/open-setup-guide.png",
-							"altText": "Click on the ∀-symbol in the top right and select 'Documentation…' > 'Setup: Show Setup Guide'."
-						}
-					},
-					{
-						"id": "lean4.welcome.windows.documentation",
-						"title": "Books and Documentation",
-						"description": "Learn using Lean 4 with the resources on the right.",
-						"media": { "markdown": "./media/guide-documentation.md" }
-					},
-					{
-						"id": "lean4.welcome.windows.installDeps",
+						"id": "lean4.welcome.installDeps.windows",
 						"title": "Install Required Dependencies",
 						"description": "Install Git.",
-						"media": { "markdown": "./media/guide-installDeps-windows.md" }
+						"media": { "markdown": "./media/guide-installDeps-windows.md" },
+						"when": "isWindows"
 					},
 					{
-						"id": "lean4.welcome.windows.installElan",
+						"id": "lean4.welcome.installElan.unix",
 						"title": "Install Lean Version Manager",
 						"description": "Install Lean's version manager Elan.\n[Click to install](command:lean4.setup.installElan)",
-						"media": { "markdown": "./media/guide-installElan-windows.md" }
+						"media": { "markdown": "./media/guide-installElan-unix.md" },
+						"when": "isLinux || isMac"
 					},
 					{
-						"id": "lean4.welcome.windows.setupProject",
+						"id": "lean4.welcome.installElan.windows",
+						"title": "Install Lean Version Manager",
+						"description": "Install Lean's version manager Elan.\n[Click to install](command:lean4.setup.installElan)",
+						"media": { "markdown": "./media/guide-installElan-windows.md" },
+						"when": "isWindows"
+					},
+					{
+						"id": "lean4.welcome.setupProject",
 						"title": "Set Up Lean 4 Project",
 						"description": "Set up a Lean 4 project by clicking on one of the options on the right.",
 						"media": { "markdown": "./media/guide-setupProject.md" }
 					},
 					{
-						"id": "lean4.welcome.windows.vscode",
+						"id": "lean4.welcome.vscode",
 						"title": "Using Lean 4 in VS Code",
 						"description": "Learn how to use Lean 4 together with its VS Code extension.",
 						"media": { "markdown": "./media/guide-vscode.md" }
 					},
 					{
-						"id": "lean4.welcome.windows.help",
+						"id": "lean4.welcome.help",
 						"title": "Questions and Troubleshooting",
 						"description": "If you have any questions or are having trouble with any of the previous steps, please visit us on the [Lean Zulip chat](https://leanprover.zulipchat.com/) so that we can help you.",
 						"media": { "markdown": "./media/guide-help.md" }

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -65,17 +65,8 @@ function activateAlwaysEnabledFeatures(context: ExtensionContext): AlwaysEnabled
         addDefaultElanPath();
     }
 
-    context.subscriptions.push(commands.registerCommand('lean4.setup.showSetupGuide', async () => {
-        if (process.platform === 'win32') {
-            await commands.executeCommand('workbench.action.openWalkthrough', 'leanprover.lean4#lean4.welcome.windows', false)
-        } else if (process.platform === 'darwin') {
-            await commands.executeCommand('workbench.action.openWalkthrough', 'leanprover.lean4#lean4.welcome.mac', false)
-        } else if (process.platform === 'linux') {
-            await commands.executeCommand('workbench.action.openWalkthrough', 'leanprover.lean4#lean4.welcome.linux', false)
-        } else {
-            await commands.executeCommand('workbench.action.openWalkthrough', 'leanprover.lean4#lean4.welcome.linux', false)
-        }
-    }))
+    context.subscriptions.push(commands.registerCommand('lean4.setup.showSetupGuide', async () =>
+        commands.executeCommand('workbench.action.openWalkthrough', 'leanprover.lean4#lean4.welcome', false)))
 
     const docView = new DocViewProvider(context.extensionUri);
     context.subscriptions.push(docView);


### PR DESCRIPTION
Because we were contributing three setup guides with mutually exclusive activation conditions, VS Code wasn't sure which to pick for the welcome page after installation and instead decided to pick none.
This PR moves the activation conditions into the guides, thus ensuring that we only contribute a single guide.