### PR TITLE
fix: do not implicitely cast Position to ls.Position.

### DIFF
--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -743,8 +743,8 @@ export class InfoProvider implements Disposable {
         return {
             uri: uri.toString(),
             range: {
-                start: selection.start,
-                end: selection.end,
+                start: { line: selection.start.line, character: selection.start.character },
+                end: { line: selection.end.line, character: selection.end.character },
             },
         }
     }


### PR DESCRIPTION
Adapting teh VSCode extension for monaco, there is an error message caused by this implicit typecast from `Position` to `ls.Position`:

```
Error updating: Error fetching goals: Rpc error: ParseError:
Cannot parse request params: {"textDocument":
{"uri":"file:///workspace/test.lean"},"sessionId":"1430986504474938216",
"position":{},"params"
{"textDocument":{"uri":"file:///workspace/test.lean"},"position":{}},
"method":"Lean.Widget.getInteractiveGoals"} Lean.Lsp.RpcCallParams.position:
Lean.Lsp.Position.line: Natural number expected. Try again.
```

I don't understand why this is, but apparently that's one way to fix it. (note: `Position` comes from the package [@codingame/monaco-vscode-api](https://www.npmjs.com/package/@codingame/monaco-vscode-api) in our setup and from VSCode in the normal setup. They should be identical.