### PR TITLE
fix: [lean4web] dispose webviewPanel in InfoProvider.dispose

### DIFF
--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -496,6 +496,7 @@ export class InfoProvider implements Disposable {
         // active client is changing.
         this.clearNotificationHandlers()
         this.clearRpcSessions(null)
+        this.webviewPanel?.dispose()
         for (const s of this.clientSubscriptions) {
             s.dispose()
         }


### PR DESCRIPTION
The InfoProvider opens the webviewPanel, so it should also call the webviewPanel's dispose function when gettting disposed.