### PR TITLE
feat: [lean4web] abstract the implementation of infoview as a webview

### DIFF
--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -9,6 +9,7 @@ import { checkAll, SetupDiagnostics } from './diagnostics/setupDiagnostics'
 import { PreconditionCheckResult, SetupNotificationOptions } from './diagnostics/setupNotifs'
 import { AlwaysEnabledFeatures, Exports, Lean4EnabledFeatures } from './exports'
 import { InfoProvider } from './infoview'
+import { VSCodeInfoWebviewFactory } from './infowebview'
 import { LeanClient } from './leanclient'
 import { LoogleView } from './loogleview'
 import { ManualView } from './manualview'
@@ -195,7 +196,7 @@ async function activateLean4Features(
     watchService.lakeFileChanged(packageUri => installer.handleLakeFileChanged(packageUri))
     context.subscriptions.push(watchService)
 
-    const infoProvider = new InfoProvider(clientProvider, context)
+    const infoProvider = new InfoProvider(clientProvider, { language: 'lean4' }, context, new VSCodeInfoWebviewFactory(context))
     context.subscriptions.push(infoProvider)
 
     context.subscriptions.push(new LeanTaskGutter(clientProvider, context))

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -9,12 +9,12 @@ import {
     ServerStoppedReason,
     TextInsertKind,
 } from '@leanprover/infoview-api'
-import { join } from 'path'
 import {
     commands,
     Diagnostic,
     Disposable,
     env,
+    Event,
     ExtensionContext,
     Position,
     Range,
@@ -22,7 +22,7 @@ import {
     TextEditor,
     TextEditorRevealType,
     Uri,
-    WebviewPanel,
+    ViewColumn,
     window,
     workspace,
 } from 'vscode'
@@ -40,8 +40,6 @@ import {
     getInfoViewShowGoalNames,
     getInfoViewShowTooltipOnHover,
     getInfoViewStyle,
-    minIfProd,
-    prodOrDev,
 } from './config'
 import { LeanClient } from './leanclient'
 import { Rpc } from './rpc'
@@ -52,6 +50,19 @@ import { lean, LeanEditor } from './utils/leanEditorProvider'
 import { logger } from './utils/logger'
 import { displayNotification } from './utils/notifs'
 import { viewColumnOfActiveTextEditor, viewColumnOfInfoView } from './utils/viewColumn'
+
+export interface InfoWebview {
+    readonly api: InfoviewApi
+    readonly rpc: Rpc
+    readonly visible: boolean
+    dispose(): any
+    reveal(viewColumn?: ViewColumn, preserveFocus?: boolean): void
+    onDidDispose: Event<void>
+}
+
+export interface InfoWebviewFactory {
+    make(editorApi: EditorApi, stylesheet: string, column: number): InfoWebview
+}
 
 const keepAlivePeriodMs = 10000
 
@@ -90,7 +101,7 @@ class RpcSessionAtPos implements Disposable {
 
 export class InfoProvider implements Disposable {
     /** Instance of the panel, if it is open. Otherwise `undefined`. */
-    private webviewPanel?: WebviewPanel & { rpc: Rpc; api: InfoviewApi }
+    private webviewPanel?: InfoWebview
     private subscriptions: Disposable[] = []
     private clientSubscriptions: Disposable[] = []
 
@@ -320,6 +331,7 @@ export class InfoProvider implements Disposable {
     constructor(
         private clientProvider: LeanClientProvider,
         private context: ExtensionContext,
+        private infoWebviewFactory: InfoWebviewFactory,
     ) {
         this.updateStylesheet()
 
@@ -582,48 +594,13 @@ export class InfoProvider implements Disposable {
         if (this.webviewPanel) {
             this.webviewPanel.reveal(undefined, true)
         } else {
-            const webviewPanel = window.createWebviewPanel(
-                'lean4_infoview',
-                'Lean Infoview',
-                { viewColumn: viewColumnOfInfoView(), preserveFocus: true },
-                {
-                    enableFindWidget: true,
-                    retainContextWhenHidden: true,
-                    enableScripts: true,
-                    enableCommandUris: true,
-                },
-            ) as WebviewPanel & { rpc: Rpc; api: InfoviewApi }
-
-            // Note that an extension can send data to its webviews using webview.postMessage().
-            // This method sends any JSON serializable data to the webview. The message is received
-            // inside the webview through the standard message event.
-            // The receiving of these messages is done inside webview\index.ts where it
-            // calls window.addEventListener('message',...
-            webviewPanel.rpc = new Rpc(m => {
-                try {
-                    void webviewPanel.webview.postMessage(m)
-                } catch (e) {
-                    // ignore any disposed object exceptions
-                }
-            })
-            webviewPanel.rpc.register(this.editorApi)
-
-            // Similarly, we can received data from the webview by listening to onDidReceiveMessage.
-            webviewPanel.webview.onDidReceiveMessage(m => {
-                try {
-                    webviewPanel.rpc.messageReceived(m)
-                } catch {
-                    // ignore any disposed object exceptions
-                }
-            })
-            webviewPanel.api = webviewPanel.rpc.getApi()
+            const webviewPanel = this.infoWebviewFactory.make(this.editorApi, this.stylesheet)
             webviewPanel.onDidDispose(() => {
                 this.webviewPanel = undefined
                 this.clearNotificationHandlers()
                 this.clearRpcSessions(null) // should be after `webviewPanel = undefined`
             })
             this.webviewPanel = webviewPanel
-            webviewPanel.webview.html = this.initialHtml()
 
             const client = this.clientProvider.findClient(leanEditor.documentExtUri)
             await this.initInfoView(leanEditor, client)
@@ -818,36 +795,5 @@ export class InfoProvider implements Disposable {
         }
         // ensure the text document has the keyboard focus.
         await window.showTextDocument(editor.document, { viewColumn: editor.viewColumn, preserveFocus: false })
-    }
-
-    private getLocalPath(path: string): string | undefined {
-        if (this.webviewPanel) {
-            return this.webviewPanel.webview.asWebviewUri(Uri.file(join(this.context.extensionPath, path))).toString()
-        }
-        return undefined
-    }
-
-    private initialHtml() {
-        const libPostfix = `.${prodOrDev}${minIfProd}.js`
-        return `
-            <!DOCTYPE html>
-            <html>
-            <head>
-                <meta charset="UTF-8" />
-                <meta http-equiv="Content-type" content="text/html;charset=utf-8">
-                <title>Infoview</title>
-                <style>${this.stylesheet}</style>
-                <link rel="stylesheet" href="${this.getLocalPath('dist/lean4-infoview/index.css')}">
-            </head>
-            <body>
-                <div id="react_root"></div>
-                <script
-                    data-importmap-leanprover-infoview="${this.getLocalPath(`dist/lean4-infoview/index${libPostfix}`)}"
-                    data-importmap-react="${this.getLocalPath(`dist/lean4-infoview/react${libPostfix}`)}"
-                    data-importmap-react-jsx-runtime="${this.getLocalPath(`dist/lean4-infoview/react-jsx-runtime${libPostfix}`)}"
-                    data-importmap-react-dom="${this.getLocalPath(`dist/lean4-infoview/react-dom${libPostfix}`)}"
-                    src="${this.getLocalPath('dist/webview.js')}"></script>
-            </body>
-            </html>`
     }
 }

--- a/vscode-lean4/src/infowebview.ts
+++ b/vscode-lean4/src/infowebview.ts
@@ -1,0 +1,97 @@
+import { EditorApi, InfoviewApi } from '@leanprover/infoview-api'
+import { join } from 'path'
+import { ExtensionContext, Uri, ViewColumn, WebviewPanel, window } from 'vscode'
+import { minIfProd, prodOrDev } from './config'
+import { InfoWebviewFactory } from './infoview'
+import { Rpc } from './rpc'
+import { viewColumnOfInfoView } from './utils/viewColumn'
+
+
+export class VSCodeInfoWebviewFactory implements InfoWebviewFactory {
+    constructor(private context: ExtensionContext) {}
+
+    make(editorApi: EditorApi, stylesheet: string) {
+        const webviewPanel = window.createWebviewPanel(
+            'lean4_infoview',
+            'Lean Infoview',
+            { viewColumn: viewColumnOfInfoView(), preserveFocus: true },
+            {
+                enableFindWidget: true,
+                retainContextWhenHidden: true,
+                enableScripts: true,
+                enableCommandUris: true,
+            },
+        )
+
+        // Note that an extension can send data to its webviews using webview.postMessage().
+        // This method sends any JSON serializable data to the webview. The message is received
+        // inside the webview through the standard message event.
+        // The receiving of these messages is done inside webview\index.ts where it
+        // calls window.addEventListener('message',...
+        const rpc = new Rpc(m => {
+            try {
+                void webviewPanel.webview.postMessage(m)
+            } catch (e) {
+                // ignore any disposed object exceptions
+            }
+        })
+        rpc.register(editorApi)
+
+        // Similarly, we can received data from the webview by listening to onDidReceiveMessage.
+        webviewPanel.webview.onDidReceiveMessage(m => {
+            try {
+                rpc.messageReceived(m)
+            } catch {
+                // ignore any disposed object exceptions
+            }
+        })
+        const api = rpc.getApi<InfoviewApi>()
+        webviewPanel.webview.html = this.initialHtml(webviewPanel, stylesheet)
+
+        return {
+            api,
+            rpc,
+            get visible() {
+                return webviewPanel.visible
+            },
+            dispose: () => {
+                webviewPanel.dispose()
+            },
+            reveal: (viewColumn?: ViewColumn, preserveFocus?: boolean) => {
+                webviewPanel.reveal(viewColumn, preserveFocus)
+            },
+            onDidDispose: webviewPanel.onDidDispose,
+        }
+    }
+
+    private getLocalPath(path: string, webviewPanel: WebviewPanel): string | undefined {
+        if (webviewPanel) {
+            return webviewPanel.webview.asWebviewUri(Uri.file(join(this.context.extensionPath, path))).toString()
+        }
+        return undefined
+    }
+
+    private initialHtml(webviewPanel: WebviewPanel, stylesheet: string) {
+        const libPostfix = `.${prodOrDev}${minIfProd}.js`
+        return `
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset="UTF-8" />
+                <meta http-equiv="Content-type" content="text/html;charset=utf-8">
+                <title>Infoview</title>
+                <style>${stylesheet}</style>
+                <link rel="stylesheet" href="${this.getLocalPath('dist/lean4-infoview/index.css', webviewPanel)}">
+            </head>
+            <body>
+                <div id="react_root"></div>
+                <script
+                    data-importmap-leanprover-infoview="${this.getLocalPath(`dist/lean4-infoview/index${libPostfix}`, webviewPanel)}"
+                    data-importmap-react="${this.getLocalPath(`dist/lean4-infoview/react${libPostfix}`, webviewPanel)}"
+                    data-importmap-react-jsx-runtime="${this.getLocalPath(`dist/lean4-infoview/react-jsx-runtime${libPostfix}`, webviewPanel)}"
+                    data-importmap-react-dom="${this.getLocalPath(`dist/lean4-infoview/react-dom${libPostfix}`, webviewPanel)}"
+                    src="${this.getLocalPath('dist/webview.js', webviewPanel)}"></script>
+            </body>
+            </html>`
+    }
+}


### PR DESCRIPTION
This is a pure refactoring. The behavior of the code has not changed. But this setup allows us to inject an iframe infoview implementation instead of the webview implementation.