### PR TITLE
feat: more helpful error when setting up project without lean/git

### DIFF
--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { URL } from 'url';
-import { FileType, Uri, workspace, WorkspaceFolder } from 'vscode';
+import { Uri, workspace, WorkspaceFolder } from 'vscode';
 import { fileExists } from './fsHelper';
 import { logger } from './logger'
 import path = require('path');

--- a/vscode-lean4/src/utils/setupDiagnostics.ts
+++ b/vscode-lean4/src/utils/setupDiagnostics.ts
@@ -1,0 +1,41 @@
+import { OutputChannel, Uri } from 'vscode';
+import { ExecutionExitCode, ExecutionResult, batchExecute } from './batch';
+
+export class SetupDiagnoser {
+    channel: OutputChannel
+    cwdUri: Uri | undefined
+
+    constructor(channel: OutputChannel, cwdUri: Uri | undefined) {
+        this.channel = channel
+        this.cwdUri = cwdUri
+    }
+
+    async checkLakeAndDepsAvailable(): Promise<'Success' | 'LakeUnavailable' | 'GitUnavailable'> {
+        if (!await this.checkLakeAvailable()) {
+            return 'LakeUnavailable'
+        }
+        if (!await this.checkGitAvailable()) {
+            return 'GitUnavailable'
+        }
+        return 'Success'
+    }
+
+    async checkLakeAvailable(): Promise<boolean> {
+        const lakeVersionResult = await this.runSilently('lake', ['--version'])
+        return lakeVersionResult.exitCode === ExecutionExitCode.Success
+    }
+
+    async checkGitAvailable(): Promise<boolean> {
+        const gitVersionResult = await batchExecute('git', ['--version'])
+        return gitVersionResult.exitCode === ExecutionExitCode.Success
+    }
+
+    private async runSilently(executablePath: string, args: string[]): Promise<ExecutionResult> {
+        return batchExecute(executablePath, args, this.cwdUri?.fsPath, { combined: this.channel })
+    }
+}
+
+export function diagnose(channel: OutputChannel, cwdUri: Uri | undefined): SetupDiagnoser {
+    return new SetupDiagnoser(channel, cwdUri)
+}
+


### PR DESCRIPTION
The extension will now check whether Git and Lake are installed and issue a helpful message that links to the setup guide when users try to set up projects without these being installed.