### PR TITLE
chore: use correct revision in blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
 # Run `git config blame.ignoreRevsFile .git-blame-ignore-revs` to ignore the revisions in this file in `git blame`.
 
 # Formatting the whole extension with prettier
-b17ebbd1201c7bc3b6100ea83a051b9204e3f5e4
+2255bc20c9d28d868d04fb91428652a95cc87a92


### PR DESCRIPTION
Rebasing changed the revision. See #430.