### PR TITLE
export index.production.min.js

### DIFF
--- a/lean4-infoview/package.json
+++ b/lean4-infoview/package.json
@@ -9,7 +9,7 @@
         "test": "tsc -p test/tsconfig.json"
     },
     "exports": {
-        ".": "./dist/index.development.js",
+        ".": "./dist/index.production.min.js",
         "./loader": "./dist/loader.production.min.js",
         "./package.json": "./package.json"
     },


### PR DESCRIPTION
checking https://www.npmjs.com/package/@leanprover/infoview?activeTab=code,
export index.production.min.js rather than export index.development.js for only index.production.min.js in the dist

