### PR TITLE
feat: better progress ux

### DIFF
--- a/vscode-lean4/src/diagnostics/fullDiagnostics.ts
+++ b/vscode-lean4/src/diagnostics/fullDiagnostics.ts
@@ -116,6 +116,7 @@ export async function performFullDiagnosis(
     channel: OutputChannel,
     cwdUri: FileUri | undefined,
 ): Promise<FullDiagnostics> {
+    const showSetupInformationContext = 'Show Setup Information'
     const diagnose = new SetupDiagnoser(channel, cwdUri)
     return {
         systemInfo: diagnose.querySystemInformation(),
@@ -124,7 +125,7 @@ export async function performFullDiagnosis(
         isCurlAvailable: await diagnose.checkCurlAvailable(),
         isGitAvailable: await diagnose.checkGitAvailable(),
         elanVersionDiagnosis: await diagnose.elanVersion(),
-        leanVersionDiagnosis: await diagnose.leanVersion(),
+        leanVersionDiagnosis: await diagnose.leanVersion(showSetupInformationContext),
         projectSetupDiagnosis: await diagnose.projectSetup(),
         elanShowOutput: await diagnose.queryElanShow(),
     }

--- a/vscode-lean4/src/diagnostics/setupDiagnoser.ts
+++ b/vscode-lean4/src/diagnostics/setupDiagnoser.ts
@@ -140,13 +140,13 @@ export class SetupDiagnoser {
         return gitVersionResult.exitCode === ExecutionExitCode.Success
     }
 
-    async queryLakeVersion(): Promise<VersionQueryResult> {
-        const lakeVersionResult = await this.runLeanCommand('lake', ['--version'], 'Checking Lake version')
+    async queryLakeVersion(context: string): Promise<VersionQueryResult> {
+        const lakeVersionResult = await this.runLeanCommand('lake', ['--version'], context, 'Checking Lake version')
         return versionQueryResult(lakeVersionResult, /version (\d+\.\d+\.\d+(\w|-)*)/)
     }
 
-    async checkLakeAvailable(): Promise<boolean> {
-        const lakeVersionResult = await this.queryLakeVersion()
+    async checkLakeAvailable(context: string): Promise<boolean> {
+        const lakeVersionResult = await this.queryLakeVersion(context)
         return lakeVersionResult.kind === 'Success'
     }
 
@@ -191,8 +191,8 @@ export class SetupDiagnoser {
         return { kind: 'UpToDate', version: currentVSCodeVersion }
     }
 
-    async queryLeanVersion(): Promise<VersionQueryResult> {
-        const leanVersionResult = await this.runLeanCommand('lean', ['--version'], 'Checking Lean version')
+    async queryLeanVersion(context: string): Promise<VersionQueryResult> {
+        const leanVersionResult = await this.runLeanCommand('lean', ['--version'], context, 'Checking Lean version')
         return versionQueryResult(leanVersionResult, /version (\d+\.\d+\.\d+(\w|-)*)/)
     }
 
@@ -223,8 +223,8 @@ export class SetupDiagnoser {
         return { kind: 'ValidProjectSetup', projectFolder: this.cwdUri }
     }
 
-    async leanVersion(): Promise<LeanVersionDiagnosis> {
-        const leanVersionResult = await this.queryLeanVersion()
+    async leanVersion(context: string): Promise<LeanVersionDiagnosis> {
+        const leanVersionResult = await this.queryLeanVersion(context)
         return checkLeanVersion(leanVersionResult)
     }
 
@@ -232,19 +232,24 @@ export class SetupDiagnoser {
         return batchExecute(executablePath, args, this.cwdUri?.fsPath, { combined: this.channel })
     }
 
-    private async runWithProgress(executablePath: string, args: string[], title: string): Promise<ExecutionResult> {
-        return batchExecuteWithProgress(executablePath, args, title, {
+    private async runWithProgress(
+        executablePath: string,
+        args: string[],
+        context: string,
+        title: string,
+    ): Promise<ExecutionResult> {
+        return batchExecuteWithProgress(executablePath, args, context, title, {
             cwd: this.cwdUri?.fsPath,
             channel: this.channel,
         })
     }
 
-    private async runLeanCommand(executablePath: string, args: string[], title: string) {
+    private async runLeanCommand(executablePath: string, args: string[], context: string, title: string) {
         const leanArgs = [...args]
         if (this.toolchain !== undefined) {
             leanArgs.unshift(`+${this.toolchain}`)
         }
-        return await this.runWithProgress(executablePath, leanArgs, title)
+        return await this.runWithProgress(executablePath, leanArgs, context, title)
     }
 }
 

--- a/vscode-lean4/src/diagnostics/setupDiagnostics.ts
+++ b/vscode-lean4/src/diagnostics/setupDiagnostics.ts
@@ -72,9 +72,10 @@ export async function checkAreDependenciesInstalled(
 
 export async function checkIsLean4Installed(
     installer: LeanInstaller,
+    context: string,
     cwdUri: FileUri | undefined,
 ): Promise<PreconditionCheckResult> {
-    const leanVersionResult = await diagnose(installer.getOutputChannel(), cwdUri).queryLeanVersion()
+    const leanVersionResult = await diagnose(installer.getOutputChannel(), cwdUri).queryLeanVersion(context)
     switch (leanVersionResult.kind) {
         case 'Success':
             return 'Fulfilled'
@@ -155,6 +156,7 @@ export async function checkIsValidProjectFolder(
 
 export async function checkIsLeanVersionUpToDate(
     channel: OutputChannel,
+    context: string,
     folderUri: ExtUri,
     options: { toolchainOverride?: string | undefined; modal: boolean },
 ): Promise<PreconditionCheckResult> {
@@ -170,7 +172,7 @@ export async function checkIsLeanVersionUpToDate(
         channel,
         extUriToCwdUri(folderUri),
         options.toolchainOverride,
-    ).leanVersion()
+    ).leanVersion(context)
     switch (projectLeanVersionDiagnosis.kind) {
         case 'NotInstalled':
             return displaySetupErrorWithOutput("Error while checking Lean version: 'lean' command was not found.")
@@ -198,6 +200,7 @@ export async function checkIsLeanVersionUpToDate(
 
 export async function checkIsLakeInstalledCorrectly(
     channel: OutputChannel,
+    context: string,
     folderUri: ExtUri,
     options: { toolchainOverride?: string | undefined },
 ): Promise<PreconditionCheckResult> {
@@ -205,7 +208,7 @@ export async function checkIsLakeInstalledCorrectly(
         channel,
         extUriToCwdUri(folderUri),
         options.toolchainOverride,
-    ).queryLakeVersion()
+    ).queryLakeVersion(context)
     switch (lakeVersionResult.kind) {
         case 'CommandNotFound':
             return displaySetupErrorWithOutput("Error while checking Lake version: 'lake' command was not found.")

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -150,11 +150,12 @@ function activateAlwaysEnabledFeatures(context: ExtensionContext): AlwaysEnabled
 
 async function checkLean4FeaturePreconditions(
     installer: LeanInstaller,
+    context: string,
     cwdUri: FileUri | undefined,
 ): Promise<PreconditionCheckResult> {
     return await checkAll(
         () => checkAreDependenciesInstalled(installer.getOutputChannel(), cwdUri),
-        () => checkIsLean4Installed(installer, cwdUri),
+        () => checkIsLean4Installed(installer, context, cwdUri),
         () =>
             checkIsElanUpToDate(installer, cwdUri, {
                 elanMustBeInstalled: false,
@@ -169,7 +170,11 @@ async function activateLean4Features(
     installer: LeanInstaller,
     projectUri: FileUri | undefined,
 ): Promise<Lean4EnabledFeatures | undefined> {
-    const preconditionCheckResult = await checkLean4FeaturePreconditions(installer, projectUri)
+    const preconditionCheckResult = await checkLean4FeaturePreconditions(
+        installer,
+        'Activate Lean 4 Extension',
+        projectUri,
+    )
     if (preconditionCheckResult === 'Fatal') {
         return undefined
     }

--- a/vscode-lean4/src/projectoperations.ts
+++ b/vscode-lean4/src/projectoperations.ts
@@ -32,7 +32,7 @@ export class ProjectOperationProvider implements Disposable {
     }
 
     private async buildProject() {
-        await this.runOperation(async lakeRunner => {
+        await this.runOperation('Build Project', async lakeRunner => {
             const fetchResult: 'Success' | 'CacheNotAvailable' | 'Cancelled' = await this.tryFetchingCache(lakeRunner)
             if (fetchResult === 'Cancelled') {
                 return
@@ -62,7 +62,7 @@ export class ProjectOperationProvider implements Disposable {
             return
         }
 
-        await this.runOperation(async lakeRunner => {
+        await this.runOperation('Clean Project', async lakeRunner => {
             const cleanResult: ExecutionResult = await lakeRunner.clean()
             if (cleanResult.exitCode === ExecutionExitCode.Cancelled) {
                 return
@@ -101,7 +101,7 @@ export class ProjectOperationProvider implements Disposable {
     }
 
     private async fetchMathlibCache() {
-        await this.runOperation(async lakeRunner => {
+        await this.runOperation('Fetch Mathlib Build Cache', async lakeRunner => {
             const result: ExecutionResult = await lakeRunner.fetchMathlibCache()
             if (result.exitCode === ExecutionExitCode.Cancelled) {
                 return
@@ -120,7 +120,7 @@ export class ProjectOperationProvider implements Disposable {
     }
 
     private async fetchMathlibCacheForFocusedFile() {
-        await this.runOperation(async lakeRunner => {
+        await this.runOperation('Fetch Mathlib Build Cache For Focused File', async lakeRunner => {
             const projectUri = lakeRunner.cwdUri!
 
             if (!window.activeTextEditor || window.activeTextEditor.document.languageId !== 'lean4') {
@@ -246,7 +246,7 @@ export class ProjectOperationProvider implements Disposable {
             return
         }
 
-        await this.runOperation(async lakeRunner => {
+        await this.runOperation('Update Dependency', async lakeRunner => {
             const result: ExecutionResult = await lakeRunner.updateDependency(dependencyChoice.name)
             if (result.exitCode === ExecutionExitCode.Cancelled) {
                 return
@@ -386,7 +386,7 @@ export class ProjectOperationProvider implements Disposable {
         }
     }
 
-    private async runOperation(command: (lakeRunner: LakeRunner) => Promise<void>) {
+    private async runOperation(context: string, command: (lakeRunner: LakeRunner) => Promise<void>) {
         if (this.isRunningOperation) {
             displayError('Another project action is already being executed. Please wait for its completion.')
             return
@@ -412,7 +412,7 @@ export class ProjectOperationProvider implements Disposable {
             return
         }
 
-        const lakeRunner: LakeRunner = lake(this.channel, activeClient.folderUri)
+        const lakeRunner: LakeRunner = lake(this.channel, activeClient.folderUri, context)
 
         const result: 'Success' | 'IsRestarting' = await activeClient.withStoppedClient(() => command(lakeRunner))
         if (result === 'IsRestarting') {

--- a/vscode-lean4/src/utils/elan.ts
+++ b/vscode-lean4/src/utils/elan.ts
@@ -2,5 +2,5 @@ import { OutputChannel } from 'vscode'
 import { batchExecuteWithProgress, ExecutionResult } from './batch'
 
 export async function elanSelfUpdate(channel: OutputChannel): Promise<ExecutionResult> {
-    return await batchExecuteWithProgress('elan', ['self', 'update'], 'Updating Elan', { channel })
+    return await batchExecuteWithProgress('elan', ['self', 'update'], undefined, 'Updating Elan', { channel })
 }

--- a/vscode-lean4/src/utils/lake.ts
+++ b/vscode-lean4/src/utils/lake.ts
@@ -9,11 +9,18 @@ export const cacheNotFoundExitError = '=> Operation failed. Exit Code: 1.'
 export class LakeRunner {
     channel: OutputChannel
     cwdUri: FileUri | undefined
+    context: string | undefined
     toolchain: string | undefined
 
-    constructor(channel: OutputChannel, cwdUri: FileUri | undefined, toolchain?: string | undefined) {
+    constructor(
+        channel: OutputChannel,
+        cwdUri: FileUri | undefined,
+        context: string | undefined,
+        toolchain?: string | undefined,
+    ) {
         this.channel = channel
         this.cwdUri = cwdUri
+        this.context = context
         this.toolchain = toolchain
     }
 
@@ -88,7 +95,7 @@ export class LakeRunner {
         if (this.toolchain) {
             args.unshift(`+${this.toolchain}`)
         }
-        return await batchExecuteWithProgress('lake', args, waitingPrompt, {
+        return await batchExecuteWithProgress('lake', args, this.context, waitingPrompt, {
             cwd: this.cwdUri?.fsPath,
             channel: this.channel,
             translator,
@@ -97,6 +104,11 @@ export class LakeRunner {
     }
 }
 
-export function lake(channel: OutputChannel, cwdUri: FileUri | undefined, toolchain?: string | undefined): LakeRunner {
-    return new LakeRunner(channel, cwdUri, toolchain)
+export function lake(
+    channel: OutputChannel,
+    cwdUri: FileUri | undefined,
+    context: string | undefined,
+    toolchain?: string | undefined,
+): LakeRunner {
+    return new LakeRunner(channel, cwdUri, context, toolchain)
 }


### PR DESCRIPTION
This PR improves two things about the way we report progress:
- Instead of attempting to badly approximate an accurate progress bar that gets stuck whenever the output of a command doesn't change, we now use VS Code's "infinite" progress bars everywhere that clearly show that an operation is actively running in the background.
- Every progress bar is prefixed with a context to make it clear which operation caused the operation. For example, when creating a new mathlib project, all external commands executed while creating the project are prefixed with "[Create Mathlib Project]".

Closes #457. IMO, our dialog UX still isn't perfect, but there doesn't seem to be a good way to improve these things short of implementing our own webviews for every command. 