### PR TITLE
fix: 'lean4.input.convert already registered' error

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -396,7 +396,7 @@
                 "command": "lean4.input.convert",
                 "key": "tab",
                 "mac": "tab",
-                "when": "editorTextFocus && editorLangId == lean4 && lean4.input.isActive"
+                "when": "editorTextFocus && lean4.input.isActive"
             },
             {
                 "command": "lean4.restartFile",

--- a/vscode-lean4/src/abbreviation/AbbreviationRewriterFeature.ts
+++ b/vscode-lean4/src/abbreviation/AbbreviationRewriterFeature.ts
@@ -1,5 +1,5 @@
 import { AbbreviationProvider } from '@leanprover/unicode-input'
-import { Disposable, languages, TextEditor, window, workspace } from 'vscode'
+import { commands, Disposable, languages, TextEditor, window, workspace } from 'vscode'
 import { VSCodeAbbreviationConfig } from './VSCodeAbbreviationConfig'
 import { VSCodeAbbreviationRewriter } from './VSCodeAbbreviationRewriter'
 
@@ -19,6 +19,14 @@ export class AbbreviationRewriterFeature {
     ) {
         this.changedVisibleTextEditors(window.visibleTextEditors)
         this.disposables.push(
+            commands.registerTextEditorCommand('lean4.input.convert', async editor => {
+                const rewriter = this.rewriters.get(editor)
+                if (rewriter === undefined) {
+                    return
+                }
+                await rewriter.replaceAllTrackedAbbreviations()
+            }),
+
             window.onDidChangeVisibleTextEditors(visibleTextEditors =>
                 this.changedVisibleTextEditors(visibleTextEditors),
             ),

--- a/vscode-lean4/src/abbreviation/VSCodeAbbreviationRewriter.ts
+++ b/vscode-lean4/src/abbreviation/VSCodeAbbreviationRewriter.ts
@@ -76,13 +76,6 @@ export class VSCodeAbbreviationRewriter implements AbbreviationTextSource {
             }),
         )
 
-        this.disposables.push(
-            commands.registerTextEditorCommand('lean4.input.convert', async () => {
-                await this.rewriter.replaceAllTrackedAbbreviations()
-                this.updateState()
-            }),
-        )
-
         this.checkIsVimExtensionInstalled()
         this.disposables.push(extensions.onDidChange(_ => this.checkIsVimExtensionInstalled()))
     }
@@ -134,6 +127,11 @@ export class VSCodeAbbreviationRewriter implements AbbreviationTextSource {
             this.writeError('Error while replacing abbreviation: ' + e)
         }
         return ok
+    }
+
+    async replaceAllTrackedAbbreviations() {
+        await this.rewriter.replaceAllTrackedAbbreviations()
+        this.updateState()
     }
 
     private updateState() {


### PR DESCRIPTION
This fixes an issue introduced in the abbreviation refactor of #469 that would sometimes cause the extension to not activate properly because a command was attempted to be registered multiple times. It also fixes another bug where `Tab` completion did not work correctly in non-Lean 4 files.

Fixes #475.