### PR TITLE
chore: revert #571

### DIFF
--- a/lean4-infoview/package.json
+++ b/lean4-infoview/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@leanprover/infoview",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "An interactive display for the Lean 4 theorem prover.",
     "scripts": {
         "watch": "rollup --config --environment NODE_ENV:development --watch",

--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -58,9 +58,6 @@ body {
 }
 
 /* Interactive traces */
-.trace-line {
-    display: inline-block;
-}
 .trace-line:hover {
     background-color: #dbeeff;
 }


### PR DESCRIPTION
This PR reverts #571 because it could sometimes cause trace messages to be formatted incorrectly. The proper fix for this issue is leanprover/lean4#7143.

On Lean versions before leanprover/lean4#7143, this PR will simply cause some trace messages to contain redundant newlines again. After leanprover/lean4#7143, these newlines will be gone, and trace messages will be formatted correctly.