### PR TITLE
fix: use 1ch unsolved goal padding instead of 1em

### DIFF
--- a/vscode-lean4/src/taskgutter.ts
+++ b/vscode-lean4/src/taskgutter.ts
@@ -467,14 +467,14 @@ export class LeanTaskGutter implements Disposable {
                 after: {
                     contentText: '🛠',
                     color: unsolvedGoalsDecorationDarkThemeColor(),
-                    margin: '0 0 0 1em',
+                    margin: '0 0 0 1ch',
                 },
             },
             light: {
                 after: {
                     contentText: '🛠',
                     color: unsolvedGoalsDecorationLightThemeColor(),
-                    margin: '0 0 0 1em',
+                    margin: '0 0 0 1ch',
                 },
             },
             isWholeLine: true,


### PR DESCRIPTION
I somehow reverted this by accident during testing. `1ch` of padding feels much more consistent for the unsolved goal symbol.