### PR TITLE
chore: change extension display name

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lean4",
-    "displayName": "lean4",
+    "displayName": "Lean 4",
     "description": "Lean 4 language support for VS Code",
     "version": "0.0.176",
     "publisher": "leanprover",
@@ -13,6 +13,7 @@
     "keywords": [
         "Lean",
         "Lean 4",
+        "lean4",
         "Theorem Provers",
         "InfoView"
     ],


### PR DESCRIPTION
This should hopefully make it easier to find the Lean 4 extension when searching for "Lean" (due to the way that the VS Code fuzzy search works). This PR also adds a "lean4" keyword so that the extension can still be found with the old identifier.