### PR TITLE
feat: customizable occurrence highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Read "lean-toolchain" files and do not set --default-toolchain to something specific.
 - elan should not install multiple toolchains.
+- Occurrence highlighting can be configured to ignore string matches and use only Lean's LSP responses
 
 ### 0.0.40 (Oct 21, 2021): c387eab150b988a47956192b0fc48e950f6c1fca
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ name of the relative path to the store the logs.
 
 * `lean4.typesInCompletionList`: controls whether the types of all items in the list of completions are displayed. By default, only the type of the highlighted item is shown.
 
+* `lean4.editor.occurrenceHighlightingMode`: determine whether occurrences should be highlighted using Lean's semantic information (the default) or string matching.
+
 ### Infoview settings
 
 * `lean4.infoview.autoOpen`: controls whether the Infoview is automatically displayed when the Lean extension is activated for the first time in a given VS Code workspace(`true` by default).  If you manually close the Infoview it will stay closed for that workspace until.  You can then open it again using the <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> `Lean 4: Infoview: Display Goal` command.

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -64,6 +64,21 @@
 					"default": true,
 					"markdownDescription": "Enable eager replacement of abbreviations that uniquely identify a symbol."
 				},
+				"lean4.editor.occurrenceHighlightingMode": {
+					"type": "string",
+					"description": "Highlight occurrences using Lean's semantic information, by string matching, or both",
+					"default": "semantic",
+					"enum": [
+						"both",
+						"semantic",
+						"strings"
+					],
+					"enumDescriptions": [
+						"Use Lean's semantic information with string matching as fallback",
+						"Use only Lean's semantic information",
+						"Use only string matching"
+					]
+				},
 				"lean4.automaticallyBuildDependencies": {
 					"type": "boolean",
 					"default": false,
@@ -740,60 +755,78 @@
 						"id": "lean4.welcome.documentation",
 						"title": "Books and Documentation",
 						"description": "Learn using Lean 4 with the resources on the right.",
-						"media": { "markdown": "./media/guide-documentation.md" }
+						"media": {
+							"markdown": "./media/guide-documentation.md"
+						}
 					},
 					{
 						"id": "lean4.welcome.installDeps.linux",
 						"title": "Install Required Dependencies",
 						"description": "Install Git and curl using your package manager.",
-						"media": { "markdown": "./media/guide-installDeps-linux.md" },
+						"media": {
+							"markdown": "./media/guide-installDeps-linux.md"
+						},
 						"when": "isLinux"
 					},
 					{
 						"id": "lean4.welcome.installDeps.mac",
 						"title": "Install Required Dependencies",
 						"description": "Install Homebrew, Git and curl.",
-						"media": { "markdown": "./media/guide-installDeps-mac.md" },
+						"media": {
+							"markdown": "./media/guide-installDeps-mac.md"
+						},
 						"when": "isMac"
 					},
 					{
 						"id": "lean4.welcome.installDeps.windows",
 						"title": "Install Required Dependencies",
 						"description": "Install Git.",
-						"media": { "markdown": "./media/guide-installDeps-windows.md" },
+						"media": {
+							"markdown": "./media/guide-installDeps-windows.md"
+						},
 						"when": "isWindows"
 					},
 					{
 						"id": "lean4.welcome.installElan.unix",
 						"title": "Install Lean Version Manager",
 						"description": "Install Lean's version manager Elan.\n[Click to install](command:lean4.setup.installElan)",
-						"media": { "markdown": "./media/guide-installElan-unix.md" },
+						"media": {
+							"markdown": "./media/guide-installElan-unix.md"
+						},
 						"when": "isLinux || isMac"
 					},
 					{
 						"id": "lean4.welcome.installElan.windows",
 						"title": "Install Lean Version Manager",
 						"description": "Install Lean's version manager Elan.\n[Click to install](command:lean4.setup.installElan)",
-						"media": { "markdown": "./media/guide-installElan-windows.md" },
+						"media": {
+							"markdown": "./media/guide-installElan-windows.md"
+						},
 						"when": "isWindows"
 					},
 					{
 						"id": "lean4.welcome.setupProject",
 						"title": "Set Up Lean 4 Project",
 						"description": "Set up a Lean 4 project by clicking on one of the options on the right.",
-						"media": { "markdown": "./media/guide-setupProject.md" }
+						"media": {
+							"markdown": "./media/guide-setupProject.md"
+						}
 					},
 					{
 						"id": "lean4.welcome.vscode",
 						"title": "Using Lean 4 in VS Code",
 						"description": "Learn how to use Lean 4 together with its VS Code extension.",
-						"media": { "markdown": "./media/guide-vscode.md" }
+						"media": {
+							"markdown": "./media/guide-vscode.md"
+						}
 					},
 					{
 						"id": "lean4.welcome.help",
 						"title": "Questions and Troubleshooting",
 						"description": "If you have any questions or are having trouble with any of the previous steps, please visit us on the [Lean Zulip chat](https://leanprover.zulipchat.com/) so that we can help you.",
-						"media": { "markdown": "./media/guide-help.md" }
+						"media": {
+							"markdown": "./media/guide-help.md"
+						}
 					}
 				]
 			}


### PR DESCRIPTION
Makes it possible to disable substring-based occurrence highlighting and use only Lean's compiler responses.

I personally found the string-based highlighting to be distracting and confusing. This change defaults to semantic-only highlighting at @mhuisi 's request, so it will be user-visible.