### PR TITLE
add span abbreviation

### DIFF
--- a/vscode-lean4/src/abbreviation/abbreviations.json
+++ b/vscode-lean4/src/abbreviation/abbreviations.json
@@ -777,6 +777,7 @@
     "straightphi": "φ",
     "st": "⋆",
     "spesmilo": "₷",
+    "span": "∙",
     "spadesuit": "♠",
     "sphericalangle": "∢",
     "section": "§",


### PR DESCRIPTION
Adds an abbreviation "span" for the Uncode "∙" used in "Mathlib/LinearAlgebra/Span.lean"

See https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Show.20the.20basis.20vectors.20of.20R.5En.20sum.20to.20R.5En/near/439392547