### PR TITLE
fix: crash when vs code opens files that do not exist

### DIFF
--- a/vscode-lean4/src/diagnostics/fullDiagnostics.ts
+++ b/vscode-lean4/src/diagnostics/fullDiagnostics.ts
@@ -2,7 +2,7 @@ import { SemVer } from 'semver'
 import { Disposable, OutputChannel, TextDocument, commands, env, window, workspace } from 'vscode'
 import { ExecutionExitCode, ExecutionResult } from '../utils/batch'
 import { ExtUri, FileUri, extUriEquals, toExtUri } from '../utils/exturi'
-import { displayInformationWithInput } from '../utils/notifs'
+import { displayError, displayInformationWithInput } from '../utils/notifs'
 import { findLeanProjectRoot } from '../utils/projectInfo'
 import {
     ElanVersionDiagnosis,
@@ -185,6 +185,12 @@ export class FullDiagnosticsProvider implements Disposable {
             this.lastActiveLeanDocumentUri !== undefined && this.lastActiveLeanDocumentUri.scheme === 'file'
                 ? await findLeanProjectRoot(this.lastActiveLeanDocumentUri)
                 : undefined
+        if (projectUri === 'FileNotFound') {
+            displayError(
+                `Cannot display setup information for file that does not exist in the file system: ${this.lastActiveLeanDocumentUri}. Please choose a different file to display the setup information for.`,
+            )
+            return
+        }
         const fullDiagnostics = await performFullDiagnosis(this.outputChannel, projectUri)
         const formattedFullDiagnostics = formatFullDiagnostics(fullDiagnostics)
         const copyToClipboardInput = 'Copy to Clipboard'

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -118,6 +118,9 @@ export class LeanClientProvider implements Disposable {
             }
             try {
                 const projectUri = await findLeanProjectRoot(uri)
+                if (projectUri === 'FileNotFound') {
+                    continue
+                }
 
                 const preconditionCheckResult = await checkLean4ProjectPreconditions(this.outputChannel, projectUri)
                 if (preconditionCheckResult !== 'Fatal') {
@@ -216,6 +219,9 @@ export class LeanClientProvider implements Disposable {
     // Returns a null client if it turns out the new workspace is a lean3 workspace.
     async ensureClient(uri: ExtUri): Promise<[boolean, LeanClient | undefined]> {
         const folderUri = uri.scheme === 'file' ? await findLeanProjectRoot(uri) : new UntitledUri()
+        if (folderUri === 'FileNotFound') {
+            return [false, undefined]
+        }
         let client = this.getClientForFolder(folderUri)
         if (client) {
             this.activeClient = client

--- a/vscode-lean4/src/utils/internalErrors.ts
+++ b/vscode-lean4/src/utils/internalErrors.ts
@@ -5,22 +5,17 @@ export async function displayInternalErrorsIn<T>(scope: string, f: () => Promise
     try {
         return await f()
     } catch (e) {
-        let msg: string
-        if (e instanceof Error) {
-            msg = `Internal error (while ${scope}):`
-            if (e.stack === undefined) {
-                msg += ` ${e.name}: ${e.message}`
-            } else {
-                msg += '\n\n' + e.stack
-            }
-        } else {
-            msg = e
+        let msg: string = `Internal error (while ${scope}): ${e}`
+        let fullMsg: string = msg
+        if (e instanceof Error && e.stack !== undefined) {
+            fullMsg += `\n\n${e.stack}`
         }
-
-        const copyToClipboardInput = 'Copy to Clipboard'
+        msg +=
+            "\n\nIf you are using an up-to-date version of the Lean 4 VS Code extension, please copy the full error message using the 'Copy Error to Clipboard' button and report it at https://github.com/leanprover/vscode-lean4/ or https://leanprover.zulipchat.com/."
+        const copyToClipboardInput = 'Copy Error to Clipboard'
         const choice = await displayErrorWithInput(msg, copyToClipboardInput)
         if (choice === copyToClipboardInput) {
-            await env.clipboard.writeText(msg)
+            await env.clipboard.writeText(fullMsg)
         }
         throw e
     }


### PR DESCRIPTION
This PR fixes two issues reported at https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/VS.20Code.20error.20too.20big.20to.20remove/near/447340051:
- When displaying an activation error, the popup can get too large, rendering VS Code unusable. We now only display the error message without the stack trace, but copy it when using the "Copy Error to Clipboard" button.
- Activating the VS Code extension would sometimes crash when VS Code attempts to open a document with a file URI that does not exist on the file system anymore. This happens when a file has unsaved changes, VS Code is closed, the file is deleted and VS Code is re-opened.