### PR TITLE
refactor: replace require-style imports

### DIFF
--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -40,6 +40,7 @@ import {
 } from './config'
 import { logger } from './utils/logger'
 // @ts-ignore
+import path from 'path'
 import { SemVer } from 'semver'
 import { c2pConverter, p2cConverter, patchConverters, setDependencyBuildMode } from './utils/converters'
 import { ExtUri, parseExtUri, toExtUri } from './utils/exturi'
@@ -50,7 +51,6 @@ import {
     displayInformationWithOptionalInput,
 } from './utils/notifs'
 import { willUseLakeServer } from './utils/projectInfo'
-import path = require('path')
 
 const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -40,7 +40,6 @@ import {
 } from './config'
 import { logger } from './utils/logger'
 // @ts-ignore
-import path from 'path'
 import { SemVer } from 'semver'
 import { c2pConverter, p2cConverter, patchConverters, setDependencyBuildMode } from './utils/converters'
 import { ExtUri, parseExtUri, toExtUri } from './utils/exturi'
@@ -51,6 +50,7 @@ import {
     displayInformationWithOptionalInput,
 } from './utils/notifs'
 import { willUseLakeServer } from './utils/projectInfo'
+import path from 'path'
 
 const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 

--- a/vscode-lean4/src/projectinit.ts
+++ b/vscode-lean4/src/projectinit.ts
@@ -28,7 +28,6 @@ import { lake } from './utils/lake'
 import { LeanInstaller } from './utils/leanInstaller'
 import { displayError, displayInformationWithInput } from './utils/notifs'
 import { checkParentFoldersForLeanProject, isValidLeanProject } from './utils/projectInfo'
-import path = require('path')
 
 async function checkCreateLean4ProjectPreconditions(
     installer: LeanInstaller,

--- a/vscode-lean4/src/projectinit.ts
+++ b/vscode-lean4/src/projectinit.ts
@@ -28,6 +28,7 @@ import { lake } from './utils/lake'
 import { LeanInstaller } from './utils/leanInstaller'
 import { displayError, displayInformationWithInput } from './utils/notifs'
 import { checkParentFoldersForLeanProject, isValidLeanProject } from './utils/projectInfo'
+import path from 'path'
 
 async function checkCreateLean4ProjectPreconditions(
     installer: LeanInstaller,

--- a/vscode-lean4/src/utils/fsHelper.ts
+++ b/vscode-lean4/src/utils/fsHelper.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { PathLike, promises } from 'fs'
-import path = require('path')
+import path from 'path'
 
 /**
  * Returns true if `pathFile` exists and is a file

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
+import path from 'path'
 import { ExtUri, FileUri, getWorkspaceFolderUri } from './exturi'
 import { dirExists, fileExists } from './fsHelper'
-import path = require('path')
 
 // Detect lean4 root directory (works for both lean4 repo and nightly distribution)
 

--- a/vscode-lean4/src/utils/projectInfo.ts
+++ b/vscode-lean4/src/utils/projectInfo.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
-import path from 'path'
 import { ExtUri, FileUri, getWorkspaceFolderUri } from './exturi'
 import { dirExists, fileExists } from './fsHelper'
+import path from 'path'
 
 // Detect lean4 root directory (works for both lean4 repo and nightly distribution)
 

--- a/vscode-lean4/test/suite/utils/helpers.ts
+++ b/vscode-lean4/test/suite/utils/helpers.ts
@@ -1,14 +1,13 @@
 import assert from 'assert'
 import * as fs from 'fs'
 import * as os from 'os'
-import { basename, join } from 'path'
+import path, { basename, join } from 'path'
 import * as vscode from 'vscode'
 import { AlwaysEnabledFeatures, EnabledFeatures, Exports } from '../../../src/exports'
 import { InfoProvider } from '../../../src/infoview'
 import { LeanClient } from '../../../src/leanclient'
 import { LeanClientProvider } from '../../../src/utils/clientProvider'
 import { logger } from '../../../src/utils/logger'
-import path = require('path')
 
 export function sleep(ms: number) {
     return new Promise(resolve => setTimeout(resolve, ms))


### PR DESCRIPTION
This PR replaces
```
import path = require('path')
```
by
```
import path from 'path'
```
in a couple of files.