### PR TITLE
feat: support for multi-toolchain workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ you to install lean via elan.  If the folder contains a `lean-toolchain` version
 otherwise it will install `leanprover/lean4:stable`.
 You can override this default version by setting an `DEFAULT_LEAN_TOOLCHAIN` environment variable.
 
-Otherwise, if there is a `lean-toolchain` (or `leanpkg.toml`) in the workspace folder or in a parent
+Otherwise, if there is a `lean-toolchain` in the workspace folder or in a parent
 folder then it will use the version specified in the specified version.
 
 Then with the selected version it runs `lean --version` to check if that version is installed yet.

--- a/vscode-lean4/src/docview.ts
+++ b/vscode-lean4/src/docview.ts
@@ -5,36 +5,12 @@ import { URL } from 'url';
 import { commands, Disposable, Uri, ViewColumn, WebviewPanel, window,
      workspace, WebviewOptions, WebviewPanelOptions, TextDocument, languages,
      Range, Position } from 'vscode';
-import { join, extname } from 'path';
+import { extname } from 'path';
 import { TempFolder } from './utils/tempFolder'
 import { SymbolsByAbbreviation, AbbreviationConfig } from './abbreviation/config'
-import { fileExists } from './utils/fsHelper';
 
 export function mkCommandUri(commandName: string, ...args: any[]): string {
     return `command:${commandName}?${encodeURIComponent(JSON.stringify(args))}`;
-}
-
-function findActiveEditorRootPath(): string | undefined {
-    const doc = window.activeTextEditor?.document?.uri;
-    if (doc) {
-        return workspace.getWorkspaceFolder(doc)?.uri?.fsPath;
-    }
-    return undefined;
-}
-
-async function findProjectDocumentation(): Promise<string | null> {
-    const rootPath = findActiveEditorRootPath();
-    if (rootPath) {
-        let html = join(rootPath, 'html', 'index.html');
-        if(await fileExists(html)) {
-            return html;
-        }
-        html = join(rootPath, 'html', 'index.htm');
-        if(await fileExists(html)) {
-            return html;
-        }
-    }
-    return null;
 }
 
 function createLocalFileUrl(path: string){
@@ -217,12 +193,6 @@ export class DocViewProvider implements Disposable {
         } else {
             const $ = cheerio.load('<body>');
             const body = $('body');
-
-            const html = await findProjectDocumentation();
-            if (html) {
-                body.append($('<p>').append($('<a>').attr('href', Uri.file(html).toString())
-                    .text('Open documentation of current project')));
-            }
 
             const books : any = {
                 'Theorem Proving in Lean': mkCommandUri('lean4.docView.openUrl', 'https://lean-lang.org/theorem_proving_in_lean4/introduction.html'),

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -4,7 +4,7 @@ import { InfoProvider } from './infoview'
 import { DocViewProvider } from './docview'
 import { LeanTaskGutter } from './taskgutter'
 import { LeanInstaller } from './utils/leanInstaller'
-import { LeanpkgService } from './utils/leanpkg'
+import { LeanConfigWatchService } from './utils/configwatchservice'
 import { LeanClientProvider } from './utils/clientProvider'
 import { addDefaultElanPath, removeElanPath, addToolchainBinPath, isElanDisabled, getDefaultLeanVersion, getDefaultElanPath} from './config'
 import { findLeanPackageVersionInfo } from './utils/projectInfo'
@@ -135,8 +135,8 @@ async function activateLean4Features(context: ExtensionContext, installer: LeanI
     const clientProvider = new LeanClientProvider(installer, installer.getOutputChannel());
     context.subscriptions.push(clientProvider)
 
-    const pkgService = new LeanpkgService()
-    pkgService.versionChanged(async uri => {
+    const watchService = new LeanConfigWatchService()
+    watchService.versionChanged(async uri => {
         const client: LeanClient | undefined = clientProvider.getClientForFolder(uri)
         if (client && !client.isRunning()) {
             // This can naturally happen when we update the Lean version using the "Update Dependency" command
@@ -146,8 +146,8 @@ async function activateLean4Features(context: ExtensionContext, installer: LeanI
         }
         await installer.handleVersionChanged(uri)
     });
-    pkgService.lakeFileChanged((uri) => installer.handleLakeFileChanged(uri));
-    context.subscriptions.push(pkgService);
+    watchService.lakeFileChanged((uri) => installer.handleLakeFileChanged(uri));
+    context.subscriptions.push(watchService);
 
     const infoProvider = new InfoProvider(clientProvider, {language: 'lean4'}, context);
     context.subscriptions.push(infoProvider)

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -69,7 +69,7 @@ export class InfoProvider implements Disposable {
 
     private rpcSessions: Map<string, RpcSessionAtPos> = new Map();
 
-    // the key is the LeanClient.getWorkspaceFolder()
+    // the key is the LeanClient.getClientFolder()
     private clientsFailed: Map<string, ServerStoppedReason> = new Map();
 
     // the key is the uri of the file who's worker has failed.
@@ -335,7 +335,7 @@ export class InfoProvider implements Disposable {
         }
 
         await this.webviewPanel?.api.serverStopped(undefined); // clear any server stopped state
-        const folder = client.getWorkspaceFolder()
+        const folder = client.getClientFolder()
         for (const uri of this.workersFailed.keys()){
             if (uri.startsWith(folder)){
                 this.workersFailed.delete(uri)
@@ -349,7 +349,7 @@ export class InfoProvider implements Disposable {
 
     private async onClientAdded(client: LeanClient) {
 
-        logger.log(`[InfoProvider] Adding client for workspace: ${client.getWorkspaceFolder()}`);
+        logger.log(`[InfoProvider] Adding client for workspace: ${client.getClientFolder()}`);
 
         this.clientSubscriptions.push(
             client.restarted(async () => {
@@ -408,10 +408,10 @@ export class InfoProvider implements Disposable {
             await this.webviewPanel?.api.serverStopped(reason);
         }
 
-        logger.log(`[InfoProvider] client stopped: ${client.getWorkspaceFolder()}`)
+        logger.log(`[InfoProvider] client stopped: ${client.getClientFolder()}`)
 
         // remember this client is in a stopped state
-        const key = client.getWorkspaceFolder()
+        const key = client.getClientFolder()
         if (key) {
             await this.sendPosition();
             if (!this.clientsFailed.has(key)) {
@@ -668,7 +668,7 @@ export class InfoProvider implements Disposable {
             const client = this.clientProvider.findClient(editor.document.uri.toString())
             if (client) {
                 const uri = window.activeTextEditor?.document.uri.toString() ?? '';
-                const folder = client.getWorkspaceFolder();
+                const folder = client.getClientFolder();
                 let reason : ServerStoppedReason | undefined;
                 if (this.clientsFailed.has(folder)){
                     reason = this.clientsFailed.get(folder);

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -28,7 +28,7 @@ import { join } from 'path';
 import { logger } from './utils/logger'
  // @ts-ignore
 import { SemVer } from 'semver';
-import { fileExists, isFileInFolder } from './utils/fsHelper';
+import { fileExists, isFileInFolder, isFileUriInFolder } from './utils/fsHelper';
 import { c2pConverter, p2cConverter, patchConverters } from './utils/converters'
 import { displayErrorWithOutput } from './utils/errors'
 import path = require('path')
@@ -335,23 +335,12 @@ export class LeanClient implements Disposable {
         });
     }
 
-    async isInFolderManagedByThisClient(uri: Uri) : Promise<boolean> {
-        if (this.folderUri.scheme !== uri.scheme) {
-            return false
-        }
-        if (this.folderUri.scheme === 'file') {
-            const realPath1 = await fs.promises.realpath(this.folderUri.fsPath)
-            const realPath2 = await fs.promises.realpath(uri.fsPath)
-            return isFileInFolder(realPath2, realPath1)
-        }
-        if (this.folderUri.scheme === 'untitled') {
-            return true
-        }
-        return false
+    isInFolderManagedByThisClient(uri: Uri): boolean {
+        return isFileUriInFolder(this.folderUri, uri)
     }
 
-    getClientFolder() : string {
-        return this.folderUri.toString();
+    getClientFolder(): Uri {
+        return this.folderUri;
     }
 
     start(): Promise<void> {
@@ -400,7 +389,7 @@ export class LeanClient implements Disposable {
 
         assert(() => this.isStarted())
 
-        if (!await this.isInFolderManagedByThisClient(doc.uri)){
+        if (!this.isInFolderManagedByThisClient(doc.uri)){
             // skip it, this file belongs to a different workspace...
             return;
         }

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -336,18 +336,18 @@ export class LeanClient implements Disposable {
     }
 
     async isInFolderManagedByThisClient(uri: Uri) : Promise<boolean> {
-        if (this.folderUri) {
-            if (this.folderUri.scheme !== uri.scheme) return false;
-            if (this.folderUri.scheme === 'file') {
-                const realPath1 = await fs.promises.realpath(this.folderUri.fsPath);
-                const realPath2 = await fs.promises.realpath(uri.fsPath);
-                return isFileInFolder(realPath2, realPath1);
-            } else {
-                return uri.toString().startsWith(this.folderUri.toString());
-            }
-        } else {
-            return uri.scheme === 'untitled'
+        if (this.folderUri.scheme !== uri.scheme) {
+            return false
         }
+        if (this.folderUri.scheme === 'file') {
+            const realPath1 = await fs.promises.realpath(this.folderUri.fsPath)
+            const realPath2 = await fs.promises.realpath(uri.fsPath)
+            return isFileInFolder(realPath2, realPath1)
+        }
+        if (this.folderUri.scheme === 'untitled') {
+            return true
+        }
+        return false
     }
 
     getClientFolder() : string {

--- a/vscode-lean4/src/taskgutter.ts
+++ b/vscode-lean4/src/taskgutter.ts
@@ -98,7 +98,7 @@ export class LeanTaskGutter implements Disposable {
         this.subscriptions.push(
             window.onDidChangeVisibleTextEditors(() => this.updateDecos()),
             client.progressChanged(([uri, processing]) => {
-                this.status[uri.toString()] = processing
+                this.status[uri] = processing
                 this.updateDecos()
             }));
     }

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -1,12 +1,12 @@
-import { Disposable, OutputChannel, workspace, TextDocument, commands, window, EventEmitter, Uri, TextEditor } from 'vscode';
+import { Disposable, OutputChannel, workspace, TextDocument, commands, window, EventEmitter, TextEditor } from 'vscode';
 import { LeanInstaller, LeanVersion } from './leanInstaller'
 import { LeanClient } from '../leanclient'
 import { LeanFileProgressProcessingInfo, ServerStoppedReason } from '@leanprover/infoview-api';
 import { checkParentFoldersForLeanProject, findLeanPackageRoot, isValidLeanProject } from './projectInfo';
-import { isFileInFolder, isFileUriInFolder } from './fsHelper';
 import { logger } from './logger'
 import { addDefaultElanPath, getDefaultElanPath, addToolchainBinPath, isElanDisabled, shouldShowInvalidProjectWarnings } from '../config'
 import { displayErrorWithOutput } from './errors';
+import { ExtUri, FileUri, UntitledUri, extUriOrError, getWorkspaceFolderUri } from './exturi';
 
 // This class ensures we have one LeanClient per folder.
 export class LeanClientProvider implements Disposable {
@@ -16,7 +16,7 @@ export class LeanClientProvider implements Disposable {
     private versions: Map<string, LeanVersion> = new Map();
     private clients: Map<string, LeanClient> = new Map();
     private pending: Map<string, boolean> = new Map();
-    private pendingInstallChanged: Uri[] = [];
+    private pendingInstallChanged: ExtUri[] = [];
     private processingInstallChanged: boolean = false;
     private activeClient: LeanClient | undefined = undefined;
 
@@ -37,7 +37,7 @@ export class LeanClientProvider implements Disposable {
         this.installer = installer;
 
         // we must setup the installChanged event handler first before any didOpenEditor calls.
-        installer.installChanged(async (uri: Uri) => await this.onInstallChanged(uri));
+        installer.installChanged(async (uri: ExtUri) => await this.onInstallChanged(uri));
 
         window.visibleTextEditors.forEach(e => this.didOpenEditor(e.document));
         this.subscriptions.push(window.onDidChangeActiveTextEditor(async e => {
@@ -62,7 +62,7 @@ export class LeanClientProvider implements Disposable {
                 return
             }
             this.clients.forEach((client, key) => {
-                if (workspace.getWorkspaceFolder(client.folderUri)) {
+                if (client.folderUri.scheme === 'untitled' || getWorkspaceFolderUri(client.folderUri)) {
                     return
                 }
 
@@ -79,7 +79,16 @@ export class LeanClientProvider implements Disposable {
         return this.activeClient;
     }
 
-    private async onInstallChanged(uri: Uri){
+    private async findPackageRootUri(uri: ExtUri): Promise<ExtUri> {
+        if (uri.scheme === 'file') {
+            const [root, _] = await findLeanPackageRoot(uri)
+            return root
+        } else {
+            return new UntitledUri()
+        }
+    }
+
+    private async onInstallChanged(uri: ExtUri){
         // Uri is a package Uri in the case a lean package file was changed.
         logger.log(`[ClientProvider] installChanged for ${uri}`);
         this.pendingInstallChanged.push(uri);
@@ -89,26 +98,26 @@ export class LeanClientProvider implements Disposable {
         }
         this.processingInstallChanged = true;
 
-        while (this.pendingInstallChanged.length > 0)
-        {
+        while (true) {
+            const uri = this.pendingInstallChanged.pop();
+            if (!uri) {
+                break
+            }
             try {
-                const uri = this.pendingInstallChanged.pop();
-                if (uri) {
-                    // have to check again here in case elan install had --default-toolchain none.
-                    const [folder, _] = await findLeanPackageRoot(uri);
-                    const packageUri = folder ?? Uri.from({scheme: 'untitled'});
-                    logger.log('[ClientProvider] testLeanVersion');
-                    const version = await this.installer.testLeanVersion(packageUri);
-                    if (version.version === '4') {
-                        logger.log('[ClientProvider] got lean version 4');
-                        const [cached, client] = await this.ensureClient(uri, version);
-                        if (cached && client) {
-                            await client.restart();
-                            logger.log('[ClientProvider] restart complete');
-                        }
-                    } else if (version.error) {
-                        logger.log(`[ClientProvider] Lean version not ok: ${version.error}`);
+                // have to check again here in case elan install had --default-toolchain none.
+                const packageUri = await this.findPackageRootUri(uri)
+
+                logger.log('[ClientProvider] testLeanVersion');
+                const version = await this.installer.testLeanVersion(packageUri);
+                if (version.version === '4') {
+                    logger.log('[ClientProvider] got lean version 4');
+                    const [cached, client] = await this.ensureClient(uri, version);
+                    if (cached && client) {
+                        await client.restart();
+                        logger.log('[ClientProvider] restart complete');
                     }
+                } else if (version.error) {
+                    logger.log(`[ClientProvider] Lean version not ok: ${version.error}`);
                 }
             } catch (e) {
                 logger.log(`[ClientProvider] Exception checking lean version: ${e}`);
@@ -131,14 +140,13 @@ export class LeanClientProvider implements Disposable {
         }
     }
 
-    private getVisibleEditor(uri: Uri) : TextEditor | null {
-        const path = uri.toString();
+    private getVisibleEditor(uri: ExtUri) : TextEditor | undefined {
         for (const editor of window.visibleTextEditors) {
-            if (editor.document.uri.toString() === path){
+            if (uri.equalsUri(editor.document.uri)){
                 return editor;
             }
         }
-        return null;
+        return undefined;
     }
 
     private restartFile() {
@@ -175,7 +183,7 @@ export class LeanClientProvider implements Disposable {
             return;
         }
 
-        if (!this.getVisibleEditor(document.uri)) {
+        if (!this.getVisibleEditor(extUriOrError(document.uri))) {
             // Sometimes VS code opens a document that has no editor yet.
             // For example, this happens when the vs code opens files to get git
             // information using a "git:" Uri scheme:
@@ -184,7 +192,7 @@ export class LeanClientProvider implements Disposable {
         }
 
         try {
-            const [cached, client] = await this.ensureClient(document.uri, undefined);
+            const [cached, client] = await this.ensureClient(extUriOrError(document.uri), undefined);
             if (!client) {
                 return
             }
@@ -199,13 +207,19 @@ export class LeanClientProvider implements Disposable {
     }
 
     // Find the client for a given document.
-    findClient(path: Uri) {
-        const candidates = this.getClients().filter(client => isFileUriInFolder(path, client.getClientFolder()))
+    findClient(path: ExtUri) {
+        const candidates = this.getClients().filter(client => client.isInFolderManagedByThisClient(path))
         // All candidate folders are a prefix of `path`, so they must necessarily be prefixes of one another
         // => the best candidate (the most top-level client folder) is just the one with the shortest path
-        let bestCandidate: LeanClient | null = null
+        let bestCandidate: LeanClient | undefined
         for (const candidate of candidates) {
-            if (!bestCandidate || candidate.getClientFolder().toString().length < bestCandidate.getClientFolder().toString().length) {
+            if (!bestCandidate) {
+                bestCandidate = candidate
+                continue
+            }
+            const folder = candidate.getClientFolder()
+            const bestFolder = bestCandidate.getClientFolder()
+            if (folder.scheme === 'file' && bestFolder.scheme === 'file' && folder.fsPath.length < bestFolder.fsPath.length) {
                 bestCandidate = candidate
             }
         }
@@ -216,26 +230,13 @@ export class LeanClientProvider implements Disposable {
         return Array.from(this.clients.values());
     }
 
-    // Return a string that can be used as a key in the clients, versions, pendingInstallChanged, and pending
-    // maps.  This is not just uri.toString() because on some platforms the file system is
-    // case insensitive.
-    getKeyFromUri(uri: Uri | null) : string{
-        const uriNonNull = uri ?? Uri.from({scheme: 'untitled'});
-        const path = uriNonNull.toString();
-        if (uriNonNull.scheme === 'file' && process.platform === 'win32') {
-            return path.toLowerCase();
-        }
-        return path;
+    getClientForFolder(folder: ExtUri) : LeanClient | undefined {
+        return this.clients.get(folder.toString());
     }
 
-    getClientForFolder(folder: Uri) : LeanClient | undefined {
-        return this.clients.get(this.getKeyFromUri(folder));
-    }
-
-    private async getLeanVersion(uri: Uri) : Promise<LeanVersion | undefined> {
-        const [folder, _] = await findLeanPackageRoot(uri);
-        const folderUri = folder ?? Uri.from({scheme: 'untitled'});
-        const key = this.getKeyFromUri(folderUri);
+    private async getLeanVersion(uri: ExtUri) : Promise<LeanVersion | undefined> {
+        const folderUri = await this.findPackageRootUri(uri);
+        const key = folderUri.toString()
         if (this.versions.has(key)){
             return this.versions.get(key);
         }
@@ -263,11 +264,10 @@ export class LeanClientProvider implements Disposable {
     // Starts a LeanClient if the given file is in a new workspace we haven't seen before.
     // Returns a boolean "true" if the LeanClient was already created.
     // Returns a null client if it turns out the new workspace is a lean3 workspace.
-    async ensureClient(uri : Uri, versionInfo: LeanVersion | undefined) : Promise<[boolean,LeanClient | undefined]> {
-        const [folder, _] = await findLeanPackageRoot(uri);
-        const folderUri = folder ?? Uri.from({scheme: 'untitled'});
+    async ensureClient(uri: ExtUri, versionInfo: LeanVersion | undefined) : Promise<[boolean,LeanClient | undefined]> {
+        const folderUri = await this.findPackageRootUri(uri)
         let client = this.getClientForFolder(folderUri);
-        const key = this.getKeyFromUri(folder);
+        const key = folderUri.toString();
         const cachedClient = (client !== undefined);
         if (!client) {
             if (this.pending.has(key)) {
@@ -346,7 +346,7 @@ export class LeanClientProvider implements Disposable {
         return [cachedClient, client];
     }
 
-    private async checkIsValidProjectFolder(folderUri: Uri) {
+    private async checkIsValidProjectFolder(folderUri: ExtUri) {
         if (!shouldShowInvalidProjectWarnings()) {
             return
         }
@@ -363,7 +363,7 @@ Click the following link to learn how to set up or open Lean projects: [(Show Se
             return
         }
 
-        const parentProjectFolder: Uri | undefined = await checkParentFoldersForLeanProject(folderUri)
+        const parentProjectFolder: FileUri | undefined = await checkParentFoldersForLeanProject(folderUri)
         if (parentProjectFolder === undefined) {
             const message = `Opened folder is not a valid Lean 4 project.
 Please open a valid Lean 4 project containing a \'lean-toolchain\' file for full functionality.

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -3,7 +3,7 @@ import { LeanInstaller, LeanVersion } from './leanInstaller'
 import { LeanClient } from '../leanclient'
 import { LeanFileProgressProcessingInfo, ServerStoppedReason } from '@leanprover/infoview-api';
 import { checkParentFoldersForLeanProject, findLeanPackageRoot, isValidLeanProject } from './projectInfo';
-import { isFileInFolder } from './fsHelper';
+import { isFileInFolder, isFileUriInFolder } from './fsHelper';
 import { logger } from './logger'
 import { addDefaultElanPath, getDefaultElanPath, addToolchainBinPath, isElanDisabled, shouldShowInvalidProjectWarnings } from '../config'
 import { displayErrorWithOutput } from './errors';
@@ -199,13 +199,13 @@ export class LeanClientProvider implements Disposable {
     }
 
     // Find the client for a given document.
-    findClient(path: string) {
-        const candidates = this.getClients().filter(client => isFileInFolder(path, client.getClientFolder()))
+    findClient(path: Uri) {
+        const candidates = this.getClients().filter(client => isFileUriInFolder(path, client.getClientFolder()))
         // All candidate folders are a prefix of `path`, so they must necessarily be prefixes of one another
         // => the best candidate (the most top-level client folder) is just the one with the shortest path
         let bestCandidate: LeanClient | null = null
         for (const candidate of candidates) {
-            if (!bestCandidate || candidate.getClientFolder().length < bestCandidate.getClientFolder().length) {
+            if (!bestCandidate || candidate.getClientFolder().toString().length < bestCandidate.getClientFolder().toString().length) {
                 bestCandidate = candidate
             }
         }

--- a/vscode-lean4/src/utils/configwatchservice.ts
+++ b/vscode-lean4/src/utils/configwatchservice.ts
@@ -66,7 +66,7 @@ export class LeanConfigWatchService implements Disposable {
         // Note: just opening the file fires this event sometimes which is annoying, so
         // we compare the contents just to be sure and normalize whitespace so that
         // just adding a new line doesn't trigger the prompt.
-        const [_1, packageUri, _2] = await findLeanPackageRoot(fileUri)
+        const [packageUri, _] = await findLeanPackageRoot(fileUri)
         if (!packageUri) {
             return
         }

--- a/vscode-lean4/src/utils/exturi.ts
+++ b/vscode-lean4/src/utils/exturi.ts
@@ -1,0 +1,96 @@
+import { Uri, workspace } from 'vscode'
+import { isFileInFolder } from './fsHelper'
+
+
+function unsupportedSchemeError(uri: Uri): Error {
+    return new Error(`Got URI with unsupported scheme '${uri.scheme}': '${uri}'`)
+}
+
+export class FileUri {
+    scheme: 'file'
+    fsPath: string
+
+    constructor(fsPath: string) {
+        this.scheme = 'file'
+        this.fsPath = fsPath
+    }
+
+    static fromUriOrError(uri: Uri): FileUri {
+        if (uri.scheme !== 'file') {
+            throw unsupportedSchemeError(uri)
+        }
+        return new FileUri(uri.fsPath)
+    }
+
+    asUri(): Uri {
+        return Uri.file(this.fsPath)
+    }
+
+    equals(other: FileUri): boolean {
+        return this.fsPath === other.fsPath
+    }
+
+    equalsUri(other: Uri): boolean {
+        if (other.scheme !== 'file') {
+            return false
+        }
+        return this.equals(new FileUri(other.fsPath))
+    }
+
+    toString(): string {
+        return this.asUri().toString()
+    }
+
+    join(...pathSegments: string[]): FileUri {
+        return new FileUri(Uri.joinPath(this.asUri(), ...pathSegments).fsPath)
+    }
+
+    isInFolder(folderUri: FileUri): boolean {
+        return isFileInFolder(this.fsPath, folderUri.fsPath)
+    }
+}
+
+export function getWorkspaceFolderUri(uri: FileUri): FileUri | undefined {
+    const folder = workspace.getWorkspaceFolder(uri.asUri())
+    if (folder === undefined) {
+        return undefined
+    }
+    return FileUri.fromUriOrError(folder.uri)
+}
+
+export class UntitledUri {
+    scheme: 'untitled'
+
+    constructor() {
+        this.scheme = 'untitled'
+    }
+
+    asUri(): Uri {
+        return Uri.from({ scheme: 'untitled' })
+    }
+
+    equalsUri(other: Uri): boolean {
+        return other.scheme === 'untitled'
+    }
+
+    toString(): string {
+        return this.asUri().toString()
+    }
+}
+
+/** Uris supported by this extension. */
+export type ExtUri = FileUri | UntitledUri
+
+export function extUriOrError(uri: Uri): ExtUri {
+    if (uri.scheme === 'untitled') {
+        return new UntitledUri()
+    }
+    if (uri.scheme === 'file') {
+        return new FileUri(uri.fsPath)
+    }
+    throw new Error(`Got URI with unsupported scheme '${uri.scheme}': '${uri}'`)
+}
+
+export function parseExtUri(uriString: string): ExtUri {
+    return extUriOrError(Uri.parse(uriString))
+}

--- a/vscode-lean4/src/utils/fsHelper.ts
+++ b/vscode-lean4/src/utils/fsHelper.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {promises, PathLike } from 'fs';
 import path = require('path');
-import { Uri } from 'vscode';
 
 /**
     Helper used to replace fs.existsSync (using existsSync to check for the existence
@@ -26,17 +25,4 @@ export function isFileInFolder(file: string, folder: string){
     const relative = path.relative(folder, file)
     const isSubdir = relative.length > 0 && !relative.startsWith('..') && !path.isAbsolute(relative)
     return isSubdir
-}
-
-export function isFileUriInFolder(fileUri: Uri, folderUri: Uri): boolean {
-    if (fileUri.scheme !== folderUri.scheme) {
-        return false
-    }
-    if (fileUri.scheme === 'untitled') {
-        return true
-    }
-    if (fileUri.scheme === 'file') {
-        return isFileInFolder(fileUri.fsPath, folderUri.fsPath)
-    }
-    return false // other URI schemes are currently not supported
 }

--- a/vscode-lean4/src/utils/fsHelper.ts
+++ b/vscode-lean4/src/utils/fsHelper.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {promises, PathLike } from 'fs';
+import path = require('path');
 
 /**
     Helper used to replace fs.existsSync (using existsSync to check for the existence
@@ -16,16 +17,12 @@ export async function fileExists(pathFile: PathLike): Promise<boolean> {
 
 /**
  * This helper function is used to check if an specific file is in certain Folder.
- * it also checks some cases with Windows (windows paths are case insensitive.)
  * @param file string that contains a file name that will be checked if it exists in a certain folder.
  * @param folder string that contains a folder name where it will check if a certain file exists
  * @returns a boolean that says if the file exists in folder
  */
 export function isFileInFolder(file: string, folder: string){
-    if (process.platform === 'win32') {
-        // windows paths are case insensitive.
-        return file.toLowerCase().startsWith(folder.toLowerCase());
-    } else {
-        return file.startsWith(folder);
-    }
+    const relative = path.relative(folder, file)
+    const isSubdir = relative.length > 0 && !relative.startsWith('..') && !path.isAbsolute(relative)
+    return isSubdir
 }

--- a/vscode-lean4/src/utils/fsHelper.ts
+++ b/vscode-lean4/src/utils/fsHelper.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {promises, PathLike } from 'fs';
 import path = require('path');
+import { Uri } from 'vscode';
 
 /**
     Helper used to replace fs.existsSync (using existsSync to check for the existence
@@ -25,4 +26,17 @@ export function isFileInFolder(file: string, folder: string){
     const relative = path.relative(folder, file)
     const isSubdir = relative.length > 0 && !relative.startsWith('..') && !path.isAbsolute(relative)
     return isSubdir
+}
+
+export function isFileUriInFolder(fileUri: Uri, folderUri: Uri): boolean {
+    if (fileUri.scheme !== folderUri.scheme) {
+        return false
+    }
+    if (fileUri.scheme === 'untitled') {
+        return true
+    }
+    if (fileUri.scheme === 'file') {
+        return isFileInFolder(fileUri.fsPath, folderUri.fsPath)
+    }
+    return false // other URI schemes are currently not supported
 }

--- a/vscode-lean4/src/utils/lake.ts
+++ b/vscode-lean4/src/utils/lake.ts
@@ -1,15 +1,16 @@
-import { OutputChannel, Uri } from 'vscode';
+import { OutputChannel } from 'vscode';
 import { ExecutionExitCode, ExecutionResult, batchExecute, batchExecuteWithProgress } from './batch';
+import { FileUri } from './exturi';
 
 export const cacheNotFoundError = 'unknown executable `cache`'
 export const cacheNotFoundExitError = '=> Operation failed. Exit Code: 1.'
 
 export class LakeRunner {
     channel: OutputChannel
-    cwdUri: Uri | undefined
+    cwdUri: FileUri | undefined
     toolchain: string | undefined
 
-    constructor(channel: OutputChannel, cwdUri: Uri | undefined, toolchain?: string | undefined) {
+    constructor(channel: OutputChannel, cwdUri: FileUri | undefined, toolchain?: string | undefined) {
         this.channel = channel
         this.cwdUri = cwdUri
         this.toolchain = toolchain
@@ -85,6 +86,6 @@ export class LakeRunner {
     }
 }
 
-export function lake(channel: OutputChannel, cwdUri: Uri | undefined, toolchain?: string | undefined): LakeRunner {
+export function lake(channel: OutputChannel, cwdUri: FileUri | undefined, toolchain?: string | undefined): LakeRunner {
     return new LakeRunner(channel, cwdUri, toolchain)
 }

--- a/vscode-lean4/src/utils/manifest.ts
+++ b/vscode-lean4/src/utils/manifest.ts
@@ -2,6 +2,7 @@ import { join } from 'path'
 import { Uri } from 'vscode'
 import { z } from 'zod'
 import * as fs from 'fs'
+import { FileUri } from './exturi'
 
 export interface DirectGitDependency {
     name: string
@@ -133,8 +134,8 @@ export function parseAsManifest(jsonString: string): Manifest | undefined {
 
 export type ManifestReadError = string
 
-export async function parseManifestInFolder(folderUri: Uri): Promise<Manifest | ManifestReadError> {
-    const manifestPath: string = join(folderUri.fsPath, 'lake-manifest.json')
+export async function parseManifestInFolder(folderUri: FileUri): Promise<Manifest | ManifestReadError> {
+    const manifestPath: string = folderUri.join('lake-manifest.json').fsPath
 
     let jsonString: string
     try {

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -59,6 +59,9 @@ export async function findLeanPackageRoot(uri: Uri) : Promise<[Uri | null, Uri |
         if (await fileExists(leanToolchain.fsPath)) {
             bestFolder = path
             bestLeanToolchain = leanToolchain
+        } else if (await isCoreLean4Directory(path)) {
+            bestFolder = path
+            bestLeanToolchain = null
         }
         if (path.toString() === containingWsFolder?.uri.toString()) {
             // don't search above a WorkspaceFolder barrier.

--- a/vscode-lean4/src/utils/setupDiagnostics.ts
+++ b/vscode-lean4/src/utils/setupDiagnostics.ts
@@ -1,11 +1,12 @@
-import { OutputChannel, Uri } from 'vscode';
+import { OutputChannel } from 'vscode';
 import { ExecutionExitCode, ExecutionResult, batchExecute } from './batch';
+import { FileUri } from './exturi';
 
 export class SetupDiagnoser {
     channel: OutputChannel
-    cwdUri: Uri | undefined
+    cwdUri: FileUri | undefined
 
-    constructor(channel: OutputChannel, cwdUri: Uri | undefined) {
+    constructor(channel: OutputChannel, cwdUri: FileUri | undefined) {
         this.channel = channel
         this.cwdUri = cwdUri
     }
@@ -35,7 +36,7 @@ export class SetupDiagnoser {
     }
 }
 
-export function diagnose(channel: OutputChannel, cwdUri: Uri | undefined): SetupDiagnoser {
+export function diagnose(channel: OutputChannel, cwdUri: FileUri | undefined): SetupDiagnoser {
     return new SetupDiagnoser(channel, cwdUri)
 }
 

--- a/vscode-lean4/test/suite/restarts/restarts.test.ts
+++ b/vscode-lean4/test/suite/restarts/restarts.test.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 import { logger } from '../../../src/utils/logger'
 import { initLean4Untitled, initLean4, waitForInfoviewHtml, closeAllEditors, waitForActiveClient,
 	extractPhrase, restartLeanServer, restartFile, assertStringInInfoview, insertText, deleteAllText } from '../utils/helpers';
+import { FileUri } from '../../../src/utils/exturi';
 
 // Expects to be launched with folder: ${workspaceFolder}/vscode-lean4/test/suite/simple
 suite('Lean Server Restart Test Suite', () => {
@@ -131,7 +132,7 @@ suite('Lean Server Restart Test Suite', () => {
 			logger.log('Now invoke the restart server command');
 			const clients = lean.exports.clientProvider;
 			assert(clients, 'No LeanClientProvider export');
-			const client = clients.getClientForFolder(vscode.Uri.file(simpleRoot));
+			const client = clients.getClientForFolder(new FileUri(simpleRoot));
 			if (client) {
 				await restartLeanServer(client);
 			} else {

--- a/vscode-lean4/test/suite/simple/simple.test.ts
+++ b/vscode-lean4/test/suite/simple/simple.test.ts
@@ -6,6 +6,7 @@ import { isElanDisabled } from '../../../src/config'
 import { initLean4Untitled, waitForActiveEditor, waitForInfoviewHtml, closeAllEditors,
     extractPhrase, gotoDefinition, assertStringInInfoview, initLean4 } from '../utils/helpers';
 import { logger } from '../../../src/utils/logger'
+import { UntitledUri } from '../../../src/utils/exturi';
 
 function getElanMode(){
     let mode = ''
@@ -67,7 +68,7 @@ suite('Lean4 Basics Test Suite', () => {
 
         const installer = lean.exports.installer;
         assert(installer, 'No LeanInstaller export');
-        const toolChains = await installer.elanListToolChains(null);
+        const toolChains = await installer.elanListToolChains(new UntitledUri());
         let defaultToolChain = toolChains.find(tc => tc.indexOf('default') > 0);
         if (defaultToolChain) {
             // the IO.appPath should output something like this:


### PR DESCRIPTION
This PR adds support for using multiple lean toolchains in the same workspace folder. It also enables users to use Lean 4 without first having to open a folder.

For nested workspaces, the client uses the outer-most Lean project. This is the correct behavior for projects in `.lake`, but not the correct behavior for actual nested projects. I unfortunately do not see a way to make the latter work because the language client library only supports globs to specify which files should be picked up by a language server, and hence cannot express something like "all Lean files in this directory, except those contained in inner directories with their own lean-toolchain". We could in principle set up middleware for every single notification and request, but this is likely to be overly fragile.

Closes #138.