### PR TITLE
feat: set x-loogle-client header for loogle requests

### DIFF
--- a/vscode-lean4/loogleview/index.ts
+++ b/vscode-lean4/loogleview/index.ts
@@ -169,6 +169,7 @@ class LoogleView {
             try {
                 const headers = new Headers({
                     'User-Agent': `Code/${this.vscodeVersion} lean4/${this.extensionVersion}`,
+                    'X-Loogle-Client': `Code/${this.vscodeVersion} lean4/${this.extensionVersion}`,
                 })
                 return await (
                     await fetch(`https://loogle.lean-lang.org/json?q=${encodeURIComponent(query)}`, {


### PR DESCRIPTION
Looks like setting the user agent in the web view doesn't really work, so we now set a separate HTTP header to tell Loogle about us. cc @nomeata