### PR TITLE
feat: support for new manifest version format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13470,7 +13470,7 @@
         },
         "vscode-lean4": {
             "name": "lean4",
-            "version": "0.0.151",
+            "version": "0.0.159",
             "license": "Apache-2.0",
             "dependencies": {
                 "@leanprover/infoview": "~0.7.0",


### PR DESCRIPTION
Lake changed its Manifest version format to semantic versioning in https://github.com/leanprover/lean4/pull/4083. This PR ensures that we can still parse the new format.