### PR TITLE
chore: use text variant of ✝︎

### DIFF
--- a/lean4-infoview-api/src/rpcApi.ts
+++ b/lean4-infoview-api/src/rpcApi.ts
@@ -40,7 +40,7 @@ export type MVarId = string
 
 export interface InteractiveHypothesisBundle {
     /** The pretty names of the variables in the bundle. Anonymous names are rendered
-     * as `"[anonymous]"` whereas inaccessible ones have a `✝` appended at the end.
+     * as `"[anonymous]"` whereas inaccessible ones have a `✝︎` appended at the end.
      * Use `InteractiveHypothesisBundle_nonAnonymousNames` to filter anonymouse ones out. */
     names: string[]
     /** Present since server version 1.1.2. */

--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -18,7 +18,7 @@ import { useEvent } from './util'
 
 /** Returns true if `h` is inaccessible according to Lean's default name rendering. */
 function isInaccessibleName(h: string): boolean {
-    return h.indexOf('✝') >= 0
+    return h.indexOf('✝︎') >= 0
 }
 
 function goalToString(g: InteractiveGoal): string {

--- a/lean4-unicode-input/src/abbreviations.json
+++ b/lean4-unicode-input/src/abbreviations.json
@@ -397,7 +397,7 @@
     "textmu": "µ",
     "textfractionsolidus": "⁄",
     "textbaht": "฿",
-    "textdied": "✝",
+    "textdied": "✝︎",
     "textdiscount": "⁒",
     "textcolonmonetary": "₡",
     "textcircledP": "℗",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14109,7 +14109,7 @@
         },
         "vscode-lean4": {
             "name": "lean4",
-            "version": "0.0.171",
+            "version": "0.0.176",
             "license": "Apache-2.0",
             "dependencies": {
                 "@leanprover/infoview": "~0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14109,7 +14109,7 @@
         },
         "vscode-lean4": {
             "name": "lean4",
-            "version": "0.0.176",
+            "version": "0.0.171",
             "license": "Apache-2.0",
             "dependencies": {
                 "@leanprover/infoview": "~0.7.0",

--- a/vscode-lean4/manual/manual.md
+++ b/vscode-lean4/manual/manual.md
@@ -255,7 +255,7 @@ Disabling the 'Lean 4 > Infoview: Auto Open Shows Goal' setting will only displa
 
 Both the proof goals in the tactic state and the expected type display a list of assumptions and locally available identifiers in a `<name> : <type>` format. At the end of the list of assumptions, a `⊢` symbol indicates the proof goal or the expected type.
 
-Inaccessible names, i.e. names that have been automatically generated and cannot be used in a Lean program, are marked with a tombstome symbol (`✝`) and greyed out.
+Inaccessible names, i.e. names that have been automatically generated and cannot be used in a Lean program, are marked with a tombstome symbol (`✝︎`) and greyed out.
 
 When a proof goal changes as the result of a tactic operation, the corresponding part of the proof state that changes is highlighted using red or green depending on whether this part of the proof state is about to be removed or was just inserted.
 


### PR DESCRIPTION
following leanprover/lean4#5174 use text-variant selector for ✝︎.