### PR TITLE
fix: special update handling for elan 3.1.0

### DIFF
--- a/vscode-lean4/src/globalDiagnostics.ts
+++ b/vscode-lean4/src/globalDiagnostics.ts
@@ -115,6 +115,11 @@ class GlobalDiagnosticsProvider {
                 if (updateElanChoice === undefined) {
                     return false
                 }
+                if (elanDiagnosis.currentVersion.compare('3.1.0') === 0) {
+                    // `elan self update` was broken in elan 3.1.0, so we need to take a different approach to updating elan here.
+                    const installElanResult = await this.installer.installElan()
+                    return installElanResult !== 'InstallationFailed'
+                }
                 const elanSelfUpdateResult = await elanSelfUpdate(this.channel)
                 if (elanSelfUpdateResult.exitCode !== ExecutionExitCode.Success) {
                     displayResultError(

--- a/vscode-lean4/src/projectinit.ts
+++ b/vscode-lean4/src/projectinit.ts
@@ -6,7 +6,6 @@ import {
     ExecutionExitCode,
     ExecutionResult,
 } from './utils/batch'
-import { elanSelfUpdate } from './utils/elan'
 import { FileUri } from './utils/exturi'
 import { lake } from './utils/lake'
 import { displayError, displayInformationWithInput } from './utils/notifs'
@@ -106,9 +105,6 @@ export class ProjectInitializationProvider implements Disposable {
         if ((await this.checkSetupDeps(projectFolder)) === 'IncompleteSetup') {
             return 'DidNotComplete'
         }
-
-        // This can fail silently in setups without Elan.
-        await elanSelfUpdate(this.channel)
 
         const projectName: string = path.basename(projectFolder.fsPath)
         const result: ExecutionResult = await lake(this.channel, projectFolder, toolchain).initProject(


### PR DESCRIPTION
Since `elan self update` was broken in Elan 3.1.0, we can't actually update `elan` that way. Instead, we now re-run the installation script for this version.

Also removes the `elan self update` call when attempting to create a project.