### PR TITLE
chore: replace webview-ui-toolkit

### DIFF
--- a/lean4-infoview/package.json
+++ b/lean4-infoview/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@leanprover/infoview",
-    "version": "0.7.7",
+    "version": "0.7.8",
     "description": "An interactive display for the Lean 4 theorem prover.",
     "scripts": {
         "watch": "rollup --config --environment NODE_ENV:development --watch",
@@ -51,7 +51,7 @@
     "dependencies": {
         "@leanprover/infoview-api": "~0.4.0",
         "@vscode/codicons": "^0.0.32",
-        "@vscode/webview-ui-toolkit": "^1.4.0",
+        "@vscode-elements/react-elements": "^0.5.0",
         "es-module-shims": "^1.7.3",
         "react-fast-compare": "^3.2.2",
         "tachyons": "^4.12.0",

--- a/lean4-infoview/src/infoview/main.tsx
+++ b/lean4-infoview/src/infoview/main.tsx
@@ -1,4 +1,4 @@
-import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
+import { VscodeButton } from '@vscode-elements/react-elements'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import type { DidCloseTextDocumentParams, DocumentUri, Location } from 'vscode-languageserver-protocol'
@@ -85,13 +85,13 @@ function Main() {
                     </div>
                 )}
                 {curUri && (
-                    <VSCodeButton
+                    <VscodeButton
                         className="restart-file-button"
                         onClick={_ => ec.api.restartFile(curUri)}
                         title="Restarts this file, rebuilding all of its outdated dependencies."
                     >
                         Restart File
-                    </VSCodeButton>
+                    </VscodeButton>
                 )}
             </div>
         )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1159,12 +1159,14 @@
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.13.0.tgz",
             "integrity": "sha512-iFhzKbbD0cFRo9cEzLS3Tdo9BYuatdxmCEKCpZs1Cro/93zNMpZ/Y9/Z7SknmW6fhDZbpBvtO8lLh9TFEcNVAQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@microsoft/fast-foundation": {
             "version": "2.49.6",
             "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.6.tgz",
             "integrity": "sha512-DZVr+J/NIoskFC1Y6xnAowrMkdbf2d5o7UyWK6gW5AiQ6S386Ql8dw4KcC4kHaeE1yL2CKvweE79cj6ZhJhTvA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@microsoft/fast-element": "^1.13.0",
@@ -1177,18 +1179,21 @@
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
             "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@microsoft/fast-foundation/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
             "license": "0BSD"
         },
         "node_modules/@microsoft/fast-react-wrapper": {
             "version": "0.3.24",
             "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.3.24.tgz",
             "integrity": "sha512-sRnSBIKaO42p4mYoYR60spWVkg89wFxFAgQETIMazAm2TxtlsnsGszJnTwVhXq2Uz+XNiD8eKBkfzK5c/i6/Kw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@microsoft/fast-element": "^1.13.0",
@@ -1202,6 +1207,7 @@
             "version": "5.4.1",
             "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
             "integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "exenv-es6": "^1.1.1"
@@ -3713,6 +3719,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.4.0.tgz",
             "integrity": "sha512-modXVHQkZLsxgmd5yoP3ptRC/G8NBDD+ob+ngPiWNQdlrH6H1xR/qgOBD85bfU3BhOB5sZzFWBwwhp9/SfoHww==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@microsoft/fast-element": "^1.12.0",
@@ -6668,6 +6675,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
             "integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/expand-template": {
@@ -13478,6 +13486,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -15693,6 +15702,7 @@
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
             "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
+            "dev": true,
             "license": "0BSD"
         },
         "node_modules/tuf-js": {
@@ -17014,7 +17024,6 @@
                 "@leanprover/unicode-input-component": "~0.1.0",
                 "@vscode-elements/elements": "^1.7.1",
                 "@vscode/codicons": "^0.0.36",
-                "@vscode/webview-ui-toolkit": "^1.4.0",
                 "markdown-it": "^14.1.0",
                 "markdown-it-anchor": "^9.0.1",
                 "semver": "^7.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,12 +28,12 @@
         },
         "lean4-infoview": {
             "name": "@leanprover/infoview",
-            "version": "0.7.6",
+            "version": "0.7.8",
             "license": "Apache-2.0",
             "dependencies": {
                 "@leanprover/infoview-api": "~0.4.0",
+                "@vscode-elements/react-elements": "^0.5.0",
                 "@vscode/codicons": "^0.0.32",
-                "@vscode/webview-ui-toolkit": "^1.4.0",
                 "es-module-shims": "^1.7.3",
                 "react-fast-compare": "^3.2.2",
                 "tachyons": "^4.12.0",
@@ -1132,6 +1132,27 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@lit-labs/ssr-dom-shim": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
+            "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ=="
+        },
+        "node_modules/@lit/react": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.6.tgz",
+            "integrity": "sha512-QIss8MPh6qUoFJmuaF4dSHts3qCsA36S3HcOLiNPShxhgYPr4XJRnCBKPipk85sR9xr6TQrOcDMfexwbNdJHYA==",
+            "peerDependencies": {
+                "@types/react": "17 || 18"
+            }
+        },
+        "node_modules/@lit/reactive-element": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+            "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+            "dependencies": {
+                "@lit-labs/ssr-dom-shim": "^1.2.0"
             }
         },
         "node_modules/@microsoft/fast-element": {
@@ -2760,14 +2781,12 @@
             "version": "15.7.13",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
             "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/react": {
             "version": "18.3.11",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
             "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/prop-types": "*",
@@ -2807,6 +2826,11 @@
             "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
         },
         "node_modules/@types/unist": {
             "version": "3.0.3",
@@ -3028,6 +3052,35 @@
             "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/@vscode-elements/elements": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@vscode-elements/elements/-/elements-1.7.1.tgz",
+            "integrity": "sha512-3iKAO+B5u/UKXVPOvnlpzFTCCh0lrESgonerNf6EOz2XgnBTBLC01qCHXTXTnFf/foSrcKEnLY7REZOnwZSe3A==",
+            "dependencies": {
+                "lit": "^3.2.0"
+            }
+        },
+        "node_modules/@vscode-elements/react-elements": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@vscode-elements/react-elements/-/react-elements-0.5.0.tgz",
+            "integrity": "sha512-+H1aKuD7uID8Dc/YiQCQUFtGcWxCX+rWH9EIcQTUB1Gj8SfQrwN4Cd46BqQbwJAwtYJkOMl9i+Urfc5mkw8HWw==",
+            "dependencies": {
+                "@lit/react": "^1.0.6",
+                "@vscode-elements/elements": "~1.7.0",
+                "react": "~18.0.0"
+            }
+        },
+        "node_modules/@vscode-elements/react-elements/node_modules/react": {
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
+            "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/@vscode/codicons": {
             "version": "0.0.32",
@@ -5566,7 +5619,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/current-release": {
@@ -9618,6 +9670,34 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/lit": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+            "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+            "dependencies": {
+                "@lit/reactive-element": "^2.0.4",
+                "lit-element": "^4.1.0",
+                "lit-html": "^3.2.0"
+            }
+        },
+        "node_modules/lit-element": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+            "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+            "dependencies": {
+                "@lit-labs/ssr-dom-shim": "^1.2.0",
+                "@lit/reactive-element": "^2.0.4",
+                "lit-html": "^3.2.0"
+            }
+        },
+        "node_modules/lit-html": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+            "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+            "dependencies": {
+                "@types/trusted-types": "^2.0.2"
             }
         },
         "node_modules/load-json-file": {
@@ -16925,7 +17005,7 @@
         },
         "vscode-lean4": {
             "name": "lean4",
-            "version": "0.0.179",
+            "version": "0.0.184",
             "license": "Apache-2.0",
             "dependencies": {
                 "@leanprover/infoview": "~0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17012,6 +17012,7 @@
                 "@leanprover/infoview-api": "~0.4.0",
                 "@leanprover/unicode-input": "~0.1.0",
                 "@leanprover/unicode-input-component": "~0.1.0",
+                "@vscode-elements/elements": "^1.7.1",
                 "@vscode/codicons": "^0.0.36",
                 "@vscode/webview-ui-toolkit": "^1.4.0",
                 "markdown-it": "^14.1.0",

--- a/vscode-lean4/.vscodeignore
+++ b/vscode-lean4/.vscodeignore
@@ -14,6 +14,7 @@
 !dist/lean4-infoview/codicon.ttf
 !dist/loogleview/static
 !dist/moogleview/static
+!dist/abbreviationview/static
 !media
 !manual
 !images

--- a/vscode-lean4/abbreviationview/index.ts
+++ b/vscode-lean4/abbreviationview/index.ts
@@ -1,17 +1,16 @@
-import {
-    DataGrid,
-    provideVSCodeDesignSystem,
-    vsCodeDataGrid,
-    vsCodeDataGridCell,
-    vsCodeDataGridRow,
-} from '@vscode/webview-ui-toolkit'
-
-provideVSCodeDesignSystem().register(vsCodeDataGrid(), vsCodeDataGridRow(), vsCodeDataGridCell())
-
-const abbreviations: { Abbreviation: string; 'Unicode symbol': string } = JSON.parse(
+const abbreviations: { Abbreviation: string; 'Unicode symbol': string }[] = JSON.parse(
     document.querySelector('script[data-id="abbreviationview-script"]')!.getAttribute('abbreviations')!,
 )
 
-const grid = document.getElementById('abbreviation-grid')! as DataGrid
+const tableBody = document.getElementById('abbreviation-table')!
 
-grid.rowsData = abbreviations as any
+for (const { Abbreviation: abbr, 'Unicode symbol': symb } of abbreviations) {
+    const row = document.createElement('vscode-table-row')
+    const abbrCell = document.createElement('vscode-table-cell')
+    abbrCell.innerText = abbr
+    row.appendChild(abbrCell)
+    const symbCell = document.createElement('vscode-table-cell')
+    symbCell.innerText = symb
+    row.appendChild(symbCell)
+    tableBody.appendChild(row)
+}

--- a/vscode-lean4/loogleview/index.ts
+++ b/vscode-lean4/loogleview/index.ts
@@ -1,8 +1,5 @@
 import { AbbreviationConfig } from '@leanprover/unicode-input'
 import { InputAbbreviationRewriter } from '@leanprover/unicode-input-component'
-import { provideVSCodeDesignSystem, vsCodeButton, vsCodeLink, vsCodeTextField } from '@vscode/webview-ui-toolkit'
-
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeTextField(), vsCodeLink())
 
 const vscodeApi = acquireVsCodeApi()
 
@@ -135,7 +132,7 @@ class LoogleView {
         })
 
         for (const querySuggestionElement of view.staticSuggestions) {
-            if (!(querySuggestionElement instanceof HTMLElement) || querySuggestionElement.tagName !== 'VSCODE-LINK') {
+            if (!(querySuggestionElement instanceof HTMLElement) || querySuggestionElement.tagName !== 'A') {
                 continue
             }
             const querySuggestion = querySuggestionElement.innerText
@@ -203,16 +200,19 @@ class LoogleView {
     }
 
     private createQuerySuggestionNode(querySuggestion: string): HTMLElement {
-        const link = document.createElement('vscode-link')
+        //const paragraph = document.createElement('p')
+        const link = document.createElement('a')
+        link.href = 'javascript:void(0)'
         link.innerText = querySuggestion
         link.addEventListener('click', () => this.runSuggestion(querySuggestion))
+        //paragraph.appendChild(link)
         return link
     }
 
     private createHitNameNode(name: string, module: string): HTMLElement {
         // This is not correct (consider e.g. escaped dots in french quotes) but it should be good enough for now.
         const docUrl = `https://leanprover-community.github.io/mathlib4_docs/${encodeURIComponent(module.replace(new RegExp(/\./, 'g'), '/'))}.html#${encodeURIComponent(name)}`
-        const link = document.createElement('vscode-link')
+        const link = document.createElement('a')
         link.innerText = name
         link.setAttribute('href', `command:simpleBrowser.show?${encodeURIComponent(JSON.stringify([docUrl]))}`)
         return link
@@ -232,12 +232,12 @@ class LoogleView {
         this.resultHeader.hidden = hits.length === 0
         const resultNodes = hits.map(hit => {
             const entry = document.createElement('li')
-            const identifierNode = document.createElement('span')
-            identifierNode.appendChild(this.createHitNameNode(hit.name, hit.module))
-            identifierNode.appendChild(document.createTextNode(` @ ${hit.module}`))
-            entry.appendChild(identifierNode)
-            entry.appendChild(document.createElement('br'))
-            entry.appendChild(document.createTextNode(hit.type))
+            const paragraph = document.createElement('p')
+            paragraph.appendChild(this.createHitNameNode(hit.name, hit.module))
+            paragraph.appendChild(document.createTextNode(` @ ${hit.module}`))
+            paragraph.appendChild(document.createElement('br'))
+            paragraph.appendChild(document.createTextNode(hit.type))
+            entry.appendChild(paragraph)
             return entry
         })
         this.results.replaceChildren(...resultNodes)

--- a/vscode-lean4/loogleview/index.ts
+++ b/vscode-lean4/loogleview/index.ts
@@ -200,12 +200,10 @@ class LoogleView {
     }
 
     private createQuerySuggestionNode(querySuggestion: string): HTMLElement {
-        //const paragraph = document.createElement('p')
         const link = document.createElement('a')
         link.href = 'javascript:void(0)'
         link.innerText = querySuggestion
         link.addEventListener('click', () => this.runSuggestion(querySuggestion))
-        //paragraph.appendChild(link)
         return link
     }
 

--- a/vscode-lean4/loogleview/static/index.css
+++ b/vscode-lean4/loogleview/static/index.css
@@ -24,10 +24,10 @@
 
 .query-label {
     display: block;
-    color: var(--foreground);
+    color: var(--vscode-foreground);
     cursor: pointer;
-    font-size: var(--type-ramp-base-font-size);
-    line-height: var(--type-ramp-base-line-height);
+    font-size: var(--vscode-font-size);
+    line-height: normal;
     margin-bottom: 2px;
 }
 
@@ -46,19 +46,19 @@
     position: relative;
     display: flex;
     flex-direction: row;
-    color: var(--input-foreground);
-    background: var(--input-background);
-    border-radius: calc(var(--corner-radius-round) * 1px);
-    border: calc(var(--border-width) * 1px) solid var(--dropdown-border);
-    height: calc(var(--input-height) * 1px);
-    min-width: var(--input-min-width);
-    font-family: var(--font-family);
+    color: var(--vscode-input-foreground);
+    background: var(--vscode-input-background);
+    border-radius: 2px;
+    border: 1px solid var(--vscode-dropdown-border);
+    height: 26px;
+    min-width: 100px;
+    font-family: var(--vscode-font-family);
     outline: none;
     user-select: none;
 }
 
 .input-container:focus-within:not([disabled]) {
-    border-color: var(--focus-border);
+    border-color: var(--vscode-focusBorder);
 }
 
 [contenteditable='true'].single-line {
@@ -67,13 +67,13 @@
     overflow: hidden;
     outline: none;
 
-    height: calc(100% - (var(--design-unit) * 1px));
+    height: calc(100% - 4px);
     margin-top: auto;
     margin-bottom: auto;
     border: none;
-    padding: 0 calc(var(--design-unit) * 2px + 1px);
-    font-size: var(--type-ramp-base-font-size);
-    line-height: var(--type-ramp-base-line-height);
+    padding: 0 9px;
+    font-size: var(--vscode-font-size);
+    line-height: normal;
 }
 [contenteditable='true'].single-line br {
     display: none;
@@ -91,4 +91,8 @@ vscode-button {
     display: inline-flex;
     margin-left: 0.5em;
     margin-right: 0.5em;
+}
+
+#suggestions a {
+    text-decoration: var(--text-link-decoration);
 }

--- a/vscode-lean4/loogleview/static/index.css
+++ b/vscode-lean4/loogleview/static/index.css
@@ -44,7 +44,6 @@
 
     box-sizing: border-box;
     position: relative;
-    display: flex;
     flex-direction: row;
     color: var(--vscode-input-foreground);
     background: var(--vscode-input-background);

--- a/vscode-lean4/loogleview/static/index.html
+++ b/vscode-lean4/loogleview/static/index.html
@@ -2,9 +2,9 @@
 <div class="query-container">
     <div class="input-container">
         <div id="query-text-field" class="single-line" contenteditable="true"></div>
-        <vscode-button id="previous-query-button" appearance="icon" aria-label="Load Previous Query"><span class="codicon codicon-arrow-left"></span></vscode-button>
-        <vscode-button id="next-query-button" appearance="icon" aria-label="Load Next Query"><span class="codicon codicon-arrow-right"></span></vscode-button>
-        <vscode-button id="find-button" appearance="icon" aria-label="Send Loogle Query"><span class="codicon codicon-search"></span></vscode-button>
+        <vscode-icon id="previous-query-button" name="arrow-left" label="Load Previous Query" action-icon></vscode-icon>
+        <vscode-icon id="next-query-button" name="arrow-right" label="Load Next Query" action-icon></vscode-icon>
+        <vscode-icon id="find-button" name="search" label="Send Loogle Query" action-icon></vscode-icon>
     </div>
     <div id="spinner" class="loader hidden"></div>
 </div>
@@ -28,41 +28,41 @@
     <li>
         <p>
             By constant:<br>
-            <vscode-link class="query-suggestion">Real.sin</vscode-link> finds all lemmas whose statement somehow mentions the sinefunction.
+            <a href="javascript:void(0)" class="query-suggestion">Real.sin</a> finds all lemmas whose statement somehow mentions the sinefunction.
         </p>
     </li>
     <li>
         <p>
             By lemma name substring:<br>
-            <vscode-link class="query-suggestion">"differ"</vscode-link> finds all lemmas that have <code>"differ"</code> somewhere in their lemma <em>name</em>.
+            <a href="javascript:void(0)" class="query-suggestion">"differ"</a> finds all lemmas that have <code>"differ"</code> somewhere in their lemma <em>name</em>.
         </p>
     </li>
     <li>
         <p>
             By subexpression:<br>
-            <vscode-link class="query-suggestion">_ * (_ ^ _)</vscode-link> finds all lemmas whose statements somewhere include a product where the second argument is raised to some power.
+            <a href="javascript:void(0)" class="query-suggestion">_ * (_ ^ _)</a> finds all lemmas whose statements somewhere include a product where the second argument is raised to some power.
         </p>
         <p>
-            The pattern can also be non-linear, as in <vscode-link class="query-suggestion">Real.sqrt ?a * Real.sqrt ?a</vscode-link>
+            The pattern can also be non-linear, as in <a href="javascript:void(0)" class="query-suggestion">Real.sqrt ?a * Real.sqrt ?a</a>
         </p>
         <p>
             If the pattern has parameters, they are matched in any order. Both of these will find <code>List.map</code>:<br>
-            <vscode-link class="query-suggestion">(?a -&gt; ?b) -&gt; List ?a -&gt; List ?b</vscode-link><br>
-            <vscode-link class="query-suggestion">List ?a -&gt; (?a -&gt; ?b) -&gt; List ?b</vscode-link>
+            <a href="javascript:void(0)" class="query-suggestion">(?a -&gt; ?b) -&gt; List ?a -&gt; List ?b</a><br>
+            <a href="javascript:void(0)" class="query-suggestion">List ?a -&gt; (?a -&gt; ?b) -&gt; List ?b</a>
         </p>
     </li>
     <li>
         <p>
             By main conclusion:<br>
-            <vscode-link class="query-suggestion">|- tsum _ = _ * tsum _</vscode-link> finds all lemmas where the conclusion (the subexpression to the right of all <code>→</code> and <code>∀</code>) has the given shape.
+            <a href="javascript:void(0)" class="query-suggestion">|- tsum _ = _ * tsum _</a> finds all lemmas where the conclusion (the subexpression to the right of all <code>→</code> and <code>∀</code>) has the given shape.
         </p>
         <p>
-            As before, if the pattern has parameters, they are matched against the hypotheses of the lemma in any order; for example, <vscode-link class="query-suggestion">|- _ &lt; _ → tsum _ &lt; tsum _</vscode-link> will find <code>tsum_lt_tsum</code> even though the hypothesis <code>f i &lt; g i</code> is not the last.
+            As before, if the pattern has parameters, they are matched against the hypotheses of the lemma in any order; for example, <a href="javascript:void(0)" class="query-suggestion">|- _ &lt; _ → tsum _ &lt; tsum _</a> will find <code>tsum_lt_tsum</code> even though the hypothesis <code>f i &lt; g i</code> is not the last.
         </p>
     </li>
 </ol>
 <p>
-    If you pass more than one such search filter, separated by commas Loogle will return lemmas which match <em>all</em> of them. The search <vscode-link class="query-suggestion">Real.sin, "two", tsum, _ * _, _ ^ _, |- _ &lt; _ → _</vscode-link>
+    If you pass more than one such search filter, separated by commas Loogle will return lemmas which match <em>all</em> of them. The search <a href="javascript:void(0)" class="query-suggestion">Real.sin, "two", tsum, _ * _, _ ^ _, |- _ &lt; _ → _</a>
     would find all lemmas which mention the constants <code>Real.sin</code>
     and <code>tsum</code>, have <code>"two"</code> as a substring of the
     lemma name, include a product and a power somewhere in the type,

--- a/vscode-lean4/moogleview/index.ts
+++ b/vscode-lean4/moogleview/index.ts
@@ -1,8 +1,5 @@
 import { AbbreviationConfig } from '@leanprover/unicode-input'
 import { InputAbbreviationRewriter } from '@leanprover/unicode-input-component'
-import { provideVSCodeDesignSystem, vsCodeButton, vsCodeLink, vsCodeTextField } from '@vscode/webview-ui-toolkit'
-
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeTextField(), vsCodeLink())
 
 const vscodeApi = acquireVsCodeApi()
 
@@ -233,7 +230,7 @@ class MoogleView {
             <div class="result-content">
                 ${declarationDocstring ? `<div class="display-html-container">${declarationDocstring}</div>` : ''}
                 <div class="display-html-container">${modifiedHtmlContent}</div>
-                <vscode-link href="${hit.sourceCodeUrl}">View source code</vscode-link>
+                <a href="${hit.sourceCodeUrl}">View source code</a>
             </div>
             `
 

--- a/vscode-lean4/moogleview/static/index.css
+++ b/vscode-lean4/moogleview/static/index.css
@@ -24,10 +24,10 @@
 
 .query-label {
     display: block;
-    color: var(--foreground);
+    color: var(--vscode-foreground);
     cursor: pointer;
-    font-size: var(--type-ramp-base-font-size);
-    line-height: var(--type-ramp-base-line-height);
+    font-size: var(--vscode-font-size);
+    line-height: normal;
     margin-bottom: 2px;
 }
 
@@ -45,19 +45,19 @@
     box-sizing: border-box;
     position: relative;
     flex-direction: row;
-    color: var(--input-foreground);
-    background: var(--input-background);
-    border-radius: calc(var(--corner-radius-round) * 1px);
-    border: calc(var(--border-width) * 1px) solid var(--dropdown-border);
-    height: calc(var(--input-height) * 1px);
-    min-width: var(--input-min-width);
-    font-family: var(--font-family);
+    color: var(--vscode-input-foreground);
+    background: var(--vscode-input-background);
+    border-radius: 2px;
+    border: 1px solid var(--vscode-dropdown-border);
+    height: 26px;
+    min-width: 100px;
+    font-family: var(--vscode-font-family);
     outline: none;
     user-select: none;
 }
 
 .input-container:focus-within:not([disabled]) {
-    border-color: var(--focus-border);
+    border-color: var(--vscode-focusBorder);
 }
 
 [contenteditable='true'].single-line {
@@ -66,13 +66,13 @@
     overflow: hidden;
     outline: none;
 
-    height: calc(100% - (var(--design-unit) * 1px));
+    height: calc(100% - 4px);
     margin-top: auto;
     margin-bottom: auto;
     border: none;
-    padding: 0 calc(var(--design-unit) * 2px + 1px);
-    font-size: var(--type-ramp-base-font-size);
-    line-height: var(--type-ramp-base-line-height);
+    padding: 0 9px;
+    font-size: var(--vscode-font-size);
+    line-height: normal;
 }
 [contenteditable='true'].single-line br {
     display: none;

--- a/vscode-lean4/moogleview/static/index.html
+++ b/vscode-lean4/moogleview/static/index.html
@@ -2,9 +2,9 @@
 <div class="query-container">
     <div class="input-container">
         <div id="query-text-field" class="single-line" contenteditable="true"></div>
-        <vscode-button id="previous-query-button" appearance="icon" aria-label="Load Previous Query"><span class="codicon codicon-arrow-left"></span></vscode-button>
-        <vscode-button id="next-query-button" appearance="icon" aria-label="Load Next Query"><span class="codicon codicon-arrow-right"></span></vscode-button>
-        <vscode-button id="find-button" appearance="icon" aria-label="Send Moogle Query"><span class="codicon codicon-search"></span></vscode-button>
+        <vscode-icon id="previous-query-button" name="arrow-left" label="Load Previous Query" action-icon></vscode-icon>
+        <vscode-icon id="next-query-button" name="arrow-right" label="Load Next Query" action-icon></vscode-icon>
+        <vscode-icon id="find-button" name="search" label="Send Loogle Query" action-icon></vscode-icon>
     </div>
     <div id="spinner" class="loader hidden"></div>
 </div>

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -940,6 +940,7 @@
         "@leanprover/unicode-input-component": "~0.1.0",
         "@vscode/codicons": "^0.0.36",
         "@vscode/webview-ui-toolkit": "^1.4.0",
+        "@vscode-elements/elements": "^1.7.1",
         "markdown-it": "^14.1.0",
         "markdown-it-anchor": "^9.0.1",
         "semver": "^7.6.0",

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -939,7 +939,6 @@
         "@leanprover/unicode-input": "~0.1.0",
         "@leanprover/unicode-input-component": "~0.1.0",
         "@vscode/codicons": "^0.0.36",
-        "@vscode/webview-ui-toolkit": "^1.4.0",
         "@vscode-elements/elements": "^1.7.1",
         "markdown-it": "^14.1.0",
         "markdown-it-anchor": "^9.0.1",

--- a/vscode-lean4/src/abbreviationview.ts
+++ b/vscode-lean4/src/abbreviationview.ts
@@ -52,10 +52,21 @@ export class AbbreviationView implements Disposable {
                 <meta charset="UTF-8" />
                 <meta http-equiv="Content-type" content="text/html;charset=utf-8">
                 <title>AbbreviationView</title>
+                <script
+                    src="${this.webviewUri(this.webviewPanel, 'dist', 'abbreviationview', 'static', 'elements', 'bundled.js')}"
+                    type="module"
+                ></script>
                 <script defer data-id="abbreviationview-script" src="${this.webviewUri(this.webviewPanel, 'dist/abbreviationview.js')}" abbreviations="${escapeHtml(JSON.stringify(abbreviations))}"></script>
             </head>
             <body>
-                <vscode-data-grid id="abbreviation-grid" aria-label="Abbreviations" grid-template-columns="20em 1fr"></vscode-data-grid>
+                <vscode-table aria-label="Abbreviations" responsive resizable bordered zebra>
+                    <vscode-table-header slot="header">
+                        <vscode-table-header-cell>Abbreviation</vscode-table-header-cell>
+                        <vscode-table-header-cell>Unicode symbol</vscode-table-header-cell>
+                    </vscode-table-header>
+                    <vscode-table-body id="abbreviation-table" slot="body">
+                    </vscode-table-body>
+                </vscode-table>
             </body>
             </html>`
         this.webviewPanel.reveal()

--- a/vscode-lean4/src/loogleview.ts
+++ b/vscode-lean4/src/loogleview.ts
@@ -63,11 +63,15 @@ export class LoogleView implements Disposable {
                         style-src ${webviewPanel.webview.cspSource} 'unsafe-inline'"
                 />
                 <title>LoogleView</title>
+                <script
+                    src="${this.webviewUri(webviewPanel, 'dist', 'loogleview', 'static', 'elements', 'bundled.js')}"
+                    type="module"
+                ></script>
                 <script defer type="module" nonce="inline">
                     document.getElementById("loogleviewRoot").innerHTML = await (await fetch("${this.webviewUri(webviewPanel, 'dist', 'loogleview', 'static', 'index.html')}")).text()
                 </script>
                 <link rel="stylesheet" href="${this.webviewUri(webviewPanel, 'dist', 'loogleview', 'static', 'index.css')}">
-                <link rel="stylesheet" href="${this.webviewUri(webviewPanel, 'dist', 'loogleview', 'static', 'codicons', 'codicon.css')}">
+                <link rel="stylesheet" id="vscode-codicon-stylesheet" href="${this.webviewUri(webviewPanel, 'dist', 'loogleview', 'static', 'codicons', 'codicon.css')}">
             </head>
             <body>
                 <div id="loogleviewRoot" style="min-width: 50em"></div>

--- a/vscode-lean4/src/moogleview.ts
+++ b/vscode-lean4/src/moogleview.ts
@@ -61,11 +61,15 @@ export class MoogleView implements Disposable {
                     "
                 />
                 <title>MoogleView</title>
+                <script
+                    src="${this.webviewUri(webviewPanel, 'dist', 'moogleview', 'static', 'elements', 'bundled.js')}"
+                    type="module"
+                ></script>
                 <script defer type="module" nonce="inline">
                     document.getElementById("moogleviewRoot").innerHTML = await (await fetch("${this.webviewUri(webviewPanel, 'dist', 'moogleview', 'static', 'index.html')}")).text()
                 </script>
                 <link rel="stylesheet" href="${this.webviewUri(webviewPanel, 'dist', 'moogleview', 'static', 'index.css')}">
-                <link rel="stylesheet" href="${this.webviewUri(webviewPanel, 'dist', 'moogleview', 'static', 'codicons', 'codicon.css')}">
+                <link rel="stylesheet" id="vscode-codicon-stylesheet" href="${this.webviewUri(webviewPanel, 'dist', 'moogleview', 'static', 'codicons', 'codicon.css')}">
             </head>
             <body>
                 <div id="moogleviewRoot" style="min-width: 50em"></div>

--- a/vscode-lean4/webpack.config.js
+++ b/vscode-lean4/webpack.config.js
@@ -94,6 +94,10 @@ const getLoogleViewConfig = env => ({
                     from: '../node_modules/@vscode/codicons/dist',
                     to: path.resolve(__dirname, 'dist', 'loogleview', 'static', 'codicons'),
                 },
+                {
+                    from: '../node_modules/@vscode-elements/elements/dist',
+                    to: path.resolve(__dirname, 'dist', 'loogleview', 'static', 'elements'),
+                },
             ],
         }),
     ],

--- a/vscode-lean4/webpack.config.js
+++ b/vscode-lean4/webpack.config.js
@@ -177,6 +177,16 @@ const getAbbreviationViewConfig = env => ({
         filename: 'abbreviationview.js',
         path: path.resolve(__dirname, 'dist'),
     },
+    plugins: [
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: '../node_modules/@vscode-elements/elements/dist',
+                    to: path.resolve(__dirname, 'dist', 'abbreviationview', 'static', 'elements'),
+                },
+            ],
+        }),
+    ],
 })
 
 /** @type {(env: Env) => import('webpack').Configuration} */

--- a/vscode-lean4/webpack.config.js
+++ b/vscode-lean4/webpack.config.js
@@ -141,6 +141,10 @@ const getMoogleViewConfig = env => ({
                     from: '../node_modules/@vscode/codicons/dist',
                     to: path.resolve(__dirname, 'dist', 'moogleview', 'static', 'codicons'),
                 },
+                {
+                    from: '../node_modules/@vscode-elements/elements/dist',
+                    to: path.resolve(__dirname, 'dist', 'moogleview', 'static', 'elements'),
+                },
             ],
         }),
     ],


### PR DESCRIPTION
[`@vscode/webview-ui-toolkit` is being deprecated in January](https://github.com/microsoft/vscode-webview-ui-toolkit/issues/561). This PR replaces the UI components from `@vscode/webview-ui-toolkit` with components from `@vscode-elements/elements`.