### PR TITLE
Log errors if something goes wrong with the lake binary

### DIFF
--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -487,6 +487,7 @@ export class LeanClient implements Disposable {
         const start = Date.now()
         const result: ExecutionResult = await batchExecute(executable, versionOptions, this.folderUri?.fsPath);
         if (result.exitCode !== ExecutionExitCode.Success) {
+            logger.error(`[LeanClient] Ran '${executable} ${versionOptions.join(' ')}', got error:\n{result.stderr}`);
             return false
         }
         logger.log(`[LeanClient] Ran '${executable} ${versionOptions.join(' ')}' in ${Date.now() - start} ms`);


### PR DESCRIPTION
When using a custom `lakePath`, it is helpful to be able to see the error messages if something goes wrong.