### PR TITLE
doc: use image urls for everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ After installing this extension, a 'Welcome' page with a setup guide should open
 
 If the setup guide does not open automatically, you can still open it manually by opening an empty file, clicking on the ∀-symbol in the top right and selecting 'Documentation…' > 'Docs: Show Setup Guide'.
 
-  ![Setup guide with instructions for how to re-open the setup guide manually](vscode-lean4/images/setup_guide.png)
+  ![Setup guide with instructions for how to re-open the setup guide manually](https://github.com/leanprover/vscode-lean4/raw/HEAD/vscode-lean4/images/setup_guide.png)
 
 ## Using this extension
 
 The [Lean 4 VS Code extension manual](https://github.com/leanprover/vscode-lean4/blob/master/vscode-lean4/manual/manual.md) provides a complete and detailed overview over all features provided by this VS Code extension. If you are new to Lean, you may find the first five subsections of the 'Interacting with Lean files' section in the manual to be very helpful.
 
-  ![Manual table of contents](vscode-lean4/images/manual.png)
+  ![Manual table of contents](https://github.com/leanprover/vscode-lean4/raw/HEAD/vscode-lean4/images/manual.png)
 
 
 ## Developing the Lean 4 VS Code extension

--- a/vscode-lean4/README.md
+++ b/vscode-lean4/README.md
@@ -12,10 +12,10 @@ After installing this extension, a 'Welcome' page with a setup guide should open
 
 If the setup guide does not open automatically, you can still open it manually by opening an empty file, clicking on the ∀-symbol in the top right and selecting 'Documentation…' > 'Docs: Show Setup Guide'.
 
-  ![Setup guide with instructions for how to re-open the setup guide manually](images/setup_guide.png)
+  ![Setup guide with instructions for how to re-open the setup guide manually](https://github.com/leanprover/vscode-lean4/raw/HEAD/vscode-lean4/images/setup_guide.png)
 
 ## Using this extension
 
 The [Lean 4 VS Code extension manual](https://github.com/leanprover/vscode-lean4/blob/master/vscode-lean4/manual/manual.md) provides a complete and detailed overview over all features provided by this VS Code extension. If you are new to Lean, you may find the first five subsections of the 'Interacting with Lean files' section in the manual to be very helpful.
 
-  ![Manual table of contents](images/manual.png)
+  ![Manual table of contents](https://github.com/leanprover/vscode-lean4/raw/HEAD/vscode-lean4/images/manual.png)


### PR DESCRIPTION
The VS Code marketplace always attempts to resolve these URLs that are relative to the README in the vscode-lean4 folder in a manner that is relative to the repository, so now we just use the image links directly. That's what the marketplace replaces them as anyways.