### PR TITLE
chore: bump unicode input versions again

### DIFF
--- a/lean4-unicode-input-component/package.json
+++ b/lean4-unicode-input-component/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@leanprover/unicode-input-component",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Typescript support for contenteditable divs with the Unicode input support of the Lean 4 theorem prover",
     "scripts": {
         "watch": "tsc --watch",
@@ -14,7 +14,7 @@
     ],
     "license": "Apache-2.0",
     "dependencies": {
-        "@leanprover/unicode-input": "^0.1.1"
+        "@leanprover/unicode-input": "^0.1.2"
     },
     "devDependencies": {
         "typescript": "^5.4.5"

--- a/lean4-unicode-input/package.json
+++ b/lean4-unicode-input/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@leanprover/unicode-input",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Unicode input mechanism for the Lean 4 theorem prover",
     "scripts": {
         "watch": "tsc --watch",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         },
         "lean4-infoview": {
             "name": "@leanprover/infoview",
-            "version": "0.8.1",
+            "version": "0.8.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@leanprover/infoview-api": "~0.5.0",
@@ -76,7 +76,7 @@
         },
         "lean4-unicode-input": {
             "name": "@leanprover/unicode-input",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "license": "Apache-2.0",
             "devDependencies": {
                 "typescript": "^5.4.5"
@@ -84,10 +84,10 @@
         },
         "lean4-unicode-input-component": {
             "name": "@leanprover/unicode-input-component",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@leanprover/unicode-input": "^0.1.1"
+                "@leanprover/unicode-input": "^0.1.2"
             },
             "devDependencies": {
                 "typescript": "^5.4.5"
@@ -16903,13 +16903,13 @@
         },
         "vscode-lean4": {
             "name": "lean4",
-            "version": "0.0.194",
+            "version": "0.0.195",
             "license": "Apache-2.0",
             "dependencies": {
                 "@leanprover/infoview": "~0.8.0",
                 "@leanprover/infoview-api": "~0.5.0",
-                "@leanprover/unicode-input": "~0.1.1",
-                "@leanprover/unicode-input-component": "~0.1.1",
+                "@leanprover/unicode-input": "~0.1.2",
+                "@leanprover/unicode-input-component": "~0.1.2",
                 "@vscode-elements/elements": "^1.7.1",
                 "@vscode/codicons": "^0.0.36",
                 "markdown-it": "^14.1.0",

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -1083,8 +1083,8 @@
     "dependencies": {
         "@leanprover/infoview": "~0.8.0",
         "@leanprover/infoview-api": "~0.5.0",
-        "@leanprover/unicode-input": "~0.1.1",
-        "@leanprover/unicode-input-component": "~0.1.1",
+        "@leanprover/unicode-input": "~0.1.2",
+        "@leanprover/unicode-input-component": "~0.1.2",
         "@vscode/codicons": "^0.0.36",
         "@vscode-elements/elements": "^1.7.1",
         "markdown-it": "^14.1.0",


### PR DESCRIPTION
The 0.1.1 versions of both packages lacked a `dist` directory. Thanks to @joneugster for noticing.