### PR TITLE
feat: sticky notifications for extension startup errors

### DIFF
--- a/vscode-lean4/src/diagnostics/fullDiagnostics.ts
+++ b/vscode-lean4/src/diagnostics/fullDiagnostics.ts
@@ -2,7 +2,7 @@ import { SemVer } from 'semver'
 import { Disposable, OutputChannel, TextDocument, commands, env, window, workspace } from 'vscode'
 import { ExecutionExitCode, ExecutionResult } from '../utils/batch'
 import { ExtUri, FileUri, extUriEquals, toExtUri } from '../utils/exturi'
-import { displayError, displayInformationWithInput } from '../utils/notifs'
+import { displayNotification, displayNotificationWithInput } from '../utils/notifs'
 import { findLeanProjectRoot } from '../utils/projectInfo'
 import {
     ElanVersionDiagnosis,
@@ -187,7 +187,8 @@ export class FullDiagnosticsProvider implements Disposable {
                 ? await findLeanProjectRoot(this.lastActiveLeanDocumentUri)
                 : undefined
         if (projectUri === 'FileNotFound') {
-            displayError(
+            displayNotification(
+                'Error',
                 `Cannot display setup information for file that does not exist in the file system: ${this.lastActiveLeanDocumentUri}. Please choose a different file to display the setup information for.`,
             )
             return
@@ -195,7 +196,7 @@ export class FullDiagnosticsProvider implements Disposable {
         const fullDiagnostics = await performFullDiagnosis(this.outputChannel, projectUri)
         const formattedFullDiagnostics = formatFullDiagnostics(fullDiagnostics)
         const copyToClipboardInput = 'Copy to Clipboard'
-        const choice = await displayInformationWithInput(formattedFullDiagnostics, copyToClipboardInput)
+        const choice = await displayNotificationWithInput('Information', formattedFullDiagnostics, copyToClipboardInput)
         if (choice === copyToClipboardInput) {
             await env.clipboard.writeText(formattedFullDiagnostics)
         }

--- a/vscode-lean4/src/diagnostics/setupDiagnostics.ts
+++ b/vscode-lean4/src/diagnostics/setupDiagnostics.ts
@@ -5,31 +5,10 @@ import { LeanInstaller } from '../utils/leanInstaller'
 import { diagnose } from './setupDiagnoser'
 import {
     PreconditionCheckResult,
-    displayDependencySetupError,
-    displayElanOutdatedSetupWarning,
-    displayElanSetupError,
-    displayElanSetupWarning,
-    displaySetupError,
-    displaySetupErrorWithOutput,
-    displaySetupWarning,
-    displaySetupWarningWithOptionalInput,
-    displaySetupWarningWithOutput,
+    SetupNotificationOptions,
+    SetupNotifier,
     worstPreconditionViolation,
 } from './setupNotifs'
-
-export async function checkAll(
-    ...checks: (() => Promise<PreconditionCheckResult>)[]
-): Promise<PreconditionCheckResult> {
-    let worstViolation: PreconditionCheckResult = 'Fulfilled'
-    for (const check of checks) {
-        const result = await check()
-        worstViolation = worstPreconditionViolation(worstViolation, result)
-        if (worstViolation === 'Fatal') {
-            return 'Fatal'
-        }
-    }
-    return worstViolation
-}
 
 const singleFileWarningMessage = `Lean 4 server is operating in restricted single file mode.
 Please open a valid Lean 4 project containing a \'lean-toolchain\' file for full functionality.
@@ -52,189 +31,225 @@ const ancientLean4ProjectWarningMessage = (origin: string, projectVersion: SemVe
     `${origin} is using a Lean 4 version (${projectVersion.toString()}) from before the first Lean 4 stable release (4.0.0).
 Pre-stable Lean 4 versions are increasingly less supported, so please consider updating to a newer Lean 4 version.`
 
-export async function checkAreDependenciesInstalled(
-    channel: OutputChannel,
-    cwdUri: FileUri | undefined,
-): Promise<PreconditionCheckResult> {
-    const missingDeps = []
-    if (!(await diagnose(channel, cwdUri).checkCurlAvailable())) {
-        missingDeps.push('curl')
-    }
-    if (!(await diagnose(channel, cwdUri).checkGitAvailable())) {
-        missingDeps.push('git')
-    }
-    if (missingDeps.length === 0) {
-        return 'Fulfilled'
-    }
-    displayDependencySetupError(missingDeps)
-    return 'Fatal'
-}
+export class SetupDiagnostics {
+    private n: SetupNotifier
 
-export async function checkIsLean4Installed(
-    installer: LeanInstaller,
-    context: string,
-    cwdUri: FileUri | undefined,
-): Promise<PreconditionCheckResult> {
-    const leanVersionResult = await diagnose(installer.getOutputChannel(), cwdUri).queryLeanVersion(context)
-    switch (leanVersionResult.kind) {
-        case 'Success':
+    constructor(o: SetupNotificationOptions) {
+        this.n = new SetupNotifier(o)
+    }
+
+    async checkAreDependenciesInstalled(
+        channel: OutputChannel,
+        cwdUri: FileUri | undefined,
+    ): Promise<PreconditionCheckResult> {
+        const missingDeps = []
+        if (!(await diagnose(channel, cwdUri).checkCurlAvailable())) {
+            missingDeps.push('curl')
+        }
+        if (!(await diagnose(channel, cwdUri).checkGitAvailable())) {
+            missingDeps.push('git')
+        }
+        if (missingDeps.length === 0) {
             return 'Fulfilled'
+        }
+        let missingDepMessage: string
+        if (missingDeps.length === 1) {
+            missingDepMessage = `One of Lean's dependencies ('${missingDeps.at(0)}') is missing`
+        } else {
+            missingDepMessage = `Multiple of Lean's dependencies (${missingDeps.map(dep => `'${dep}'`).join(', ')}) are missing`
+        }
 
-        case 'CommandError':
-            return displaySetupErrorWithOutput(`Error while checking Lean version: ${leanVersionResult.message}`)
-
-        case 'InvalidVersion':
-            return displaySetupErrorWithOutput(
-                `Error while checking Lean version: 'lean --version' returned a version that could not be parsed: '${leanVersionResult.versionResult}'`,
-            )
-
-        case 'CommandNotFound':
-            return await displayElanSetupError(installer, 'Lean is not installed.')
+        const errorMessage = `${missingDepMessage}. Please read the Setup Guide on how to install missing dependencies and set up Lean 4.`
+        return await this.n.displaySetupErrorWithSetupGuide(errorMessage)
     }
-}
 
-export async function checkIsElanUpToDate(
-    installer: LeanInstaller,
-    cwdUri: FileUri | undefined,
-    options: { elanMustBeInstalled: boolean; modal: boolean },
-): Promise<PreconditionCheckResult> {
-    const elanDiagnosis = await diagnose(installer.getOutputChannel(), cwdUri).elanVersion()
+    async checkIsLean4Installed(
+        installer: LeanInstaller,
+        context: string,
+        cwdUri: FileUri | undefined,
+    ): Promise<PreconditionCheckResult> {
+        const leanVersionResult = await diagnose(installer.getOutputChannel(), cwdUri).queryLeanVersion(context)
+        switch (leanVersionResult.kind) {
+            case 'Success':
+                return 'Fulfilled'
 
-    switch (elanDiagnosis.kind) {
-        case 'NotInstalled':
-            if (options.elanMustBeInstalled) {
-                return await displayElanSetupError(installer, "Lean's version manager Elan is not installed.")
-            }
-            return await displayElanSetupWarning(
-                installer,
-                "Lean's version manager Elan is not installed. This means that the correct Lean 4 toolchain version of Lean 4 projects will not be selected or installed automatically.",
-            )
-
-        case 'ExecutionError':
-            return await displaySetupWarningWithOutput('Cannot determine Elan version: ' + elanDiagnosis.message, {
-                modal: options.modal,
-            })
-
-        case 'Outdated':
-            return await displayElanOutdatedSetupWarning(
-                installer,
-                elanDiagnosis.currentVersion,
-                elanDiagnosis.recommendedVersion,
-            )
-
-        case 'UpToDate':
-            return 'Fulfilled'
-    }
-}
-
-export async function checkIsValidProjectFolder(
-    channel: OutputChannel,
-    folderUri: ExtUri,
-): Promise<PreconditionCheckResult> {
-    const projectSetupDiagnosis = await diagnose(channel, extUriToCwdUri(folderUri)).projectSetup()
-    switch (projectSetupDiagnosis.kind) {
-        case 'SingleFile':
-            return await displaySetupWarning(singleFileWarningMessage)
-
-        case 'MissingLeanToolchain':
-            const parentProjectFolder = projectSetupDiagnosis.parentProjectFolder
-            if (parentProjectFolder === undefined) {
-                return await displaySetupWarning(missingLeanToolchainWarningMessage)
-            } else {
-                return displaySetupWarningWithOptionalInput(
-                    missingLeanToolchainWithParentProjectWarningMessage(parentProjectFolder),
-                    'Open Parent Directory Project',
-                    // this kills the extension host
-                    () => commands.executeCommand('vscode.openFolder', parentProjectFolder),
+            case 'CommandError':
+                return this.n.displaySetupErrorWithOutput(
+                    `Error while checking Lean version: ${leanVersionResult.message}`,
                 )
-            }
 
-        case 'ValidProjectSetup':
-            return 'Fulfilled'
+            case 'InvalidVersion':
+                return this.n.displaySetupErrorWithOutput(
+                    `Error while checking Lean version: 'lean --version' returned a version that could not be parsed: '${leanVersionResult.versionResult}'`,
+                )
+
+            case 'CommandNotFound':
+                return await this.n.displayElanSetupError(installer, 'Lean is not installed.')
+        }
+    }
+
+    async checkIsElanUpToDate(
+        installer: LeanInstaller,
+        cwdUri: FileUri | undefined,
+        options: { elanMustBeInstalled: boolean },
+    ): Promise<PreconditionCheckResult> {
+        const elanDiagnosis = await diagnose(installer.getOutputChannel(), cwdUri).elanVersion()
+
+        switch (elanDiagnosis.kind) {
+            case 'NotInstalled':
+                if (options.elanMustBeInstalled) {
+                    return await this.n.displayElanSetupError(
+                        installer,
+                        "Lean's version manager Elan is not installed.",
+                    )
+                }
+                return await this.n.displayElanSetupWarning(
+                    installer,
+                    "Lean's version manager Elan is not installed. This means that the correct Lean 4 toolchain version of Lean 4 projects will not be selected or installed automatically.",
+                )
+
+            case 'ExecutionError':
+                return await this.n.displaySetupWarningWithOutput(
+                    'Cannot determine Elan version: ' + elanDiagnosis.message,
+                )
+
+            case 'Outdated':
+                return await this.n.displayElanOutdatedSetupWarning(
+                    installer,
+                    elanDiagnosis.currentVersion,
+                    elanDiagnosis.recommendedVersion,
+                )
+
+            case 'UpToDate':
+                return 'Fulfilled'
+        }
+    }
+
+    async checkIsValidProjectFolder(channel: OutputChannel, folderUri: ExtUri): Promise<PreconditionCheckResult> {
+        const projectSetupDiagnosis = await diagnose(channel, extUriToCwdUri(folderUri)).projectSetup()
+        switch (projectSetupDiagnosis.kind) {
+            case 'SingleFile':
+                return await this.n.displaySetupWarning(singleFileWarningMessage)
+
+            case 'MissingLeanToolchain':
+                const parentProjectFolder = projectSetupDiagnosis.parentProjectFolder
+                if (parentProjectFolder === undefined) {
+                    return await this.n.displaySetupWarning(missingLeanToolchainWarningMessage)
+                } else {
+                    return this.n.displaySetupWarningWithInput(
+                        missingLeanToolchainWithParentProjectWarningMessage(parentProjectFolder),
+                        {
+                            input: 'Open Parent Directory Project',
+                            // this kills the extension host
+                            action: () => commands.executeCommand('vscode.openFolder', parentProjectFolder),
+                        },
+                    )
+                }
+
+            case 'ValidProjectSetup':
+                return 'Fulfilled'
+        }
+    }
+
+    async checkIsLeanVersionUpToDate(
+        channel: OutputChannel,
+        context: string,
+        folderUri: ExtUri,
+        options: { toolchainOverride?: string | undefined },
+    ): Promise<PreconditionCheckResult> {
+        let origin: string
+        if (options.toolchainOverride !== undefined) {
+            origin = `Project toolchain '${options.toolchainOverride}'`
+        } else if (folderUri.scheme === 'untitled') {
+            origin = 'Opened file'
+        } else {
+            origin = 'Opened project'
+        }
+        const projectLeanVersionDiagnosis = await diagnose(
+            channel,
+            extUriToCwdUri(folderUri),
+            options.toolchainOverride,
+        ).leanVersion(context)
+        switch (projectLeanVersionDiagnosis.kind) {
+            case 'NotInstalled':
+                return this.n.displaySetupErrorWithOutput(
+                    "Error while checking Lean version: 'lean' command was not found.",
+                )
+
+            case 'ExecutionError':
+                return this.n.displaySetupErrorWithOutput(
+                    `Error while checking Lean version: ${projectLeanVersionDiagnosis.message}`,
+                )
+
+            case 'IsLean3Version':
+                return this.n.displaySetupError(lean3ProjectErrorMessage(origin, projectLeanVersionDiagnosis.version))
+
+            case 'IsAncientLean4Version':
+                return await this.n.displaySetupWarning(
+                    ancientLean4ProjectWarningMessage(origin, projectLeanVersionDiagnosis.version),
+                )
+
+            case 'UpToDate':
+                return 'Fulfilled'
+        }
+    }
+
+    async checkIsLakeInstalledCorrectly(
+        channel: OutputChannel,
+        context: string,
+        folderUri: ExtUri,
+        options: { toolchainOverride?: string | undefined },
+    ): Promise<PreconditionCheckResult> {
+        const lakeVersionResult = await diagnose(
+            channel,
+            extUriToCwdUri(folderUri),
+            options.toolchainOverride,
+        ).queryLakeVersion(context)
+        switch (lakeVersionResult.kind) {
+            case 'CommandNotFound':
+                return this.n.displaySetupErrorWithOutput(
+                    "Error while checking Lake version: 'lake' command was not found.",
+                )
+
+            case 'CommandError':
+                return this.n.displaySetupErrorWithOutput(
+                    `Error while checking Lake version: ${lakeVersionResult.message}`,
+                )
+
+            case 'InvalidVersion':
+                return this.n.displaySetupErrorWithOutput(
+                    `Error while checking Lake version: Invalid Lake version format: '${lakeVersionResult.versionResult}'`,
+                )
+
+            case 'Success':
+                return 'Fulfilled'
+        }
+    }
+
+    async checkIsVSCodeUpToDate(): Promise<PreconditionCheckResult> {
+        const vscodeVersionResult = diagnose(undefined, undefined).queryVSCodeVersion()
+        switch (vscodeVersionResult.kind) {
+            case 'Outdated':
+                return await this.n.displaySetupWarning(
+                    `VS Code version is too out-of-date for new versions of the Lean 4 VS Code extension. The current VS Code version is ${vscodeVersionResult.currentVersion}, but a version of at least ${vscodeVersionResult.recommendedVersion} is recommended so that new versions of the Lean 4 VS Code extension can be installed.`,
+                )
+
+            case 'UpToDate':
+                return 'Fulfilled'
+        }
     }
 }
 
-export async function checkIsLeanVersionUpToDate(
-    channel: OutputChannel,
-    context: string,
-    folderUri: ExtUri,
-    options: { toolchainOverride?: string | undefined; modal: boolean },
+export async function checkAll(
+    ...checks: (() => Promise<PreconditionCheckResult>)[]
 ): Promise<PreconditionCheckResult> {
-    let origin: string
-    if (options.toolchainOverride !== undefined) {
-        origin = `Project toolchain '${options.toolchainOverride}'`
-    } else if (folderUri.scheme === 'untitled') {
-        origin = 'Opened file'
-    } else {
-        origin = 'Opened project'
+    let worstViolation: PreconditionCheckResult = 'Fulfilled'
+    for (const check of checks) {
+        const result = await check()
+        worstViolation = worstPreconditionViolation(worstViolation, result)
+        if (worstViolation === 'Fatal') {
+            return 'Fatal'
+        }
     }
-    const projectLeanVersionDiagnosis = await diagnose(
-        channel,
-        extUriToCwdUri(folderUri),
-        options.toolchainOverride,
-    ).leanVersion(context)
-    switch (projectLeanVersionDiagnosis.kind) {
-        case 'NotInstalled':
-            return displaySetupErrorWithOutput("Error while checking Lean version: 'lean' command was not found.")
-
-        case 'ExecutionError':
-            return displaySetupErrorWithOutput(
-                `Error while checking Lean version: ${projectLeanVersionDiagnosis.message}`,
-            )
-
-        case 'IsLean3Version':
-            return displaySetupError(lean3ProjectErrorMessage(origin, projectLeanVersionDiagnosis.version))
-
-        case 'IsAncientLean4Version':
-            return await displaySetupWarning(
-                ancientLean4ProjectWarningMessage(origin, projectLeanVersionDiagnosis.version),
-                {
-                    modal: options.modal,
-                },
-            )
-
-        case 'UpToDate':
-            return 'Fulfilled'
-    }
-}
-
-export async function checkIsLakeInstalledCorrectly(
-    channel: OutputChannel,
-    context: string,
-    folderUri: ExtUri,
-    options: { toolchainOverride?: string | undefined },
-): Promise<PreconditionCheckResult> {
-    const lakeVersionResult = await diagnose(
-        channel,
-        extUriToCwdUri(folderUri),
-        options.toolchainOverride,
-    ).queryLakeVersion(context)
-    switch (lakeVersionResult.kind) {
-        case 'CommandNotFound':
-            return displaySetupErrorWithOutput("Error while checking Lake version: 'lake' command was not found.")
-
-        case 'CommandError':
-            return displaySetupErrorWithOutput(`Error while checking Lake version: ${lakeVersionResult.message}`)
-
-        case 'InvalidVersion':
-            return displaySetupErrorWithOutput(
-                `Error while checking Lake version: Invalid Lake version format: '${lakeVersionResult.versionResult}'`,
-            )
-
-        case 'Success':
-            return 'Fulfilled'
-    }
-}
-
-export async function checkIsVSCodeUpToDate(): Promise<PreconditionCheckResult> {
-    const vscodeVersionResult = diagnose(undefined, undefined).queryVSCodeVersion()
-    switch (vscodeVersionResult.kind) {
-        case 'Outdated':
-            return displaySetupWarning(
-                `VS Code version is too out-of-date for new versions of the Lean 4 VS Code extension. The current VS Code version is ${vscodeVersionResult.currentVersion}, but at least a version of ${vscodeVersionResult.recommendedVersion} is recommended so that new versions of the Lean 4 VS Code extension can be installed.`,
-            )
-
-        case 'UpToDate':
-            return 'Fulfilled'
-    }
+    return worstViolation
 }

--- a/vscode-lean4/src/diagnostics/setupNotifs.ts
+++ b/vscode-lean4/src/diagnostics/setupNotifs.ts
@@ -52,8 +52,6 @@ export function worstPreconditionViolation(...results: PreconditionCheckResult[]
     return worstViolation
 }
 
-export type ModalSetupOptions = { modal: true } | { modal: false; finalizer?: (() => void) | undefined }
-
 export type SetupNotificationOptions = {
     errorMode: { mode: 'Sticky'; retry: () => Promise<void> } | { mode: 'Modal' } | { mode: 'NonModal' }
     warningMode: { modal: boolean; proceedByDefault: boolean }

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -52,7 +52,7 @@ import { LeanClientProvider } from './utils/clientProvider'
 import { c2pConverter, p2cConverter } from './utils/converters'
 import { ExtUri, parseExtUri, toExtUri } from './utils/exturi'
 import { logger } from './utils/logger'
-import { displayError, displayInformation } from './utils/notifs'
+import { displayNotification } from './utils/notifs'
 
 const keepAlivePeriodMs = 10000
 
@@ -258,7 +258,7 @@ export class InfoProvider implements Disposable {
         },
         copyToClipboard: async text => {
             await env.clipboard.writeText(text)
-            displayInformation(`Copied to clipboard: ${text}`)
+            displayNotification('Information', `Copied to clipboard: ${text}`)
         },
         insertText: async (text, kind, tdpp) => {
             let uri: ExtUri | undefined
@@ -586,7 +586,8 @@ export class InfoProvider implements Disposable {
         } else if (window.activeTextEditor && window.activeTextEditor.document.languageId === 'lean4') {
             await this.openPreview(window.activeTextEditor)
         } else {
-            displayError(
+            displayNotification(
+                'Error',
                 'No active Lean editor tab. Make sure to focus the Lean editor tab for which you want to open the infoview.',
             )
         }

--- a/vscode-lean4/src/utils/batch.ts
+++ b/vscode-lean4/src/utils/batch.ts
@@ -1,7 +1,7 @@
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process'
 import { OutputChannel, Progress, ProgressLocation, ProgressOptions, window } from 'vscode'
 import { logger } from './logger'
-import { displayErrorWithOutput } from './notifs'
+import { displayNotificationWithOutput } from './notifs'
 
 export interface ExecutionChannel {
     combined?: OutputChannel | undefined
@@ -255,7 +255,7 @@ export function displayResultError(result: ExecutionResult, message: string) {
         throw Error()
     }
     const errorMessage: string = formatErrorMessage(result, message)
-    displayErrorWithOutput(errorMessage)
+    displayNotificationWithOutput('Error', errorMessage)
 }
 
 function formatErrorMessage(error: ExecutionResult, message: string): string {

--- a/vscode-lean4/src/utils/events.ts
+++ b/vscode-lean4/src/utils/events.ts
@@ -1,0 +1,51 @@
+import { Disposable, Event } from 'vscode'
+
+export function onNextEvent<T>(ev: Event<T>, listener: (e: T) => any): Disposable {
+    const d = ev(e => {
+        d.dispose()
+        listener(e)
+    })
+    return d
+}
+
+export function onEventWhile<T>(ev: Event<T>, listener: (e: T) => Promise<'Continue' | 'Stop'>): Disposable {
+    const d = ev(async e => {
+        const r = await listener(e)
+        if (r === 'Stop') {
+            d.dispose()
+        }
+    })
+    return d
+}
+
+export function withoutReentrancy<V, R>(onReentrancy: R, f: (v: V) => Promise<R>): (v: V) => Promise<R> {
+    let isRunning = false
+    return async v => {
+        if (isRunning) {
+            return onReentrancy
+        }
+        isRunning = true
+
+        try {
+            return await f(v)
+        } finally {
+            isRunning = false
+        }
+    }
+}
+
+export function actionWithoutReentrancy<T>(f: (v: T) => Promise<void>): (v: T) => Promise<void> {
+    let isRunning = false
+    return async v => {
+        if (isRunning) {
+            return
+        }
+        isRunning = true
+
+        try {
+            await f(v)
+        } finally {
+            isRunning = false
+        }
+    }
+}

--- a/vscode-lean4/src/utils/internalErrors.ts
+++ b/vscode-lean4/src/utils/internalErrors.ts
@@ -1,5 +1,5 @@
 import { env } from 'vscode'
-import { displayErrorWithInput } from './notifs'
+import { displayNotificationWithInput } from './notifs'
 
 export async function displayInternalErrorsIn<T>(scope: string, f: () => Promise<T>): Promise<T> {
     try {
@@ -13,7 +13,7 @@ export async function displayInternalErrorsIn<T>(scope: string, f: () => Promise
         msg +=
             "\n\nIf you are using an up-to-date version of the Lean 4 VS Code extension, please copy the full error message using the 'Copy Error to Clipboard' button and report it at https://github.com/leanprover/vscode-lean4/ or https://leanprover.zulipchat.com/."
         const copyToClipboardInput = 'Copy Error to Clipboard'
-        const choice = await displayErrorWithInput(msg, copyToClipboardInput)
+        const choice = await displayNotificationWithInput('Error', msg, copyToClipboardInput)
         if (choice === copyToClipboardInput) {
             await env.clipboard.writeText(fullMsg)
         }

--- a/vscode-lean4/src/utils/leanEditorProvider.ts
+++ b/vscode-lean4/src/utils/leanEditorProvider.ts
@@ -1,0 +1,313 @@
+import { Disposable, EventEmitter, ExtensionContext, TextDocument, TextEditor, Uri, window, workspace } from 'vscode'
+import { ExtUri, isExtUri } from './exturi'
+
+function groupByKey<K, V>(values: V[], key: (value: V) => K): Map<K, V[]> {
+    const r = new Map<K, V[]>()
+    for (const v of values) {
+        const k = key(v)
+        const group = r.get(k) ?? []
+        group.push(v)
+        r.set(k, group)
+    }
+    return r
+}
+
+function groupByUniqueKey<K, V>(values: V[], key: (value: V) => K): Map<K, V> {
+    const r = new Map<K, V>()
+    for (const v of values) {
+        r.set(key(v), v)
+    }
+    return r
+}
+
+class TextDocumentIndex {
+    private docsByUri: Map<string, TextDocument>
+
+    /**
+     * Assumes that `docs` only contains at most one `TextDocument` per URI.
+     * This is given for `TextDocument`s from VS Code.
+     * */
+    constructor(docs: TextDocument[]) {
+        this.docsByUri = groupByUniqueKey(docs, doc => doc.uri.toString())
+    }
+
+    get(uri: Uri): TextDocument | undefined {
+        return this.docsByUri.get(uri.toString())
+    }
+}
+
+class TextEditorIndex {
+    private editorsByUri: Map<string, TextEditor[]>
+
+    constructor(editors: TextEditor[]) {
+        this.editorsByUri = groupByKey(editors, editor => editor.document.uri.toString())
+    }
+
+    get(uri: Uri): TextEditor[] | undefined {
+        return this.editorsByUri.get(uri.toString())
+    }
+}
+
+export function isLeanDocument(doc: TextDocument): boolean {
+    return isExtUri(doc.uri) && doc.languageId === 'lean4'
+}
+
+export function filterLeanDocuments(docs: readonly TextDocument[]): TextDocument[] {
+    return docs.filter(doc => isLeanDocument(doc))
+}
+
+export function filterLeanDocument(doc: TextDocument | undefined): TextDocument | undefined {
+    if (doc !== undefined && isLeanDocument(doc)) {
+        return doc
+    }
+    return undefined
+}
+
+export function isLeanEditor(editor: TextEditor): boolean {
+    return isLeanDocument(editor.document)
+}
+
+export function filterLeanEditors(editors: readonly TextEditor[]): TextEditor[] {
+    return editors.filter(editor => isLeanEditor(editor))
+}
+
+export function filterLeanEditor(editor: TextEditor | undefined): TextEditor | undefined {
+    if (editor !== undefined && isLeanEditor(editor)) {
+        return editor
+    }
+    return undefined
+}
+
+export class LeanEditorProvider implements Disposable {
+    private subscriptions: Disposable[] = []
+
+    private _visibleLeanEditors: TextEditor[]
+    private visibleLeanEditorsByUri: TextEditorIndex
+    private readonly onDidChangeVisibleLeanEditorsEmitter = new EventEmitter<readonly TextEditor[]>()
+    readonly onDidChangeVisibleLeanEditors = this.onDidChangeVisibleLeanEditorsEmitter.event
+    private readonly onDidRevealLeanEditorEmitter = new EventEmitter<TextEditor>()
+    readonly onDidRevealLeanEditor = this.onDidRevealLeanEditorEmitter.event
+    private readonly onDidConcealLeanEditorEmitter = new EventEmitter<TextEditor>()
+    readonly onDidConcealLeanEditor = this.onDidConcealLeanEditorEmitter.event
+
+    private _activeLeanEditor: TextEditor | undefined
+    private readonly onDidChangeActiveLeanEditorEmitter = new EventEmitter<TextEditor | undefined>()
+    readonly onDidChangeActiveLeanEditor = this.onDidChangeActiveLeanEditorEmitter.event
+
+    private _lastActiveLeanEditor: TextEditor | undefined
+    private readonly onDidChangeLastActiveLeanEditorEmitter = new EventEmitter<TextEditor | undefined>()
+    readonly onDidChangeLastActiveLeanEditor = this.onDidChangeLastActiveLeanEditorEmitter.event
+
+    private _leanDocuments: TextDocument[]
+    private leanDocumentsByUri: TextDocumentIndex
+    private readonly onDidChangeLeanDocumentsEmitter = new EventEmitter<readonly TextDocument[]>()
+    readonly onDidChangeLeanDocuments = this.onDidChangeLeanDocumentsEmitter.event
+    private readonly onDidOpenLeanDocumentEmitter = new EventEmitter<TextDocument>()
+    readonly onDidOpenLeanDocument = this.onDidOpenLeanDocumentEmitter.event
+    private readonly onDidCloseLeanDocumentEmitter = new EventEmitter<TextDocument>()
+    readonly onDidCloseLeanDocument = this.onDidCloseLeanDocumentEmitter.event
+
+    private _lastActiveLeanDocument: TextDocument | undefined
+    private readonly onDidChangeLastActiveLeanDocumentEmitter = new EventEmitter<TextDocument | undefined>()
+    readonly onDidChangeLastActiveLeanDocument = this.onDidChangeLastActiveLeanDocumentEmitter.event
+
+    constructor() {
+        this._visibleLeanEditors = filterLeanEditors(window.visibleTextEditors)
+        this.visibleLeanEditorsByUri = new TextEditorIndex(this._visibleLeanEditors)
+        this.subscriptions.push(
+            window.onDidChangeVisibleTextEditors(editors => {
+                const oldVisibleLeanEditors = [...this._visibleLeanEditors]
+                this.updateVisibleLeanEditors(editors)
+                this.revealLeanEditors(oldVisibleLeanEditors, editors)
+                this.concealLeanEditors(oldVisibleLeanEditors, editors)
+                this.invalidateInvisibleLastActiveLeanEditor(editors)
+            }),
+        )
+
+        this._activeLeanEditor = filterLeanEditor(window.activeTextEditor)
+        this.subscriptions.push(
+            window.onDidChangeActiveTextEditor(editor => {
+                this.updateActiveLeanEditor(editor)
+                this.updateLastActiveLeanEditor(editor)
+                this.updateLastActiveLeanDocument(editor)
+            }),
+        )
+
+        this._leanDocuments = filterLeanDocuments(workspace.textDocuments)
+        this.leanDocumentsByUri = new TextDocumentIndex(this._leanDocuments)
+        this.subscriptions.push(
+            workspace.onDidOpenTextDocument(doc => {
+                this.updateLeanDocuments(workspace.textDocuments)
+                this.openLeanDocument(doc)
+            }),
+        )
+        this.subscriptions.push(
+            workspace.onDidCloseTextDocument(doc => {
+                this.updateLeanDocuments(workspace.textDocuments)
+                this.closeLeanDocument(doc)
+                this.invalidateClosedLastActiveLeanDocument(doc)
+            }),
+        )
+    }
+
+    private updateVisibleLeanEditors(visibleTextEditors: readonly TextEditor[]) {
+        const newVisibleLeanEditors = filterLeanEditors(visibleTextEditors)
+        if (
+            newVisibleLeanEditors.length === this._visibleLeanEditors.length &&
+            newVisibleLeanEditors.every(
+                (newVisibleLeanEditor, i) => newVisibleLeanEditor === this._visibleLeanEditors[i],
+            )
+        ) {
+            return
+        }
+        this._visibleLeanEditors = newVisibleLeanEditors
+        this.visibleLeanEditorsByUri = new TextEditorIndex(newVisibleLeanEditors)
+        this.onDidChangeVisibleLeanEditorsEmitter.fire(newVisibleLeanEditors)
+    }
+
+    private revealLeanEditors(
+        oldVisibleLeanEditors: readonly TextEditor[],
+        newVisibleTextEditors: readonly TextEditor[],
+    ) {
+        const oldVisibleLeanEditorsIndex = new Set(oldVisibleLeanEditors)
+        const newVisibleLeanEditors = filterLeanEditors(newVisibleTextEditors)
+        const revealedLeanEditors = newVisibleLeanEditors.filter(
+            newVisibleLeanEditor => !oldVisibleLeanEditorsIndex.has(newVisibleLeanEditor),
+        )
+        for (const revealedLeanEditor of revealedLeanEditors) {
+            this.onDidRevealLeanEditorEmitter.fire(revealedLeanEditor)
+        }
+    }
+
+    private concealLeanEditors(
+        oldVisibleLeanEditors: readonly TextEditor[],
+        newVisibleTextEditors: readonly TextEditor[],
+    ) {
+        const newVisibleLeanEditors = filterLeanEditors(newVisibleTextEditors)
+        const newVisibleLeanEditorsIndex = new Set(newVisibleLeanEditors)
+        const concealedLeanEditors = oldVisibleLeanEditors.filter(
+            newVisibleLeanEditor => !newVisibleLeanEditorsIndex.has(newVisibleLeanEditor),
+        )
+        for (const concealedLeanEditor of concealedLeanEditors) {
+            this.onDidConcealLeanEditorEmitter.fire(concealedLeanEditor)
+        }
+    }
+
+    private updateActiveLeanEditor(activeTextEditor: TextEditor | undefined) {
+        const newActiveLeanEditor = filterLeanEditor(activeTextEditor)
+        if (newActiveLeanEditor === this._activeLeanEditor) {
+            return
+        }
+        this._activeLeanEditor = newActiveLeanEditor
+        this.onDidChangeActiveLeanEditorEmitter.fire(newActiveLeanEditor)
+    }
+
+    private invalidateInvisibleLastActiveLeanEditor(visibleTextEditors: readonly TextEditor[]) {
+        if (this._lastActiveLeanEditor !== undefined && !visibleTextEditors.includes(this._lastActiveLeanEditor)) {
+            this._lastActiveLeanEditor = undefined
+            this.onDidChangeLastActiveLeanEditorEmitter.fire(undefined)
+        }
+    }
+
+    private updateLastActiveLeanEditor(activeTextEditor: TextEditor | undefined) {
+        const newLastActiveLeanEditor = filterLeanEditor(activeTextEditor)
+        if (newLastActiveLeanEditor === undefined) {
+            return
+        }
+        if (newLastActiveLeanEditor === this._lastActiveLeanEditor) {
+            return
+        }
+        this._lastActiveLeanEditor = newLastActiveLeanEditor
+        this.onDidChangeLastActiveLeanEditorEmitter.fire(newLastActiveLeanEditor)
+    }
+
+    private updateLeanDocuments(textDocuments: readonly TextDocument[]) {
+        const newLeanDocuments = filterLeanDocuments(textDocuments)
+        if (
+            newLeanDocuments.length === this._leanDocuments.length &&
+            newLeanDocuments.every((newLeanDocument, i) => newLeanDocument === this._leanDocuments[i])
+        ) {
+            return
+        }
+        this._leanDocuments = newLeanDocuments
+        this.leanDocumentsByUri = new TextDocumentIndex(newLeanDocuments)
+        this.onDidChangeLeanDocumentsEmitter.fire(newLeanDocuments)
+    }
+
+    private openLeanDocument(textDocument: TextDocument) {
+        const leanTextDocument = filterLeanDocument(textDocument)
+        if (leanTextDocument === undefined) {
+            return
+        }
+        this.onDidOpenLeanDocumentEmitter.fire(leanTextDocument)
+    }
+
+    private closeLeanDocument(textDocument: TextDocument) {
+        const leanTextDocument = filterLeanDocument(textDocument)
+        if (leanTextDocument === undefined) {
+            return
+        }
+        this.onDidCloseLeanDocumentEmitter.fire(leanTextDocument)
+    }
+
+    private invalidateClosedLastActiveLeanDocument(closedTextDocument: TextDocument) {
+        if (this._lastActiveLeanDocument === closedTextDocument) {
+            this._lastActiveLeanDocument = undefined
+            this.onDidChangeLastActiveLeanDocumentEmitter.fire(undefined)
+        }
+    }
+
+    private updateLastActiveLeanDocument(activeTextEditor: TextEditor | undefined) {
+        const newLastActiveLeanDocument = filterLeanDocument(activeTextEditor?.document)
+        if (newLastActiveLeanDocument === undefined) {
+            return
+        }
+        if (newLastActiveLeanDocument === this._lastActiveLeanDocument) {
+            return
+        }
+        this._lastActiveLeanDocument = newLastActiveLeanDocument
+        this.onDidChangeLastActiveLeanDocumentEmitter.fire(newLastActiveLeanDocument)
+    }
+
+    get visibleLeanEditors(): readonly TextEditor[] {
+        return this._visibleLeanEditors
+    }
+
+    get activeLeanEditor(): TextEditor | undefined {
+        return this._activeLeanEditor
+    }
+
+    get lastActiveLeanEditor(): TextEditor | undefined {
+        return this._lastActiveLeanEditor
+    }
+
+    get leanDocuments(): readonly TextDocument[] {
+        return this._leanDocuments
+    }
+
+    get lastActiveLeanDocument(): TextDocument | undefined {
+        return this._lastActiveLeanDocument
+    }
+
+    getVisibleLeanEditorsByUri(uri: ExtUri): readonly TextEditor[] | undefined {
+        return this.visibleLeanEditorsByUri.get(uri.asUri())
+    }
+
+    getLeanDocumentByUri(uri: ExtUri): TextDocument | undefined {
+        return this.leanDocumentsByUri.get(uri.asUri())
+    }
+
+    dispose() {
+        for (const s of this.subscriptions) {
+            s.dispose()
+        }
+    }
+}
+
+export let leanEditor: LeanEditorProvider
+
+/** Must be called at the very start when the extension is activated so that `leanEditor` is defined. */
+export function registerLeanEditor(context: ExtensionContext) {
+    leanEditor = new LeanEditorProvider()
+    context.subscriptions.push(leanEditor)
+}

--- a/vscode-lean4/src/utils/notifs.ts
+++ b/vscode-lean4/src/utils/notifs.ts
@@ -72,7 +72,6 @@ function makeSticky<T>(n: StickyNotification<T>): Disposable {
                     activeStickyNotification = nextStickyNotification
                     nextStickyNotification = undefined
                     gotNewStickyNotification = true
-                    await activeStickyNotification?.options.onDisplay()
                 }
             } while ((r !== undefined && continueDisplaying) || gotNewStickyNotification)
             if (!continueDisplaying) {
@@ -129,7 +128,6 @@ export async function displayNotificationWithInput<T extends string>(
 }
 
 export type Input<T> = { input: T; action: () => void }
-export type StickyInput<T> = { input: T; continueDisplaying: boolean; action: () => Promise<void> }
 
 export function displayNotificationWithOptionalInput<T extends string>(
     severity: NotificationSeverity,
@@ -148,6 +146,8 @@ export function displayNotificationWithOptionalInput<T extends string>(
         }
     })()
 }
+
+export type StickyInput<T> = { input: T; continueDisplaying: boolean; action: () => Promise<void> }
 
 export function displayStickyNotificationWithOptionalInput<T extends string>(
     severity: NotificationSeverity,
@@ -192,9 +192,9 @@ export function displayNotificationWithOutput(
 export async function displayModalNotificationWithOutput(
     severity: NotificationSeverity,
     message: string,
-    ...otherInputs: string[]
+    ...otherItems: string[]
 ): Promise<'Show Output' | string | undefined> {
-    const choice = await displayNotificationWithInput(severity, message, 'Show Output', ...otherInputs)
+    const choice = await displayNotificationWithInput(severity, message, 'Show Output', ...otherItems)
     if (choice === 'Show Output') {
         await commands.executeCommand('lean4.troubleshooting.showOutput')
     }
@@ -205,14 +205,14 @@ export function displayStickyNotificationWithOutput(
     severity: NotificationSeverity,
     message: string,
     options: StickyNotificationOptions<'Show Output' | string>,
-    ...otherItems: StickyInput<string>[]
+    ...otherInputs: StickyInput<string>[]
 ): Disposable {
     const showOutputItem: StickyInput<'Show Output'> = {
         input: 'Show Output',
         continueDisplaying: true,
         action: async () => await commands.executeCommand('lean4.troubleshooting.showOutput'),
     }
-    return displayStickyNotificationWithOptionalInput(severity, message, options, showOutputItem, ...otherItems)
+    return displayStickyNotificationWithOptionalInput(severity, message, options, showOutputItem, ...otherInputs)
 }
 
 export function displayNotificationWithSetupGuide(
@@ -236,22 +236,22 @@ export function displayStickyNotificationWithSetupGuide(
     severity: NotificationSeverity,
     message: string,
     options: StickyNotificationOptions<'Open Setup Guide' | string>,
-    ...otherItems: StickyInput<string>[]
+    ...otherInputs: StickyInput<string>[]
 ): Disposable {
     const openSetupGuideItem: StickyInput<'Open Setup Guide'> = {
         input: 'Open Setup Guide',
         continueDisplaying: true,
         action: async () => await commands.executeCommand('lean4.docs.showSetupGuide'),
     }
-    return displayStickyNotificationWithOptionalInput(severity, message, options, openSetupGuideItem, ...otherItems)
+    return displayStickyNotificationWithOptionalInput(severity, message, options, openSetupGuideItem, ...otherInputs)
 }
 
 export async function displayModalNotificationWithSetupGuide(
     severity: NotificationSeverity,
     message: string,
-    ...otherInputs: string[]
+    ...otherItems: string[]
 ): Promise<'Open Setup Guide' | string | undefined> {
-    const choice = await displayNotificationWithInput(severity, message, 'Open Setup Guide', ...otherInputs)
+    const choice = await displayNotificationWithInput(severity, message, 'Open Setup Guide', ...otherItems)
     if (choice === 'Open Setup Guide') {
         await commands.executeCommand('lean4.docs.showSetupGuide')
     }

--- a/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
+++ b/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
@@ -1,7 +1,7 @@
 import assert from 'assert'
 import { suite } from 'mocha'
 import { logger } from '../../../src/utils/logger'
-import { displayInformation } from '../../../src/utils/notifs'
+import { displayNotification } from '../../../src/utils/notifs'
 import {
     cleanTempFolder,
     closeAllEditors,
@@ -16,7 +16,7 @@ import {
 suite('Lean4 Bootstrap Test Suite', () => {
     test('Install elan on demand', async () => {
         logger.log('=================== Install elan on demand ===================')
-        displayInformation('Running tests: ' + __dirname)
+        displayNotification('Information', 'Running tests: ' + __dirname)
 
         cleanTempFolder('elan')
 
@@ -66,7 +66,7 @@ suite('Lean4 Bootstrap Test Suite', () => {
         )
 
         logger.log(`=================== Install leanprover/lean4:${version} build on demand ===================`)
-        displayInformation('Running tests: ' + __dirname)
+        displayNotification('Information', 'Running tests: ' + __dirname)
 
         // Lean is already installed so this should be quick.
         const features = await initLean4Untitled('#eval Lean.versionString')

--- a/vscode-lean4/test/suite/multi/multi.test.ts
+++ b/vscode-lean4/test/suite/multi/multi.test.ts
@@ -3,7 +3,7 @@ import { suite } from 'mocha'
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { logger } from '../../../src/utils/logger'
-import { displayInformation } from '../../../src/utils/notifs'
+import { displayNotification } from '../../../src/utils/notifs'
 import { assertStringInInfoview, closeAllEditors, getAltBuildVersion, initLean4 } from '../utils/helpers'
 
 suite('Multi-Folder Test Suite', () => {
@@ -11,7 +11,7 @@ suite('Multi-Folder Test Suite', () => {
         logger.log('=================== Load Lean Files in a multi-project workspace ===================')
         // make sure test is always run in predictable state, which is no file or folder open
         await closeAllEditors()
-        displayInformation('Running tests: ' + __dirname)
+        displayNotification('Information', 'Running tests: ' + __dirname)
 
         const multiRoot = path.join(__dirname, '..', '..', '..', '..', 'test', 'test-fixtures', 'multi')
         const features = await initLean4(path.join(multiRoot, 'test', 'Main.lean'))

--- a/vscode-lean4/test/suite/restarts/restarts.test.ts
+++ b/vscode-lean4/test/suite/restarts/restarts.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import * as vscode from 'vscode'
 import { FileUri } from '../../../src/utils/exturi'
 import { logger } from '../../../src/utils/logger'
-import { displayInformation } from '../../../src/utils/notifs'
+import { displayNotification } from '../../../src/utils/notifs'
 import {
     assertStringInInfoview,
     closeAllEditors,
@@ -25,7 +25,7 @@ suite('Lean Server Restart Test Suite', () => {
         logger.log(
             '=================== Test worker crashed and client running - Restarting Lean Server ===================',
         )
-        displayInformation('Running tests: ' + __dirname)
+        displayNotification('Information', 'Running tests: ' + __dirname)
 
         // add normal values to initialize lean4 file
         const hello = 'Hello World'
@@ -70,7 +70,7 @@ suite('Lean Server Restart Test Suite', () => {
         logger.log(
             '=================== Test worker crashed and client running (Refreshing dependencies) ===================',
         )
-        displayInformation('Running tests: ' + __dirname)
+        displayNotification('Information', 'Running tests: ' + __dirname)
 
         // add normal values to initialize lean4 file
         const hello = 'Hello World'
@@ -113,7 +113,7 @@ suite('Lean Server Restart Test Suite', () => {
 
     test('Restart Server', async () => {
         logger.log('=================== Test Restart Server ===================')
-        displayInformation('Running tests: ' + __dirname)
+        displayNotification('Information', 'Running tests: ' + __dirname)
 
         // Test we can restart the lean server
         const simpleRoot = path.join(__dirname, '..', '..', '..', '..', 'test', 'test-fixtures', 'simple')

--- a/vscode-lean4/test/suite/simple/simple.test.ts
+++ b/vscode-lean4/test/suite/simple/simple.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import * as vscode from 'vscode'
 import { UntitledUri } from '../../../src/utils/exturi'
 import { logger } from '../../../src/utils/logger'
-import { displayInformation } from '../../../src/utils/notifs'
+import { displayNotification } from '../../../src/utils/notifs'
 import {
     assertStringInInfoview,
     closeAllEditors,
@@ -19,7 +19,7 @@ import {
 suite('Lean4 Basics Test Suite', () => {
     test('Untitled Lean File', async () => {
         logger.log('=================== Untitled Lean File ===================')
-        displayInformation('Running tests: ' + __dirname)
+        displayNotification('Information', 'Running tests: ' + __dirname)
 
         const features = await initLean4Untitled('#eval Lean.versionString')
         const info = features.infoProvider
@@ -52,7 +52,7 @@ suite('Lean4 Basics Test Suite', () => {
 
     test('Orphaned Lean File', async () => {
         logger.log('=================== Orphaned Lean File ===================')
-        displayInformation('Running tests: ' + __dirname)
+        displayNotification('Information', 'Running tests: ' + __dirname)
 
         const testsRoot = path.join(__dirname, '..', '..', '..', '..', 'test', 'test-fixtures', 'orphan')
         const features = await initLean4(path.join(testsRoot, 'factorial.lean'))
@@ -83,7 +83,7 @@ suite('Lean4 Basics Test Suite', () => {
 
     test('Goto definition in a package folder', async () => {
         logger.log('=================== Goto definition in a package folder ===================')
-        displayInformation('Running tests: ' + __dirname)
+        displayNotification('Information', 'Running tests: ' + __dirname)
 
         // Test we can load file in a project folder from a package folder and also
         // have goto definition work showing that the LeanClient is correctly

--- a/vscode-lean4/test/suite/toolchains/toolchain.test.ts
+++ b/vscode-lean4/test/suite/toolchains/toolchain.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 import { suite } from 'mocha'
 import * as path from 'path'
 import { logger } from '../../../src/utils/logger'
-import { displayInformation } from '../../../src/utils/notifs'
+import { displayNotification } from '../../../src/utils/notifs'
 import {
     assertStringInInfoview,
     closeAllEditors,
@@ -17,7 +17,7 @@ import {
 suite('Toolchain Test Suite', () => {
     test('Edit lean-toolchain version', async () => {
         logger.log('=================== Edit lean-toolchain version ===================')
-        displayInformation('Running tests: ' + __dirname)
+        displayNotification('Information', 'Running tests: ' + __dirname)
 
         const testsRoot = path.join(__dirname, '..', '..', '..', '..', 'test', 'test-fixtures', 'simple')
 


### PR DESCRIPTION
This PR changes the notifications for extension startup errors to a new "sticky" notification mechanism.

Before this PR, when one of the precondition checks of the extension failed (e.g. because Lean was not installed), we would issue a small non-modal notification in the bottom right and then rely on users to figure out that after fixing their setup, they need to open a new Lean document to restart the check. If users closed this notification, there would also be no further indication for why the extension is not activating.
This is quite unintuitive, so we now instead issue a modal notification when the error first occurs and then a sticky notification that re-appears whenever a new Lean text editor is made visible. Clicking the retry button on this notification will re-try the check. This way, it's much harder to miss the error and how to restart the check.

Since these new sticky notifications invert the control flow, this PR required a broad refactoring of the notification architecture.

This PR also fixes a bug where starting VS Code on an untitled Lean 4 file would not start the language server and introduces a new Lean 4 specific abstraction layer for VS Code API event handlers. This abstraction layer is currently only in use in the code that had to be refactored for this PR, but it will be introduced more broadly in further PRs.