### PR TITLE
feat: shift-click to unselect

### DIFF
--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -159,7 +159,14 @@ const InfoDisplayContent = React.memo((props: InfoDisplayContentProps) => {
 
     /* Adding {' '} to manage string literals properly: https://reactjs.org/docs/jsx-in-depth.html#string-literals-1 */
     return (
-        <>
+        <span
+            onClick={e => {
+                if (e.shiftKey) setSelectedLocs([])
+            }}
+            onPointerDown={e => {
+                if (e.shiftKey) e.preventDefault()
+            }}
+        >
             {hasError && (
                 <div className="error" key="errors">
                     Error updating: {error}.
@@ -243,7 +250,7 @@ const InfoDisplayContent = React.memo((props: InfoDisplayContentProps) => {
                 ) : (
                     'No info found.'
                 ))}
-        </>
+        </span>
     )
 })
 


### PR DESCRIPTION
A simple(istic) implementation of an easier way to unselect hypotheses or types in a goal: shift-clicking anywhere in the info display that "does nothing" (i.e., doesn't select something else or show up a popup) unselects all items. This might still be a bit annoying, since a shift-misclick will clear everything, but better than nothing. (I am open to suggestions for alternatives.)

CC @PatrickMassot 

https://github.com/leanprover/vscode-lean4/assets/13901751/6e9e18a5-dbf6-4030-8674-cb17775fc7e0