### PR TITLE
fix: do not consider folders called `lean-toolchain`

### DIFF
--- a/vscode-lean4/src/utils/fsHelper.ts
+++ b/vscode-lean4/src/utils/fsHelper.ts
@@ -3,19 +3,25 @@ import { PathLike, promises } from 'fs'
 import path = require('path')
 
 /**
-    Helper used to replace fs.existsSync (using existsSync to check for the existence
-    of a file before calling fs.open(), fs.readFile() or fs.writeFile() is not recommended.
-    Doing so introduces a race condition, since other processes may change the file's state between the two calls.
-    Instead, user code should open/read/write the file directly and handle the error raised if the file does not exist.)
-    param: pathFile - A string representing a PathLike
-
-    returns Promise<boolean> that represents if a file exist
-**/
+ * Returns true if `pathFile` exists and is a file
+ */
 export async function fileExists(pathFile: PathLike): Promise<boolean> {
-    return await promises.access(pathFile).then(
-        () => true,
-        () => false,
-    )
+    try {
+        return (await promises.stat(pathFile)).isFile()
+    } catch (e) {
+        return false
+    }
+}
+
+/**
+ * Returns true if `pathFile` exists and is a directory
+ */
+export async function dirExists(pathFile: PathLike): Promise<boolean> {
+    try {
+        return (await promises.stat(pathFile)).isDirectory()
+    } catch (e) {
+        return false
+    }
 }
 
 /**

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs'
 import { ExtUri, FileUri, getWorkspaceFolderUri } from './exturi'
-import { fileExists } from './fsHelper'
+import { dirExists, fileExists } from './fsHelper'
 import path = require('path')
 
 // Detect lean4 root directory (works for both lean4 repo and nightly distribution)
@@ -11,21 +11,21 @@ export async function isCoreLean4Directory(path: FileUri): Promise<boolean> {
     const srcPath = path.join('src').fsPath
 
     const isCoreLean4RootDirectory =
-        (await fileExists(licensePath)) && (await fileExists(licensesPath)) && (await fileExists(srcPath))
+        (await fileExists(licensePath)) && (await fileExists(licensesPath)) && (await dirExists(srcPath))
     if (isCoreLean4RootDirectory) {
         return true
     }
 
-    const initPath = path.join('Init').fsPath
-    const leanPath = path.join('Lean').fsPath
+    const initPath = path.join('Init.lean').fsPath
+    const leanPath = path.join('Lean.lean').fsPath
     const kernelPath = path.join('kernel').fsPath
     const runtimePath = path.join('runtime').fsPath
 
     const isCoreLean4SrcDirectory =
         (await fileExists(initPath)) &&
         (await fileExists(leanPath)) &&
-        (await fileExists(kernelPath)) &&
-        (await fileExists(runtimePath))
+        (await dirExists(kernelPath)) &&
+        (await dirExists(runtimePath))
     return isCoreLean4SrcDirectory
 }
 


### PR DESCRIPTION
Some unusual mount-points will report every top-level directory as existing. On such a system, the extension mistakenly thinks a `lean-toolchain` directory is valid.

Similarly, the check for the lean core directory needs to check for some non-directories to avoid a false positive.