### PR TITLE
fix: redundant line breaks in trace messages

### DIFF
--- a/lean4-infoview/package.json
+++ b/lean4-infoview/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@leanprover/infoview",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "An interactive display for the Lean 4 theorem prover.",
     "scripts": {
         "watch": "rollup --config --environment NODE_ENV:development --watch",

--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -58,6 +58,9 @@ body {
 }
 
 /* Interactive traces */
+.trace-line {
+    display: inline-block;
+}
 .trace-line:hover {
     background-color: #dbeeff;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16903,7 +16903,7 @@
         },
         "vscode-lean4": {
             "name": "lean4",
-            "version": "0.0.189",
+            "version": "0.0.191",
             "license": "Apache-2.0",
             "dependencies": {
                 "@leanprover/infoview": "~0.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         },
         "lean4-infoview": {
             "name": "@leanprover/infoview",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@leanprover/infoview-api": "~0.5.0",


### PR DESCRIPTION
This PR ensures that there are no redundant line breaks when the trace formatter is including a newline at the end of a trace line. 

Example (from `whnfProj.lean`):
```lean
import Lean

def h (x : Nat) := x
def f (x : Nat) := x + 1
def g (x : Nat) := (x, x+1).fst


open Lean
open Lean.Meta

def tst (declName : Name) : MetaM Unit := do
  let c ← getConstInfo declName
  lambdaTelescope c.value! fun _ b => do
    trace[Meta.debug] "1. {b}"
    trace[Meta.debug] "2. {← withReducible <| whnf b}"
    trace[Meta.debug] "3. {← withReducibleAndInstances <| whnf b}"
    trace[Meta.debug] "4. {← withDefault <| whnf b}"
    pure ()

set_option trace.Meta.debug true
#eval tst `f
#eval tst `g
```