### PR TITLE
feat: vs code and vs code extension version diagnostics

### DIFF
--- a/vscode-lean4/src/diagnostics/setupDiagnostics.ts
+++ b/vscode-lean4/src/diagnostics/setupDiagnostics.ts
@@ -222,3 +222,16 @@ export async function checkIsLakeInstalledCorrectly(
             return 'Fulfilled'
     }
 }
+
+export async function checkIsVSCodeUpToDate(): Promise<PreconditionCheckResult> {
+    const vscodeVersionResult = diagnose(undefined, undefined).queryVSCodeVersion()
+    switch (vscodeVersionResult.kind) {
+        case 'Outdated':
+            return displaySetupWarning(
+                `VS Code version is too out-of-date for new versions of the Lean 4 VS Code extension. The current VS Code version is ${vscodeVersionResult.currentVersion}, but at least a version of ${vscodeVersionResult.recommendedVersion} is recommended so that new versions of the Lean 4 VS Code extension can be installed.`,
+            )
+
+        case 'UpToDate':
+            return 'Fulfilled'
+    }
+}

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -10,6 +10,7 @@ import {
     checkAreDependenciesInstalled,
     checkIsElanUpToDate,
     checkIsLean4Installed,
+    checkIsVSCodeUpToDate,
 } from './diagnostics/setupDiagnostics'
 import { PreconditionCheckResult } from './diagnostics/setupNotifs'
 import { AlwaysEnabledFeatures, Exports, Lean4EnabledFeatures } from './exports'
@@ -143,6 +144,7 @@ async function checkLean4FeaturePreconditions(
                 elanMustBeInstalled: false,
                 modal: false,
             }),
+        () => checkIsVSCodeUpToDate(),
     )
 }
 


### PR DESCRIPTION
This helps us debug old VS Code extension versions and warns users if their VS Code version will not clear an extension VS Code version requirement.