### PR TITLE
chore: document white-space fix for firefox

### DIFF
--- a/lean4-unicode-input-component/README.md
+++ b/lean4-unicode-input-component/README.md
@@ -2,6 +2,7 @@
 1. Add a new `contenteditable` div to your HTML that serves as the input: `<div id="unicode-input" contenteditable="true"></div>`
 2. Import `InputAbbreviationRewriter` from this package and create a new `InputAbbreviationRewriter` for `#unicode-input`
 3. Make sure to call `InputAbbreviationRewriter.resetAbbreviations` whenever setting the text of `#unicode-input` programmatically, as the `InputAbbreviationRewriter` only triggers on actual user input
-4. Style `#unicode-input` to your liking
+4. Add `white-space: -moz-pre-space` to `#unicode-input`, otherwise there's an error with multiple spaces on Firefox.
+5. Style `#unicode-input` to your liking
 
 This component only supports single-line input and no rich text styling other than the abbreviation highlighting.


### PR DESCRIPTION
Came across this while I tried to use the input. Took me a while to figure out why it wasn't behaving like on https://loogle.lean-lang.org/, so I think the fix should be documented.