### PR TITLE
feat: theme colors in 'unsolved goals' decoration

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -199,13 +199,13 @@
                 },
                 "lean4.unsolvedGoalsDecorationLightThemeColor": {
                     "type": "string",
-                    "default": "#1A85FF88",
-                    "markdownDescription": "Color used in unsolved goal decorations when using a light theme."
+                    "default": "editorInfo.foreground",
+                    "markdownDescription": "Color used in unsolved goal decorations when using a light theme. Can either denote a CSS color or a [VS Code theme color](https://code.visualstudio.com/api/references/theme-color)."
                 },
                 "lean4.unsolvedGoalsDecorationDarkThemeColor": {
                     "type": "string",
-                    "default": "#3794FF88",
-                    "markdownDescription": "Color used in unsolved goal decorations when using a dark theme."
+                    "default": "editorInfo.foreground",
+                    "markdownDescription": "Color used in unsolved goal decorations when using a dark theme. Can either denote a CSS color or a [VS Code theme color](https://code.visualstudio.com/api/references/theme-color)."
                 },
                 "lean4.goalsAccomplishedDecorationKind": {
                     "type": "string",

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -1,9 +1,13 @@
-import { ConfigurationTarget, workspace } from 'vscode'
+import { ConfigurationTarget, ThemeColor, workspace } from 'vscode'
 import { elanStableChannel } from './utils/elan'
 import { PATH } from './utils/envPath'
 
-// TODO: does currently not contain config options for `./abbreviation`
-// so that it is easy to keep it in sync with vscode-lean.
+function processConfigColor(c: string): ThemeColor | string {
+    if (c.match(/^(#|rgb\(|rgba\(|hsl\(|hsla\()/)) {
+        return c
+    }
+    return new ThemeColor(c)
+}
 
 export function getPowerShellPath(): string {
     const windir = process.env.windir
@@ -117,12 +121,16 @@ export function showUnsolvedGoalsDecoration(): boolean {
     return workspace.getConfiguration('lean4').get('showUnsolvedGoalsDecoration', true)
 }
 
-export function unsolvedGoalsDecorationLightThemeColor(): string {
-    return workspace.getConfiguration('lean4').get('unsolvedGoalsDecorationLightThemeColor', '#1A85FF88')
+export function unsolvedGoalsDecorationLightThemeColor(): ThemeColor | string {
+    return processConfigColor(
+        workspace.getConfiguration('lean4').get('unsolvedGoalsDecorationLightThemeColor', 'editorInfo.foreground'),
+    )
 }
 
-export function unsolvedGoalsDecorationDarkThemeColor(): string {
-    return workspace.getConfiguration('lean4').get('unsolvedGoalsDecorationDarkThemeColor', '#3794FF88')
+export function unsolvedGoalsDecorationDarkThemeColor(): ThemeColor | string {
+    return processConfigColor(
+        workspace.getConfiguration('lean4').get('unsolvedGoalsDecorationDarkThemeColor', 'editorInfo.foreground'),
+    )
 }
 
 export function goalsAccomplishedDecorationKind(): string {


### PR DESCRIPTION
This PR allows theme colors in the color settings for the 'unsolved goals' decoration and changes the default color of the 'unsolved goals' decoration to `editorInfo.foreground`.