### PR TITLE
chore: replace lean 3 extension compatibility with warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12806,7 +12806,7 @@
     },
     "vscode-lean4": {
       "name": "lean4",
-      "version": "0.0.135",
+      "version": "0.0.136",
       "license": "Apache-2.0",
       "dependencies": {
         "@leanprover/infoview": "~0.6.0",

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -45,13 +45,12 @@
 				"lean4.input.languages": {
 					"type": "array",
 					"default": [
-						"lean4",
-						"lean"
+						"lean4"
 					],
 					"markdownDescription": "Enable Lean Unicode input in other file types.",
 					"items": {
 						"type": "string",
-						"description": "the name of a language, e.g. 'lean', 'lean4', 'markdown'"
+						"description": "the name of a language, e.g. 'lean4', 'markdown'"
 					}
 				},
 				"lean4.input.leader": {
@@ -377,18 +376,11 @@
 		],
 		"languages": [
 			{
-				"id": "lean",
-				"aliases": [
-					"Lean",
-					"lean"
-				],
+				"id": "lean4",
+				"configuration": "./language-configuration.json",
 				"extensions": [
 					".lean"
 				]
-			},
-			{
-				"id": "lean4",
-				"configuration": "./language-configuration.json"
 			},
 			{
 				"id": "lean4markdown",

--- a/vscode-lean4/src/abbreviation/config.ts
+++ b/vscode-lean4/src/abbreviation/config.ts
@@ -13,7 +13,7 @@ export class AbbreviationConfig {
 	});
 
 	readonly languages = new VsCodeSetting('lean4.input.languages', {
-		serializer: serializerWithDefault(['lean4', 'lean']),
+		serializer: serializerWithDefault(['lean4']),
 	});
 
 	readonly inputModeCustomTranslations = new VsCodeSetting(

--- a/vscode-lean4/src/taskgutter.ts
+++ b/vscode-lean4/src/taskgutter.ts
@@ -106,7 +106,7 @@ export class LeanTaskGutter implements Disposable {
     private updateDecos() {
         const uris: { [uri: string]: boolean } = {}
         for (const editor of window.visibleTextEditors) {
-            if (editor.document.languageId !== 'lean4' && editor.document.languageId !== 'lean') continue;
+            if (editor.document.languageId !== 'lean4') continue;
             const uri = editor.document.uri.toString();
             uris[uri] = true
             const processed = uri in this.status ? this.status[uri] : []

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -173,7 +173,7 @@ export class LeanClientProvider implements Disposable {
 
     async didOpenEditor(document: TextDocument) {
         // bail as quickly as possible on non-lean files.
-        if (document.languageId !== 'lean' && document.languageId !== 'lean4') {
+        if (document.languageId !== 'lean4') {
             return;
         }
 
@@ -182,21 +182,6 @@ export class LeanClientProvider implements Disposable {
             // For example, this happens when the vs code opens files to get git
             // information using a "git:" Uri scheme:
             //  git:/d%3A/Temp/lean_examples/Foo/Foo/Hello.lean.git?%7B%22path%22%3A%22d%3A%5C%5CTemp%5C%5Clean_examples%5C%5CFoo%5C%5CFoo%5C%5CHello.lean%22%2C%22ref%22%3A%22%22%7D
-            return;
-        }
-
-        // All open .lean files are assumed to be Lean 4 files.
-        // We need to do this because by default, .lean is associated with language id `lean`,
-        // i.e. Lean 3. vscode-lean is expected to yield when isLean4Project is true.
-        if (document.languageId === 'lean') {
-            // Only change the document language for *visible* documents,
-            // because this closes and then reopens the document.
-            await languages.setTextDocumentLanguage(document, 'lean4');
-
-            // setTextDocumentLanguage triggers another didOpenEditor event,
-            // and we want that event callback to be the one that calls
-            // ensureClient, so we bail here so we don't try and do it twice
-            // on the same document.
             return;
         }
 


### PR DESCRIPTION
It turns out that us setting the language ID of files to `lean4` post-hoc after opening the file interferes with semantic highlighting `refresh` requests due to a bug in VS Code (c.f. https://github.com/leanprover/lean4/issues/2977#issuecomment-2029876340).

Since Lean 3 isn't being used much anymore, this PR removes the compatibility with the Lean 3 extension that ensures that we can always run both extensions at the same time. After this PR, there is a potential conflict between the the use of the `.lean` file extension both for the Lean 3 and the Lean 4 language.

To warn users of this potential conflict, a warning is issued when both extensions are enabled, asking users to disable either one of the two.