### PR TITLE
Export `LocationsContext` in `@leanprover/infoview`

### DIFF
--- a/lean4-infoview/src/index.tsx
+++ b/lean4-infoview/src/index.tsx
@@ -12,7 +12,7 @@ export { EditorContext, VersionContext } from './infoview/contexts';
 export { EditorConnection } from './infoview/editorConnection';
 export { RpcContext } from './infoview/rpcSessions';
 export { ServerVersion } from './infoview/serverVersion';
-export { GoalLocation, GoalsLocation } from './infoview/goalLocation';
+export { LocationsContext, GoalLocation, GoalsLocation } from './infoview/goalLocation';
 export { importWidgetModule, DynamicComponent, DynamicComponentProps,
     PanelWidgetProps } from './infoview/userWidget';
 


### PR DESCRIPTION
The `LocationsContext` is exported in `infoview/goalLocation.tsx` but not in the `.index.tsx` file. It is sometimes useful to be able to use the `LocationsContext` while writing widgets.