### PR TITLE
feat: expose client-side language server logging in config

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -95,6 +95,17 @@
                         "description": "an argument to pass to the server"
                     }
                 },
+                "lean4.trace.server": {
+                    "type": "string",
+                    "default": "off",
+                    "enum": [
+                        "off",
+                        "messages",
+                        "compact",
+                        "verbose"
+                    ],
+                    "markdownDescription": "Whether to enable client-side logging for language server messages."
+                },
                 "lean4.serverLogging.enabled": {
                     "type": "boolean",
                     "default": false,


### PR DESCRIPTION
The language client library has a very convenient setting for tracing language server messages on the client-side, but I'm getting tired of having to edit the `settings.json` to use it. This PR exposes the client-side logging setting in the vscode-lean4 config.