### PR TITLE
feat: add `\tiny` and `\miny` for `⧾` and `⧿`

### DIFF
--- a/lean4-unicode-input/src/abbreviations.json
+++ b/lean4-unicode-input/src/abbreviations.json
@@ -1830,5 +1830,7 @@
     "goal": "⊢",
     "Vdash": "⊩",
     "Vert": "‖",
-    "Vvdash": "⊪"
+    "Vvdash": "⊪",
+    "tiny": "⧾",
+    "miny": "⧿"
 }


### PR DESCRIPTION
These symbols are in use within combinatorial game theory, and are used in the [CGT repo](https://github.com/vihdzp/combinatorial-games).