### PR TITLE
chore: change name of 'rebuild imports' button

### DIFF
--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -119,8 +119,8 @@ export class LeanClient implements Disposable {
             return
         }
 
-        const message = `Imports of '${fileName}' are out of date and must be rebuilt.`
-        const input = 'Rebuild Imports'
+        const message = `Imports of '${fileName}' are out of date and must be rebuilt. Restarting the file will rebuild them.`
+        const input = 'Restart File'
         const choice = await window.showInformationMessage(message, input)
         if (choice !== input) {
             return


### PR DESCRIPTION
The disparity between the name of the 'restart file' command and the 'rebuild imports' button has confused people in the past.