### PR TITLE
fix: widget persistence

### DIFF
--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -131,6 +131,13 @@ function GoalInfoDisplay(props: GoalInfoDisplayProps) {
 
     const [selectedLocs, setSelectedLocs] = React.useState<GoalsLocation[]>([])
 
+    // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+    const [prevPos, setPrevPos] = React.useState<DocumentPosition>(pos)
+    if (!DocumentPosition.isEqual(pos, prevPos)) {
+        setPrevPos(pos)
+        setSelectedLocs([])
+    }
+
     const locs: Locations = React.useMemo(
         () => ({
             isSelected: (l: GoalsLocation) => selectedLocs.some(v => GoalsLocation.isEqual(v, l)),
@@ -218,12 +225,7 @@ const InfoDisplayContent = React.memo((props: InfoDisplayContentProps) => {
                     </a>
                 </div>
             )}
-            <GoalInfoDisplay
-                pos={pos}
-                goals={goals}
-                termGoal={termGoal}
-                userWidgets={userWidgets}
-            />
+            <GoalInfoDisplay pos={pos} goals={goals} termGoal={termGoal} userWidgets={userWidgets} />
             <div style={{ display: hasMessages ? 'block' : 'none' }} key="messages">
                 <Details initiallyOpen key="messages">
                     <>Messages ({messages.length})</>

--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -219,7 +219,6 @@ const InfoDisplayContent = React.memo((props: InfoDisplayContentProps) => {
                 </div>
             )}
             <GoalInfoDisplay
-                key={DocumentPosition.toString(pos)}
                 pos={pos}
                 goals={goals}
                 termGoal={termGoal}


### PR DESCRIPTION
While developing some widgets today I noticed that their state is no longer persisted when the cursor moves. The resulting re-mounting/reinitialization can be bad for performance, is jittery (see recordings), and makes it impossible for widgets to animate between adjacent states.

Persistence was broken in #500 with the addition of a `key` that resets the entire `GoalInfoDisplay` component. This PR removes the key and reintroduces a state-clearing operation which is needed for correctness, but follows React docs so that there should hopefully not be any degradation in performance (I did not measure this, however). Note that setting state during rendering does technically result in a re-render, but it's a cheap one: the JSX that was returned in the first pass is never mounted or rendered.

Before: https://github.com/user-attachments/assets/4ff9c1c4-ee92-4dd0-a401-987c3259f4ca
After: https://github.com/user-attachments/assets/6e5624d0-f256-4013-8381-86421b254ccf

