### PR TITLE
feat: refinements for 185

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -199,6 +199,12 @@
                 "description": "Restarts the Lean server for the file that is currently focused to refresh the dependencies."
             },
             {
+                "command": "lean4.redisplaySetupError",
+                "category": "Lean 4",
+                "title": "Re-Display Active Setup Error",
+                "description": "Re-displays the currently active setup error if it was closed previously."
+            },
+            {
                 "command": "lean4.input.convert",
                 "category": "Lean 4",
                 "title": "Input: Convert Current Abbreviation",
@@ -511,6 +517,10 @@
                     "when": "lean4.isLeanFeatureSetActive"
                 },
                 {
+                    "command": "lean4.redisplaySetupError",
+                    "when": "lean4.isStickyNotificationActiveButHidden"
+                },
+                {
                     "command": "lean4.input.convert",
                     "when": "lean4.isLeanFeatureSetActive && lean4.input.isActive"
                 },
@@ -673,6 +683,11 @@
                     "submenu": "lean4.titlebar.documentation",
                     "when": "config.lean4.alwaysShowTitleBarMenu || lean4.isLeanFeatureSetActive",
                     "group": "8_documentation@1"
+                },
+                {
+                    "command": "lean4.redisplaySetupError",
+                    "when": "lean4.isStickyNotificationActiveButHidden",
+                    "group": "9_setupError@1"
                 }
             ],
             "lean4.titlebar.newProject": [

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -24,7 +24,12 @@ import { FileUri } from './utils/exturi'
 import { displayInternalErrorsIn } from './utils/internalErrors'
 import { lean, LeanEditor, registerLeanEditorProvider } from './utils/leanEditorProvider'
 import { LeanInstaller } from './utils/leanInstaller'
-import { displayNotification, displayNotificationWithInput } from './utils/notifs'
+import {
+    displayActiveStickyNotification,
+    displayNotification,
+    displayNotificationWithInput,
+    setStickyNotificationActiveButHidden,
+} from './utils/notifs'
 import { PathExtensionProvider } from './utils/pathExtensionProvider'
 import { findLeanProjectRoot } from './utils/projectInfo'
 
@@ -253,6 +258,10 @@ async function tryActivatingLean4Features(
 export async function activate(context: ExtensionContext): Promise<Exports> {
     await setLeanFeatureSetActive(false)
     registerLeanEditorProvider(context)
+    await setStickyNotificationActiveButHidden(false)
+    context.subscriptions.push(
+        commands.registerCommand('lean4.redisplaySetupError', async () => displayActiveStickyNotification()),
+    )
 
     const alwaysEnabledFeatures: AlwaysEnabledFeatures = await displayInternalErrorsIn(
         'activating Lean 4 extension',

--- a/vscode-lean4/src/utils/viewColumn.ts
+++ b/vscode-lean4/src/utils/viewColumn.ts
@@ -9,7 +9,17 @@ export function viewColumnOfInfoView(): ViewColumn {
             return tabGroup.viewColumn
         }
     }
-    return ViewColumn.Beside
+
+    // We do not use `ViewColumn.Beside` here because `ViewColumn.Beside` will never
+    // add a tab to a locked tab group.
+    // This is especially problematic because locking the tab group of the InfoView
+    // is a workaround for https://github.com/microsoft/vscode/issues/212679
+    // and using `ViewColumn.Beside` will retain an empty locked tab group when restarting VS Code.
+    const activeColumn = window.activeTextEditor?.viewColumn
+    if (activeColumn === undefined) {
+        return ViewColumn.Two
+    }
+    return activeColumn + 1
 }
 
 export function viewColumnOfActiveTextEditor(): ViewColumn {


### PR DESCRIPTION
- Fixes a bug where InfoView would not appear in locked tab group after restarting VS Code
- Adds a command to the forall menu for re-displaying a sticky setup error in case it was closed by accident and users have no clue how to re-open it (by selecting a new Lean tab)