### PR TITLE
fix: only prevent default for `tab` if it replaces something

### DIFF
--- a/lean4-unicode-input-component/package.json
+++ b/lean4-unicode-input-component/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@leanprover/unicode-input-component",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Typescript support for contenteditable divs with the Unicode input support of the Lean 4 theorem prover",
     "scripts": {
         "watch": "tsc --watch",

--- a/lean4-unicode-input-component/src/index.ts
+++ b/lean4-unicode-input-component/src/index.ts
@@ -187,9 +187,12 @@ export class InputAbbreviationRewriter implements AbbreviationTextSource {
         })
 
         textInput.addEventListener('keydown', async (ev: KeyboardEvent) => {
-            if (ev.key === 'Tab') {
+            if (ev.key === 'Tab' && this.rewriter.getTrackedAbbreviations().size > 0) {
                 await this.rewriter.replaceAllTrackedAbbreviations()
                 this.updateState()
+                // Don't send event to any other listeners, it was handled here.
+                ev.stopImmediatePropagation()
+                // Don't move focus to the next element.
                 ev.preventDefault()
             }
         })


### PR DESCRIPTION
I tried to use this component, but it prevents accessibility because it prevents default for all `tab` clicks.