### PR TITLE
feat: adjust edit delay and make it configurable

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -218,6 +218,11 @@
                     ],
                     "default": "Double Checkmark",
                     "markdownDescription": "Style of icon used in 'Goals accomplished' decoration."
+                },
+                "lean4.decorationEditDelay": {
+                    "type": "number",
+                    "default": 750,
+                    "markdownDescription": "Delay after an edit in milliseconds until certain editor decorations (like the 'unsolved goals' decoration) update."
                 }
             }
         },

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -129,6 +129,10 @@ export function goalsAccomplishedDecorationKind(): string {
     return workspace.getConfiguration('lean4').get('goalsAccomplishedDecorationKind', 'Double Checkmark')
 }
 
+export function decorationEditDelay(): number {
+    return workspace.getConfiguration('lean4').get('decorationEditDelay', 750)
+}
+
 export function isRunningTest(): boolean {
     return typeof process.env.LEAN4_TEST_FOLDER === 'string'
 }


### PR DESCRIPTION
This PR makes the edit delay for the "unsolved goal" decoration adjustable for testing purposes, reduces it to 750ms and fixes a bug that caused the decoration to sometimes be displayed in the wrong location for a moment.