### PR TITLE
feat: [lean4web] abstract lean client setup for websocket clients

### DIFF
--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -10,6 +10,7 @@ import { PreconditionCheckResult, SetupNotificationOptions } from './diagnostics
 import { AlwaysEnabledFeatures, Exports, Lean4EnabledFeatures } from './exports'
 import { InfoProvider } from './infoview'
 import { LeanClient } from './leanclient'
+import { setupClient } from './leanclientsetup'
 import { LoogleView } from './loogleview'
 import { ManualView } from './manualview'
 import { MoogleView } from './moogleview'
@@ -177,7 +178,7 @@ async function activateLean4Features(
     installer: LeanInstaller,
     elanCommandProvider: ElanCommandProvider,
 ): Promise<Lean4EnabledFeatures> {
-    const clientProvider = new LeanClientProvider(installer, installer.getOutputChannel())
+    const clientProvider = new LeanClientProvider(installer, installer.getOutputChannel(), setupClient)
     elanCommandProvider.setClientProvider(clientProvider)
     context.subscriptions.push(clientProvider)
 

--- a/vscode-lean4/src/leanclientsetup.ts
+++ b/vscode-lean4/src/leanclientsetup.ts
@@ -1,0 +1,83 @@
+import {
+    ClientCapabilities,
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+    StaticFeature,
+} from 'vscode-languageclient/node'
+import { serverArgs, serverLoggingEnabled, serverLoggingPath } from './config'
+import { patchConverters } from './utils/converters'
+import { ExtUri } from './utils/exturi'
+import { willUseLakeServer } from './utils/projectInfo'
+
+interface LeanClientCapabilties {
+    silentDiagnosticSupport?: boolean | undefined
+}
+
+const leanClientCapabilities: LeanClientCapabilties = {
+    silentDiagnosticSupport: true,
+}
+
+async function determineExecutable(folderUri: ExtUri): Promise<[string, string[]]> {
+    if (await willUseLakeServer(folderUri)) {
+        return ['lake', ['serve', '--']]
+    } else {
+        return ['lean', ['--server']]
+    }
+}
+
+async function determineServerOptions(
+    toolchainOverride: string | undefined,
+    folderUri: ExtUri,
+): Promise<ServerOptions> {
+    const env = Object.assign({}, process.env)
+    if (serverLoggingEnabled()) {
+        env.LEAN_SERVER_LOG_DIR = serverLoggingPath()
+    }
+
+    const [serverExecutable, options] = await determineExecutable(folderUri)
+    if (toolchainOverride) {
+        options.unshift('+' + toolchainOverride)
+    }
+
+    const cwd = folderUri.scheme === 'file' ? folderUri.fsPath : undefined
+    if (cwd) {
+        // Add folder name to command-line so that it shows up in `ps aux`.
+        options.push(cwd)
+    } else {
+        options.push('untitled')
+    }
+
+    return {
+        command: serverExecutable,
+        args: options.concat(serverArgs()),
+        options: {
+            cwd,
+            env,
+        },
+    }
+}
+
+export async function setupClient(
+    toolchainOverride: string | undefined,
+    folderUri: ExtUri,
+    clientOptions: LanguageClientOptions,
+): Promise<LanguageClient> {
+    const serverOptions: ServerOptions = await determineServerOptions(toolchainOverride, folderUri)
+
+    const client = new LanguageClient('lean4', 'Lean 4', serverOptions, clientOptions)
+    const leanCapabilityFeature: StaticFeature = {
+        initialize(_1, _2) {},
+        getState() {
+            return { kind: 'static' }
+        },
+        fillClientCapabilities(capabilities: ClientCapabilities & { lean?: LeanClientCapabilties | undefined }) {
+            capabilities.lean = leanClientCapabilities
+        },
+        dispose() {},
+    }
+    client.registerFeature(leanCapabilityFeature)
+
+    patchConverters(client.protocol2CodeConverter, client.code2ProtocolConverter)
+    return client
+}


### PR DESCRIPTION
This is a pure refactoring. The behavior of the code has not changed.

This allows us to replace local lean clients by websocket lean clients.