### PR TITLE
fix: unexpected uri error

### DIFF
--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -9,7 +9,7 @@ import {
 } from '../config'
 import { LeanClient } from '../leanclient'
 import { displayErrorWithOutput } from './errors'
-import { ExtUri, extUriOrError, FileUri, getWorkspaceFolderUri, UntitledUri } from './exturi'
+import { ExtUri, FileUri, getWorkspaceFolderUri, toExtUri, UntitledUri } from './exturi'
 import { LeanInstaller, LeanVersion } from './leanInstaller'
 import { logger } from './logger'
 import { checkParentFoldersForLeanProject, findLeanPackageRoot, isValidLeanProject } from './projectInfo'
@@ -193,7 +193,12 @@ export class LeanClientProvider implements Disposable {
             return
         }
 
-        if (!this.getVisibleEditor(extUriOrError(document.uri))) {
+        const uri = toExtUri(document.uri)
+        if (uri === undefined) {
+            return
+        }
+
+        if (!this.getVisibleEditor(uri)) {
             // Sometimes VS code opens a document that has no editor yet.
             // For example, this happens when the vs code opens files to get git
             // information using a "git:" Uri scheme:
@@ -202,7 +207,7 @@ export class LeanClientProvider implements Disposable {
         }
 
         try {
-            const [cached, client] = await this.ensureClient(extUriOrError(document.uri), undefined)
+            const [cached, client] = await this.ensureClient(uri, undefined)
             if (!client) {
                 return
             }


### PR DESCRIPTION
Bug originally reported at https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/VScode.20extension.20not.20showing.20infoview/near/435562684 and originally introduced in #428.

It turns out that VS Code sometimes hands us non-file/untitled URIs, e.g. 'output' URIs. I totally forgot about those. This PR ensures that instead of throwing an error when we encounter such a URI, the extension bails as soon as possible.