### PR TITLE
fix: only yield 'lake missing' error if `lake --serve` is used

### DIFF
--- a/vscode-lean4/src/projectDiagnostics.ts
+++ b/vscode-lean4/src/projectDiagnostics.ts
@@ -1,6 +1,7 @@
 import { SemVer } from 'semver'
 import { OutputChannel, commands } from 'vscode'
 import { ExtUri, FileUri } from './utils/exturi'
+import { willUseLakeServer } from './utils/projectInfo'
 import {
     PreconditionCheckResult,
     SetupDiagnoser,
@@ -97,7 +98,11 @@ class ProjectDiagnosticsProvider {
         }
     }
 
-    async checkIsLakeInstalled(): Promise<PreconditionCheckResult> {
+    async checkIsLakeInstalledCorrectly(): Promise<PreconditionCheckResult> {
+        if (!(await willUseLakeServer(this.folderUri))) {
+            return PreconditionCheckResult.Fulfilled
+        }
+
         const lakeVersionResult = await this.diagnose().queryLakeVersion()
         switch (lakeVersionResult.kind) {
             case 'CommandNotFound':
@@ -138,7 +143,7 @@ export async function checkLean4ProjectPreconditions(
         return PreconditionCheckResult.Fatal
     }
 
-    const lakeVersionCheckResult = await diagnosticsProvider.checkIsLakeInstalled()
+    const lakeVersionCheckResult = await diagnosticsProvider.checkIsLakeInstalledCorrectly()
 
     return worstPreconditionViolation(leanProjectCheckResult, lakeVersionCheckResult)
 }

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs'
-import { FileUri, getWorkspaceFolderUri } from './exturi'
+import { ExtUri, FileUri, getWorkspaceFolderUri } from './exturi'
 import { fileExists } from './fsHelper'
 import path = require('path')
 
@@ -130,4 +130,14 @@ export async function checkParentFoldersForLeanProject(folder: FileUri): Promise
         }
     } while (!childFolder.equals(folder))
     return undefined
+}
+
+export async function willUseLakeServer(folder: ExtUri): Promise<boolean> {
+    if (folder.scheme !== 'file') {
+        return false
+    }
+
+    const lakefileLean = folder.join('lakefile.lean')
+    const lakefileToml = folder.join('lakefile.toml')
+    return (await fileExists(lakefileLean.fsPath)) || (await fileExists(lakefileToml.fsPath))
 }


### PR DESCRIPTION
This fixes an issue where opening the core Lean 4 repository would yield an error and not actually launch the language client because Lake is genuinely missing from stage0.