### PR TITLE
fix: don't automatically build dependencies by default

### DIFF
--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -42,7 +42,7 @@ import { assert } from './utils/assert'
 import { logger } from './utils/logger'
 // @ts-ignore
 import { SemVer } from 'semver'
-import { c2pConverter, p2cConverter, patchConverters } from './utils/converters'
+import { c2pConverter, p2cConverter, patchConverters, setDependencyBuildMode } from './utils/converters'
 import { collectAllOpenLeanDocumentUris } from './utils/docInfo'
 import { ExtUri, extUriEquals, parseExtUri, toExtUri } from './utils/exturi'
 import {
@@ -408,7 +408,7 @@ export class LeanClient implements Disposable {
         this.openServerDocuments.add(uri)
         await this.client.sendNotification(
             'textDocument/didOpen',
-            this.client.code2ProtocolConverter.asOpenTextDocumentParams(doc),
+            setDependencyBuildMode(this.client.code2ProtocolConverter.asOpenTextDocumentParams(doc), 'once'),
         )
 
         this.restartedWorkerEmitter.fire(uri)

--- a/vscode-lean4/src/utils/converters.ts
+++ b/vscode-lean4/src/utils/converters.ts
@@ -11,7 +11,7 @@
  */
 
 import * as code from 'vscode'
-import { Code2ProtocolConverter, Protocol2CodeConverter } from 'vscode-languageclient'
+import { Code2ProtocolConverter, DidOpenTextDocumentParams, Protocol2CodeConverter } from 'vscode-languageclient'
 import { createConverter as createC2PConverter } from 'vscode-languageclient/lib/common/codeConverter'
 import { createConverter as createP2CConverter } from 'vscode-languageclient/lib/common/protocolConverter'
 import * as async from 'vscode-languageclient/lib/common/utils/async'
@@ -36,6 +36,15 @@ namespace SnippetTextEdit {
         if (typeof snip.value !== 'string' && !(snip.value instanceof String)) return false
         return true
     }
+}
+
+export function setDependencyBuildMode(
+    params: DidOpenTextDocumentParams,
+    dependencyBuildMode: 'once' | 'never',
+): DidOpenTextDocumentParams {
+    const updatedParams: any = params
+    updatedParams.dependencyBuildMode = automaticallyBuildDependencies() ? 'always' : dependencyBuildMode
+    return updatedParams
 }
 
 export const p2cConverter = createP2CConverter(undefined, true, true)
@@ -71,8 +80,7 @@ export function patchConverters(p2cConverter: Protocol2CodeConverter, c2pConvert
     const oldC2pAsOpenTextDocumentParams = c2pConverter.asOpenTextDocumentParams
     c2pConverter.asOpenTextDocumentParams = doc => {
         const params = oldC2pAsOpenTextDocumentParams.apply(this, [doc])
-        params.dependencyBuildMode = automaticallyBuildDependencies() ? 'always' : 'once'
-        return params
+        return setDependencyBuildMode(params, 'never')
     }
 
     // eslint-disable-next-line @typescript-eslint/unbound-method


### PR DESCRIPTION
This slipped in while refactoring things in #460.