### PR TITLE
feat: add uri handler for the setup-guide

### DIFF
--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -1,6 +1,6 @@
 import * as os from 'os'
 import * as path from 'path'
-import { commands, ExtensionContext, extensions, TextDocument, window, workspace } from 'vscode'
+import { commands, ExtensionContext, extensions, TextDocument, Uri, window, workspace } from 'vscode'
 import { AbbreviationFeature } from './abbreviation/AbbreviationFeature'
 import { AbbreviationView } from './abbreviationview'
 import { getDefaultLeanVersion } from './config'
@@ -151,6 +151,14 @@ function activateAlwaysEnabledFeatures(context: ExtensionContext): AlwaysEnabled
 
     const elanCommandProvider = new ElanCommandProvider(outputChannel)
     context.subscriptions.push(elanCommandProvider)
+
+    window.registerUriHandler({
+        async handleUri(uri: Uri) {
+            if (uri.path === '/setup-guide') {
+                await commands.executeCommand('lean4.docs.showSetupGuide')
+            }
+        },
+    })
 
     return { projectInitializationProvider, outputChannel, installer, fullDiagnosticsProvider, elanCommandProvider }
 }

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -1,6 +1,6 @@
 import * as os from 'os'
 import * as path from 'path'
-import { commands, ExtensionContext, extensions, TextDocument, Uri, window, workspace } from 'vscode'
+import { commands, ExtensionContext, extensions, TextDocument, window, workspace } from 'vscode'
 import { AbbreviationFeature } from './abbreviation/AbbreviationFeature'
 import { AbbreviationView } from './abbreviationview'
 import { getDefaultLeanVersion } from './config'
@@ -34,6 +34,7 @@ import {
 } from './utils/notifs'
 import { PathExtensionProvider } from './utils/pathExtensionProvider'
 import { findLeanProjectRoot } from './utils/projectInfo'
+import { UriHandlerService } from './utils/uriHandlerService'
 
 async function setLeanFeatureSetActive(isActive: boolean) {
     await commands.executeCommand('setContext', 'lean4.isLeanFeatureSetActive', isActive)
@@ -152,13 +153,8 @@ function activateAlwaysEnabledFeatures(context: ExtensionContext): AlwaysEnabled
     const elanCommandProvider = new ElanCommandProvider(outputChannel)
     context.subscriptions.push(elanCommandProvider)
 
-    window.registerUriHandler({
-        async handleUri(uri: Uri) {
-            if (uri.path === '/setup-guide') {
-                await commands.executeCommand('lean4.docs.showSetupGuide')
-            }
-        },
-    })
+    const uriHandlerService = new UriHandlerService()
+    context.subscriptions.push(uriHandlerService)
 
     return { projectInitializationProvider, outputChannel, installer, fullDiagnosticsProvider, elanCommandProvider }
 }

--- a/vscode-lean4/src/utils/uriHandlerService.ts
+++ b/vscode-lean4/src/utils/uriHandlerService.ts
@@ -1,0 +1,27 @@
+import { commands, Disposable, Uri, window } from 'vscode'
+
+export class UriHandlerService implements Disposable {
+    private subscriptions: Disposable[] = []
+
+    constructor() {
+        this.registerUriHandler()
+    }
+
+    dispose(): void {
+        for (const s of this.subscriptions) {
+            s.dispose()
+        }
+    }
+
+    private registerUriHandler() {
+        this.subscriptions.push(
+            window.registerUriHandler({
+                async handleUri(uri: Uri) {
+                    if (uri.path === '/setup-guide') {
+                        await commands.executeCommand('lean4.docs.showSetupGuide')
+                    }
+                },
+            }),
+        )
+    }
+}


### PR DESCRIPTION
I’m not certain whether this is the best place to add a new `registerUriHandler`. However, it's a hook for the URI `vscode://leanprover.lean4/setup-guide`, which will open the setup guide. This is useful for future documentation in the web, especially when detailing the installation process.