### PR TITLE
feat: auto-closing abbreviation hover

### DIFF
--- a/vscode-lean4/src/abbreviation/AbbreviationHoverProvider.ts
+++ b/vscode-lean4/src/abbreviation/AbbreviationHoverProvider.ts
@@ -30,12 +30,19 @@ export class AbbreviationHoverProvider implements HoverProvider {
 		const leader = this.config.abbreviationCharacter.get();
 
 		const hoverMarkdown = allAbbrevs
-			.map(
-				({ symbol, abbrevs }) =>
-					`Type ${symbol} using ${abbrevs
-						.map((a) => '`' + leader + a + '`')
-						.join(' or ')}`
-			)
+			.map(({ symbol, abbrevs }) => {
+				const abbrevInfo = `Type ${symbol} using ${abbrevs
+					.map((a) => '`' + leader + a + '`')
+					.join(' or ')}`
+				const autoClosingAbbrevs = this.abbreviations.findAutoClosingAbbreviations(symbol)
+				const autoClosingInfo =
+					autoClosingAbbrevs.length === 0
+					? ''
+					: `. ${symbol} can also be auto-closed with ${autoClosingAbbrevs
+						.map((([a, closingSym]) => `${closingSym} using \`${leader}${a}\``))
+						.join(' or ')}.`
+				return abbrevInfo + autoClosingInfo
+			})
 			.join('\n\n');
 
 		const maxSymbolLength = Math.max(

--- a/vscode-lean4/src/abbreviation/AbbreviationHoverProvider.ts
+++ b/vscode-lean4/src/abbreviation/AbbreviationHoverProvider.ts
@@ -38,7 +38,7 @@ export class AbbreviationHoverProvider implements HoverProvider {
 				const autoClosingInfo =
 					autoClosingAbbrevs.length === 0
 					? ''
-					: `. ${symbol} can also be auto-closed with ${autoClosingAbbrevs
+					: `. ${symbol} can be auto-closed with ${autoClosingAbbrevs
 						.map((([a, closingSym]) => `${closingSym} using \`${leader}${a}\``))
 						.join(' or ')}.`
 				return abbrevInfo + autoClosingInfo

--- a/vscode-lean4/src/abbreviation/AbbreviationProvider.ts
+++ b/vscode-lean4/src/abbreviation/AbbreviationProvider.ts
@@ -44,6 +44,12 @@ export class AbbreviationProvider implements Disposable {
 			.map(([abbr]) => abbr);
 	}
 
+	findAutoClosingAbbreviations(openingSymbol: string): [string, string][]  {
+		return Object.entries(this.symbolsByAbbreviation)
+			.filter(([_, sym]) => sym.startsWith(`${openingSymbol}$CURSOR`))
+			.map(([abbr, sym]) => [abbr, sym.replace(`${openingSymbol}$CURSOR`, '')])
+	}
+
 	findSymbolsIn(symbolPlusUnknown: string): string[] {
 		const result = new Set<string>();
 		for (const [abbr, sym] of Object.entries(this.symbolsByAbbreviation)) {


### PR DESCRIPTION
Since we cannot have auto-closing abbreviations (see #417), we might as well improve the discoverability of abbreviations like `\<>` by telling users about it in the abbreviation hover.