### PR TITLE
fix: revert to using one abbreviation rewriter for active editor

### DIFF
--- a/vscode-lean4/src/abbreviation/AbbreviationFeature.ts
+++ b/vscode-lean4/src/abbreviation/AbbreviationFeature.ts
@@ -1,5 +1,5 @@
 import { AbbreviationProvider } from '@leanprover/unicode-input'
-import { Disposable, languages } from 'vscode'
+import { Disposable, OutputChannel, languages } from 'vscode'
 import { AbbreviationHoverProvider } from './AbbreviationHoverProvider'
 import { AbbreviationRewriterFeature } from './AbbreviationRewriterFeature'
 import { VSCodeAbbreviationConfig } from './VSCodeAbbreviationConfig'
@@ -8,7 +8,7 @@ export class AbbreviationFeature {
     private readonly disposables = new Array<Disposable>()
     readonly abbreviations: AbbreviationProvider
 
-    constructor() {
+    constructor(outputChannel: OutputChannel) {
         const config = new VSCodeAbbreviationConfig()
         this.disposables.push(config)
         this.abbreviations = new AbbreviationProvider(config)
@@ -18,7 +18,7 @@ export class AbbreviationFeature {
                 config.languages,
                 new AbbreviationHoverProvider(config, this.abbreviations),
             ),
-            new AbbreviationRewriterFeature(config, this.abbreviations),
+            new AbbreviationRewriterFeature(config, this.abbreviations, outputChannel),
         )
     }
 

--- a/vscode-lean4/src/abbreviation/AbbreviationRewriterFeature.ts
+++ b/vscode-lean4/src/abbreviation/AbbreviationRewriterFeature.ts
@@ -1,5 +1,5 @@
 import { AbbreviationProvider } from '@leanprover/unicode-input'
-import { commands, Disposable, languages, TextEditor, window, workspace } from 'vscode'
+import { commands, Disposable, languages, OutputChannel, TextEditor, window, workspace } from 'vscode'
 import { extUriEquals, toExtUri } from '../utils/exturi'
 import { VSCodeAbbreviationConfig } from './VSCodeAbbreviationConfig'
 import { VSCodeAbbreviationRewriter } from './VSCodeAbbreviationRewriter'
@@ -16,6 +16,7 @@ export class AbbreviationRewriterFeature {
     constructor(
         private readonly config: VSCodeAbbreviationConfig,
         private readonly abbreviationProvider: AbbreviationProvider,
+        private readonly outputChannel: OutputChannel,
     ) {
         void this.changedActiveTextEditor(window.activeTextEditor)
 
@@ -46,6 +47,7 @@ export class AbbreviationRewriterFeature {
                     this.activeAbbreviationRewriter = new VSCodeAbbreviationRewriter(
                         config,
                         abbreviationProvider,
+                        outputChannel,
                         window.activeTextEditor,
                     )
                 } else if (
@@ -78,6 +80,7 @@ export class AbbreviationRewriterFeature {
         this.activeAbbreviationRewriter = new VSCodeAbbreviationRewriter(
             this.config,
             this.abbreviationProvider,
+            this.outputChannel,
             activeTextEditor,
         )
     }

--- a/vscode-lean4/src/abbreviation/VSCodeAbbreviationRewriter.ts
+++ b/vscode-lean4/src/abbreviation/VSCodeAbbreviationRewriter.ts
@@ -31,7 +31,6 @@ export class VSCodeAbbreviationRewriter implements AbbreviationTextSource {
         textDecoration: 'underline',
     })
 
-    private stderrOutput: OutputChannel
     private firstOutput = true
     private isVimExtensionInstalled = false
 
@@ -42,6 +41,7 @@ export class VSCodeAbbreviationRewriter implements AbbreviationTextSource {
     constructor(
         readonly config: AbbreviationConfig,
         readonly abbreviationProvider: AbbreviationProvider,
+        private readonly outputChannel: OutputChannel,
         private readonly textEditor: TextEditor,
     ) {
         this.rewriter = new AbbreviationRewriter(config, abbreviationProvider, this)
@@ -81,10 +81,9 @@ export class VSCodeAbbreviationRewriter implements AbbreviationTextSource {
     }
 
     private writeError(e: string) {
-        this.stderrOutput = this.stderrOutput || window.createOutputChannel('Lean: Editor')
-        this.stderrOutput.appendLine(e)
+        this.outputChannel.appendLine(e)
         if (this.firstOutput) {
-            this.stderrOutput.show(true)
+            this.outputChannel.show(true)
             this.firstOutput = false
         }
     }

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -122,7 +122,7 @@ function activateAlwaysEnabledFeatures(context: ExtensionContext): AlwaysEnabled
     const fullDiagnosticsProvider = new FullDiagnosticsProvider(outputChannel)
     context.subscriptions.push(fullDiagnosticsProvider)
 
-    const abbreviationFeature = new AbbreviationFeature()
+    const abbreviationFeature = new AbbreviationFeature(outputChannel)
     context.subscriptions.push(abbreviationFeature)
 
     const abbreviationView = new AbbreviationView(extensionPath, abbreviationFeature.abbreviations)

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -24,6 +24,7 @@ import { LeanClientProvider } from './utils/clientProvider'
 import { LeanConfigWatchService } from './utils/configwatchservice'
 import { PATH, setProcessEnvPATH } from './utils/envPath'
 import { FileUri, isExtUri, toExtUriOrError } from './utils/exturi'
+import { displayInternalErrorsIn } from './utils/internalErrors'
 import { LeanInstaller } from './utils/leanInstaller'
 import { displayWarning } from './utils/notifs'
 import { PathExtensionProvider } from './utils/pathExtensionProvider'
@@ -191,15 +192,17 @@ async function activateLean4Features(
 
 export async function activate(context: ExtensionContext): Promise<Exports> {
     await setLeanFeatureSetActive(false)
-    const alwaysEnabledFeatures: AlwaysEnabledFeatures = activateAlwaysEnabledFeatures(context)
+    const alwaysEnabledFeatures: AlwaysEnabledFeatures = await displayInternalErrorsIn(
+        'activating Lean 4 extension',
+        async () => activateAlwaysEnabledFeatures(context),
+    )
 
     const lean4EnabledFeatures: Promise<Lean4EnabledFeatures> = new Promise(async (resolve, _) => {
         const doc: TextDocument | undefined = findOpenLeanDocument()
         if (doc) {
-            const lean4EnabledFeatures: Lean4EnabledFeatures | undefined = await activateLean4Features(
-                context,
-                alwaysEnabledFeatures.installer,
-                doc,
+            const lean4EnabledFeatures: Lean4EnabledFeatures | undefined = await displayInternalErrorsIn(
+                'activating Lean 4 features',
+                () => activateLean4Features(context, alwaysEnabledFeatures.installer, doc),
             )
             if (lean4EnabledFeatures) {
                 resolve(lean4EnabledFeatures)
@@ -212,10 +215,9 @@ export async function activate(context: ExtensionContext): Promise<Exports> {
             if (!isLean4Document(doc)) {
                 return
             }
-            const lean4EnabledFeatures: Lean4EnabledFeatures | undefined = await activateLean4Features(
-                context,
-                alwaysEnabledFeatures.installer,
-                doc,
+            const lean4EnabledFeatures: Lean4EnabledFeatures | undefined = await displayInternalErrorsIn(
+                'activating Lean 4 features',
+                () => activateLean4Features(context, alwaysEnabledFeatures.installer, doc),
             )
             if (!lean4EnabledFeatures) {
                 return

--- a/vscode-lean4/src/utils/internalErrors.ts
+++ b/vscode-lean4/src/utils/internalErrors.ts
@@ -1,0 +1,27 @@
+import { env } from 'vscode'
+import { displayErrorWithInput } from './notifs'
+
+export async function displayInternalErrorsIn<T>(scope: string, f: () => Promise<T>): Promise<T> {
+    try {
+        return await f()
+    } catch (e) {
+        let msg: string
+        if (e instanceof Error) {
+            msg = `Internal error (while ${scope}):`
+            if (e.stack === undefined) {
+                msg += ` ${e.name}: ${e.message}`
+            } else {
+                msg += '\n\n' + e.stack
+            }
+        } else {
+            msg = e
+        }
+
+        const copyToClipboardInput = 'Copy to Clipboard'
+        const choice = await displayErrorWithInput(msg, copyToClipboardInput)
+        if (choice === copyToClipboardInput) {
+            await env.clipboard.writeText(msg)
+        }
+        throw e
+    }
+}


### PR DESCRIPTION
In #469, I refactored the abbreviation provider to maintain one abbreviation rewriter per visible text editor. The idea was that it would be nice if the abbreviation state was maintained when switching between visible text editors.

It turns out that this is way too fiddly to get right:

- Since `TextEditor`s have no ID, it relies on the fact that `TextEditor` references are stable. I'm not sure if this is actually true, and I don't want to debug issues that are caused by this assumption being violated.
- The abbreviation rewriters for two text editors for the same text can trample over one another.
- The benefit isn't huge. We already always replace abbreviations when the selection is moved away from the abbreviation, so why shouldn't this also be the case when moving the cursor across text editors?

Still, the new behavior is a bit more consistent than the behavior before #469, as it correctly deals with changed language IDs and triggers abbreviations when moving the cursor away from the editor (instead of simply unselecting the abbreviation).

This PR also ensures that exceptions during the activation of the extension are displayed in a modal dialog. An exception at this point always breaks the extension for the user, so they should know about it (and the error shouldn't be hidden away in the developer console).

Fixes #478.