### PR TITLE
fix: don't collapse tactic state on all requested infoview actions

### DIFF
--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -252,7 +252,7 @@ export const FilteredGoals = React.memo(({ headerChildren, goals, displayCount, 
 
     const setOpenRef = React.useRef<React.Dispatch<React.SetStateAction<boolean>>>()
     useEvent(ec.events.requestedAction, _ => {
-        if (setOpenRef.current !== undefined) {
+        if (togglingAction !== undefined && setOpenRef.current !== undefined) {
             setOpenRef.current(t => !t)
         }
     }, [setOpenRef, togglingAction], togglingAction)


### PR DESCRIPTION
This was accidentally introduced in #408 when refactoring the event handlers for `requestedAction` to use keys.