### PR TITLE
feat: revamp infoview options and actions

### DIFF
--- a/lean4-infoview-api/package.json
+++ b/lean4-infoview-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@leanprover/infoview-api",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "description": "Types and API for @leanprover/infoview.",
     "scripts": {
         "watch": "tsc --watch",

--- a/lean4-infoview-api/src/infoviewApi.ts
+++ b/lean4-infoview-api/src/infoviewApi.ts
@@ -19,7 +19,7 @@ export interface InfoviewConfig {
     reverseTacticState: boolean
     hideTypeAssumptions: boolean
     hideInstanceAssumptions: boolean
-    hideHiddenAssumptions: boolean
+    hideInaccessibleAssumptions: boolean
     hideLetValues: boolean
     showTooltipOnHover: boolean
 }
@@ -106,7 +106,7 @@ export const defaultInfoviewConfig: InfoviewConfig = {
     reverseTacticState: false,
     hideTypeAssumptions: false,
     hideInstanceAssumptions: false,
-    hideHiddenAssumptions: false,
+    hideInaccessibleAssumptions: false,
     hideLetValues: false,
     showTooltipOnHover: true,
 }
@@ -140,8 +140,8 @@ export type ContextMenuEntry =
     | 'showTypeAssumptions'
     | 'hideInstanceAssumptions'
     | 'showInstanceAssumptions'
-    | 'hideHiddenAssumptions'
-    | 'showHiddenAssumptions'
+    | 'hideInaccessibleAssumptions'
+    | 'showInaccessibleAssumptions'
     | 'hideLetValues'
     | 'showLetValues'
     | 'hideGoalNames'

--- a/lean4-infoview-api/src/infoviewApi.ts
+++ b/lean4-infoview-api/src/infoviewApi.ts
@@ -17,10 +17,10 @@ export interface InfoviewConfig {
     showGoalNames: boolean
     emphasizeFirstGoal: boolean
     reverseTacticState: boolean
-    filterTypes: boolean
-    filterInstances: boolean
-    filterHiddenAssumptions: boolean
-    filterLetValues: boolean
+    hideTypeAssumptions: boolean
+    hideInstanceAssumptions: boolean
+    hideHiddenAssumptions: boolean
+    hideLetValues: boolean
     showTooltipOnHover: boolean
 }
 
@@ -104,10 +104,10 @@ export const defaultInfoviewConfig: InfoviewConfig = {
     showGoalNames: true,
     emphasizeFirstGoal: false,
     reverseTacticState: false,
-    filterTypes: false,
-    filterInstances: false,
-    filterHiddenAssumptions: false,
-    filterLetValues: false,
+    hideTypeAssumptions: false,
+    hideInstanceAssumptions: false,
+    hideHiddenAssumptions: false,
+    hideLetValues: false,
     showTooltipOnHover: true,
 }
 
@@ -136,18 +136,18 @@ export type ContextMenuEntry =
     | 'goToMessageLocation'
     | 'displayTargetBeforeAssumptions'
     | 'displayAssumptionsBeforeTarget'
+    | 'hideTypeAssumptions'
+    | 'showTypeAssumptions'
+    | 'hideInstanceAssumptions'
+    | 'showInstanceAssumptions'
+    | 'hideHiddenAssumptions'
+    | 'showHiddenAssumptions'
+    | 'hideLetValues'
+    | 'showLetValues'
     | 'hideGoalNames'
     | 'showGoalNames'
     | 'emphasizeFirstGoal'
     | 'deemphasizeFirstGoal'
-    | 'filterTypes'
-    | 'showTypes'
-    | 'filterInstances'
-    | 'showInstances'
-    | 'filterHiddenAssumptions'
-    | 'showHiddenAssumptions'
-    | 'filterLetValues'
-    | 'showLetValues'
     | 'saveSettings'
 
 export interface ContextMenuAction {

--- a/lean4-infoview-api/src/infoviewApi.ts
+++ b/lean4-infoview-api/src/infoviewApi.ts
@@ -7,6 +7,23 @@ import type {
     WorkspaceEdit,
 } from 'vscode-languageserver-protocol'
 
+export type ExpectedTypeVisibility = 'Expanded by default' | 'Collapsed by default' | 'Hidden'
+
+export interface InfoviewConfig {
+    allErrorsOnLine: boolean
+    autoOpenShowsGoal: boolean
+    debounceTime: number
+    expectedTypeVisibility: ExpectedTypeVisibility
+    showGoalNames: boolean
+    emphasizeFirstGoal: boolean
+    reverseTacticState: boolean
+    filterTypes: boolean
+    filterInstances: boolean
+    filterHiddenAssumptions: boolean
+    filterLetValues: boolean
+    showTooltipOnHover: boolean
+}
+
 /**
  * An insert `here` should be written exactly at the specified position,
  * while one `above` should go on the preceding line.
@@ -15,6 +32,8 @@ export type TextInsertKind = 'here' | 'above'
 
 /** Interface that the InfoView WebView uses to talk to the hosting editor. */
 export interface EditorApi {
+    saveConfig(config: InfoviewConfig): Promise<any>
+
     /** Make a request to the LSP server. */
     sendClientRequest(uri: string, method: string, params: any): Promise<any>
     /** Send a notification to the LSP server. */
@@ -77,25 +96,18 @@ export interface InfoviewTacticStateFilter {
     flags: string
 }
 
-export interface InfoviewConfig {
-    allErrorsOnLine: boolean
-    autoOpenShowsGoal: boolean
-    debounceTime: number
-    showExpectedType: boolean
-    showGoalNames: boolean
-    emphasizeFirstGoal: boolean
-    reverseTacticState: boolean
-    showTooltipOnHover: boolean
-}
-
 export const defaultInfoviewConfig: InfoviewConfig = {
     allErrorsOnLine: true,
     autoOpenShowsGoal: true,
     debounceTime: 50,
-    showExpectedType: true,
+    expectedTypeVisibility: 'Expanded by default',
     showGoalNames: true,
     emphasizeFirstGoal: false,
     reverseTacticState: false,
+    filterTypes: false,
+    filterInstances: false,
+    filterHiddenAssumptions: false,
+    filterLetValues: false,
     showTooltipOnHover: true,
 }
 
@@ -108,7 +120,35 @@ export type InfoviewActionKind =
 
 export type InfoviewAction = { kind: InfoviewActionKind }
 
-export type ContextMenuEntry = 'goToDefinition' | 'select' | 'unselect' | 'unselectAll'
+export type ContextMenuEntry =
+    | 'goToDefinition'
+    | 'select'
+    | 'unselect'
+    | 'unselectAll'
+    | 'pause'
+    | 'unpause'
+    | 'pin'
+    | 'unpin'
+    | 'refresh'
+    | 'pauseAllMessages'
+    | 'unpauseAllMessages'
+    | 'goToPinnedLocation'
+    | 'goToMessageLocation'
+    | 'displayTargetBeforeAssumptions'
+    | 'displayAssumptionsBeforeTarget'
+    | 'hideGoalNames'
+    | 'showGoalNames'
+    | 'emphasizeFirstGoal'
+    | 'deemphasizeFirstGoal'
+    | 'filterTypes'
+    | 'showTypes'
+    | 'filterInstances'
+    | 'showInstances'
+    | 'filterHiddenAssumptions'
+    | 'showHiddenAssumptions'
+    | 'filterLetValues'
+    | 'showLetValues'
+    | 'saveSettings'
 
 export interface ContextMenuAction {
     entry: ContextMenuEntry

--- a/lean4-infoview/package.json
+++ b/lean4-infoview/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@leanprover/infoview",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "An interactive display for the Lean 4 theorem prover.",
     "scripts": {
         "watch": "rollup --config --environment NODE_ENV:development --watch",
@@ -49,7 +49,7 @@
         "typescript": "^5.4.5"
     },
     "dependencies": {
-        "@leanprover/infoview-api": "~0.6.0",
+        "@leanprover/infoview-api": "~0.7.0",
         "@vscode/codicons": "^0.0.32",
         "@vscode-elements/react-elements": "^0.5.0",
         "es-module-lexer": "^1.5.4",

--- a/lean4-infoview/src/infoview/collapsing.tsx
+++ b/lean4-infoview/src/infoview/collapsing.tsx
@@ -26,7 +26,7 @@ export function useIsVisible(): [(element: HTMLElement) => void, boolean] {
     return [node, isVisible]
 }
 
-interface DetailsProps {
+interface DetailsProps extends React.PropsWithoutRef<React.HTMLProps<HTMLDetailsElement>> {
     initiallyOpen?: boolean
     children: [React.ReactNode, ...React.ReactNode[]]
     setOpenRef?: (_: React.Dispatch<React.SetStateAction<boolean>>) => void
@@ -34,11 +34,16 @@ interface DetailsProps {
 
 /** Like `<details>` but can be programatically revealed using `setOpenRef`.
  * The first child is placed inside the `<summary>` node. */
-export function Details({ initiallyOpen, children: [summary, ...children], setOpenRef }: DetailsProps): JSX.Element {
+export function Details({
+    initiallyOpen,
+    children: [summary, ...children],
+    setOpenRef,
+    ...props
+}: DetailsProps): JSX.Element {
     const [isOpen, setOpen] = React.useState<boolean>(initiallyOpen === undefined ? false : initiallyOpen)
     if (setOpenRef) setOpenRef(setOpen)
     return (
-        <details open={isOpen}>
+        <details open={isOpen} {...props}>
             <summary
                 className="mv2 pointer "
                 onClick={e => {

--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -71,7 +71,7 @@ function goalSettingsStateOfConfig(config: InfoviewConfig): GoalSettingsState {
         emphasizeFirstGoal: config.emphasizeFirstGoal,
         showType: !config.hideTypeAssumptions,
         showInstance: !config.hideInstanceAssumptions,
-        showHiddenAssumption: !config.hideHiddenAssumptions,
+        showHiddenAssumption: !config.hideInaccessibleAssumptions,
         showLetValue: !config.hideLetValues,
     }
 }
@@ -328,7 +328,7 @@ export const FilteredGoals = React.memo(
                 emphasizeFirstGoal: goalSettings.emphasizeFirstGoal,
                 hideTypeAssumptions: !goalSettings.showType,
                 hideInstanceAssumptions: !goalSettings.showInstance,
-                hideHiddenAssumptions: !goalSettings.showHiddenAssumption,
+                hideInaccessibleAssumptions: !goalSettings.showHiddenAssumption,
                 hideLetValues: !goalSettings.showLetValue,
             })
         }, [config, ec.api, goalSettings])
@@ -377,7 +377,7 @@ export const FilteredGoals = React.memo(
                 {mkSettingButton(
                     s => ({ ...s, showHiddenAssumption: !s.showHiddenAssumption }),
                     gs => !gs.showHiddenAssumption,
-                    'Hide hidden assumptions',
+                    'Hide inaccessible assumptions',
                 )}
                 <br />
                 {mkSettingButton(
@@ -438,12 +438,12 @@ export const FilteredGoals = React.memo(
         useSettingsContextMenuEvent('hideInstanceAssumptions', { showInstance: false }, goalSettings.showInstance)
         useSettingsContextMenuEvent('showInstanceAssumptions', { showInstance: true }, !goalSettings.showInstance)
         useSettingsContextMenuEvent(
-            'hideHiddenAssumptions',
+            'hideInaccessibleAssumptions',
             { showHiddenAssumption: false },
             goalSettings.showHiddenAssumption,
         )
         useSettingsContextMenuEvent(
-            'showHiddenAssumptions',
+            'showInaccessibleAssumptions',
             { showHiddenAssumption: true },
             !goalSettings.showHiddenAssumption,
         )

--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -1,5 +1,6 @@
 import {
     InfoviewActionKind,
+    InfoviewConfig,
     InteractiveGoal,
     InteractiveGoals,
     InteractiveHypothesisBundle,
@@ -46,9 +47,13 @@ export function goalsToString(goals: InteractiveGoals): string {
     return goals.goals.map(goalToString).join('\n\n')
 }
 
-interface GoalFilterState {
+interface GoalSettingsState {
     /** If true reverse the list of hypotheses, if false present the order received from LSP. */
     reverse: boolean
+    /** If true hide the names of goals, otherwise show them. */
+    hideGoalNames: boolean
+    /** If true emphasize the first goal, otherwise don't emphasize it. */
+    emphasizeFirstGoal: boolean
     /** If true show hypotheses that have isType=True, otherwise hide them. */
     showType: boolean
     /** If true show hypotheses that have isInstance=True, otherwise hide them. */
@@ -59,15 +64,27 @@ interface GoalFilterState {
     showLetValue: boolean
 }
 
+function goalSettingsStateOfConfig(config: InfoviewConfig): GoalSettingsState {
+    return {
+        reverse: config.reverseTacticState,
+        hideGoalNames: !config.showGoalNames,
+        emphasizeFirstGoal: config.emphasizeFirstGoal,
+        showType: !config.filterTypes,
+        showInstance: !config.filterInstances,
+        showHiddenAssumption: !config.filterHiddenAssumptions,
+        showLetValue: !config.filterLetValues,
+    }
+}
+
 function getFilteredHypotheses(
     hyps: InteractiveHypothesisBundle[],
-    filter: GoalFilterState,
+    settings: GoalSettingsState,
 ): InteractiveHypothesisBundle[] {
     return hyps.reduce((acc: InteractiveHypothesisBundle[], h) => {
-        if (h.isInstance && !filter.showInstance) return acc
-        if (h.isType && !filter.showType) return acc
-        const names = filter.showHiddenAssumption ? h.names : h.names.filter(n => !isInaccessibleName(n))
-        const hNew: InteractiveHypothesisBundle = filter.showLetValue
+        if (h.isInstance && !settings.showInstance) return acc
+        if (h.isType && !settings.showType) return acc
+        const names = settings.showHiddenAssumption ? h.names : h.names.filter(n => !isInaccessibleName(n))
+        const hNew: InteractiveHypothesisBundle = settings.showLetValue
             ? { ...h, names }
             : { ...h, names, val: undefined }
         if (names.length !== 0) acc.push(hNew)
@@ -181,7 +198,7 @@ function Hyp({ hyp: h, mvarId }: HypProps) {
 
 interface GoalProps {
     goal: InteractiveGoal
-    filter: GoalFilterState
+    settings: GoalSettingsState
     additionalClassNames: string
 }
 
@@ -189,12 +206,12 @@ interface GoalProps {
  * Displays the hypotheses, target type and optional case label of a goal according to the
  * provided `filter`. */
 export const Goal = React.memo((props: GoalProps) => {
-    const { goal, filter, additionalClassNames } = props
+    const { goal, settings, additionalClassNames } = props
     const config = React.useContext(ConfigContext)
 
     const prefix = goal.goalPrefix ?? '⊢ '
-    const filteredList = getFilteredHypotheses(goal.hyps, filter)
-    const hyps = filter.reverse ? filteredList.slice().reverse() : filteredList
+    const filteredList = getFilteredHypotheses(goal.hyps, settings)
+    const hyps = settings.reverse ? filteredList.slice().reverse() : filteredList
     const locs = React.useContext(LocationsContext)
     const goalLocs = React.useMemo(
         () =>
@@ -217,12 +234,12 @@ export const Goal = React.memo((props: GoalProps) => {
     if (props.goal.isRemoved) cn += ' b--removed '
 
     const children: React.ReactNode[] = [
-        filter.reverse && goalLi,
+        settings.reverse && goalLi,
         hyps.map((h, i) => <Hyp hyp={h} mvarId={goal.mvarId} key={i} />),
-        !filter.reverse && goalLi,
+        !settings.reverse && goalLi,
     ]
 
-    if (goal.userName && config.showGoalNames) {
+    if (goal.userName && !settings.hideGoalNames) {
         return (
             <details open className={cn}>
                 <summary className="mv1 pointer">
@@ -237,12 +254,12 @@ export const Goal = React.memo((props: GoalProps) => {
 
 interface GoalsProps {
     goals: InteractiveGoals
-    filter: GoalFilterState
+    settings: GoalSettingsState
     /** Whether or not to display the number of goals. */
     displayCount: boolean
 }
 
-function Goals({ goals, filter, displayCount }: GoalsProps) {
+function Goals({ goals, settings, displayCount }: GoalsProps) {
     const nGoals = goals.goals.length
     const config = React.useContext(ConfigContext)
     if (nGoals === 0) {
@@ -260,8 +277,8 @@ function Goals({ goals, filter, displayCount }: GoalsProps) {
                     <Goal
                         key={i}
                         goal={g}
-                        filter={filter}
-                        additionalClassNames={i !== 0 && config.emphasizeFirstGoal ? unemphasizeCn : ''}
+                        settings={settings}
+                        additionalClassNames={i !== 0 && settings.emphasizeFirstGoal ? unemphasizeCn : ''}
                     />
                 ))}
             </>
@@ -295,50 +312,41 @@ export const FilteredGoals = React.memo(
         const ec = React.useContext(EditorContext)
         const config = React.useContext(ConfigContext)
 
-        const copyToCommentButton = (
-            <a
-                className="link pointer mh2 dim codicon codicon-quote"
-                data-id="copy-goal-to-comment"
-                onClick={_ => {
-                    if (goals) void ec.copyToComment(goalsToString(goals))
-                }}
-                title="copy state to comment"
-            />
-        )
+        const [goalSettings, setGoalSettings] = React.useState<GoalSettingsState>(goalSettingsStateOfConfig(config))
 
-        const [goalFilters, setGoalFilters] = React.useState<GoalFilterState>({
-            reverse: config.reverseTacticState,
-            showType: true,
-            showInstance: true,
-            showHiddenAssumption: true,
-            showLetValue: true,
-        })
-        const sortClasses =
-            'link pointer mh2 dim codicon ' + (goalFilters.reverse ? 'codicon-arrow-up ' : 'codicon-arrow-down ')
-        const sortButton = (
-            <a
-                className={sortClasses}
-                title="reverse list"
-                onClick={_ => {
-                    setGoalFilters(s => ({ ...s, reverse: !s.reverse }))
-                }}
-            />
-        )
+        const goalSettingsDifferFromDefaultConfig =
+            JSON.stringify(goalSettings) !== JSON.stringify(goalSettingsStateOfConfig(config))
+        const disabledSaveStyle: React.CSSProperties = goalSettingsDifferFromDefaultConfig
+            ? {}
+            : { color: 'var(--vscode-disabledForeground)', pointerEvents: 'none' }
 
-        const mkFilterButton = (
-            filterFn: React.SetStateAction<GoalFilterState>,
-            filledFn: (_: GoalFilterState) => boolean,
+        const saveConfig = React.useCallback(async () => {
+            await ec.api.saveConfig({
+                ...config,
+                reverseTacticState: goalSettings.reverse,
+                showGoalNames: !goalSettings.hideGoalNames,
+                emphasizeFirstGoal: goalSettings.emphasizeFirstGoal,
+                filterTypes: !goalSettings.showType,
+                filterInstances: !goalSettings.showInstance,
+                filterHiddenAssumptions: !goalSettings.showHiddenAssumption,
+                filterLetValues: !goalSettings.showLetValue,
+            })
+        }, [config, ec.api, goalSettings])
+
+        const mkSettingButton = (
+            settingFn: React.SetStateAction<GoalSettingsState>,
+            filledFn: (_: GoalSettingsState) => boolean,
             name: string,
         ) => (
             <a
                 className="link pointer tooltip-menu-content"
                 onClick={_ => {
-                    setGoalFilters(filterFn)
+                    setGoalSettings(settingFn)
                 }}
             >
                 <span
                     className={
-                        'tooltip-menu-icon codicon ' + (filledFn(goalFilters) ? 'codicon-check ' : 'codicon-blank ')
+                        'tooltip-menu-icon codicon ' + (filledFn(goalSettings) ? 'codicon-check ' : 'codicon-blank ')
                     }
                 >
                     &nbsp;
@@ -348,46 +356,112 @@ export const FilteredGoals = React.memo(
         )
         const filterMenu = (
             <span>
-                {mkFilterButton(
+                {mkSettingButton(
+                    s => ({ ...s, reverse: !s.reverse }),
+                    gs => gs.reverse,
+                    'Display target before assumptions',
+                )}
+                <br />
+                {mkSettingButton(
+                    s => ({ ...s, hideGoalNames: !s.hideGoalNames }),
+                    gs => gs.hideGoalNames,
+                    'Hide goal names',
+                )}
+                <br />
+                {mkSettingButton(
+                    s => ({ ...s, emphasizeFirstGoal: !s.emphasizeFirstGoal }),
+                    gs => gs.emphasizeFirstGoal,
+                    'Emphasize first goal',
+                )}
+                <br />
+                {mkSettingButton(
                     s => ({ ...s, showType: !s.showType }),
-                    gf => gf.showType,
-                    'types',
+                    gs => !gs.showType,
+                    'Filter types',
                 )}
                 <br />
-                {mkFilterButton(
+                {mkSettingButton(
                     s => ({ ...s, showInstance: !s.showInstance }),
-                    gf => gf.showInstance,
-                    'instances',
+                    gs => !gs.showInstance,
+                    'Filter instances',
                 )}
                 <br />
-                {mkFilterButton(
+                {mkSettingButton(
                     s => ({ ...s, showHiddenAssumption: !s.showHiddenAssumption }),
-                    gf => gf.showHiddenAssumption,
-                    'hidden assumptions',
+                    gs => !gs.showHiddenAssumption,
+                    'Filter hidden assumptions',
                 )}
                 <br />
-                {mkFilterButton(
+                {mkSettingButton(
                     s => ({ ...s, showLetValue: !s.showLetValue }),
-                    gf => gf.showLetValue,
-                    'let-values',
+                    gs => !gs.showLetValue,
+                    'Filter let-values',
                 )}
+                <br className="saveConfigLineBreak" style={disabledSaveStyle} />
+                <a
+                    className="link pointer tooltip-menu-content saveConfigButton"
+                    style={disabledSaveStyle}
+                    onClick={_ => saveConfig()}
+                >
+                    <span className="tooltip-menu-icon codicon codicon-save">&nbsp;</span>
+                    <span className="tooltip-menu-text">Save current settings to default settings</span>
+                </a>
             </span>
         )
 
-        const isFiltered =
-            !goalFilters.showInstance ||
-            !goalFilters.showType ||
-            !goalFilters.showHiddenAssumption ||
-            !goalFilters.showLetValue
-        const filterButton = (
+        const settingsButton = (
             <WithTooltipOnHover tooltipChildren={filterMenu} className="dim ">
-                <a
-                    className={
-                        'link pointer mh2 codicon ' + (isFiltered ? 'codicon-filter-filled ' : 'codicon-filter ')
-                    }
-                />
+                <a className={'link pointer mh2 codicon codicon-settings-gear'} />
             </WithTooltipOnHover>
         )
+
+        const context: { [k: string]: any } = {}
+        const id = React.useId()
+        const useContextMenuEvent = (
+            name: string,
+            action: () => void,
+            isEnabled: boolean,
+            dependencies?: React.DependencyList,
+        ) => {
+            if (isEnabled) {
+                context[name + 'Id'] = id
+            }
+            useEvent(ec.events.clickedContextMenu, _ => action(), dependencies, `${name}:${id}`)
+        }
+        const useSettingsContextMenuEvent = (name: string, setting: any, isEnabled: boolean) =>
+            useContextMenuEvent(name, () => setGoalSettings(s => ({ ...s, ...setting })), isEnabled)
+
+        useSettingsContextMenuEvent('displayTargetBeforeAssumptions', { reverse: true }, !goalSettings.reverse)
+        useSettingsContextMenuEvent('displayAssumptionsBeforeTarget', { reverse: false }, goalSettings.reverse)
+        useSettingsContextMenuEvent('hideGoalNames', { hideGoalNames: true }, !goalSettings.hideGoalNames)
+        useSettingsContextMenuEvent('showGoalNames', { hideGoalNames: false }, goalSettings.hideGoalNames)
+        useSettingsContextMenuEvent(
+            'emphasizeFirstGoal',
+            { emphasizeFirstGoal: true },
+            !goalSettings.emphasizeFirstGoal,
+        )
+        useSettingsContextMenuEvent(
+            'deemphasizeFirstGoal',
+            { emphasizeFirstGoal: false },
+            goalSettings.emphasizeFirstGoal,
+        )
+        useSettingsContextMenuEvent('filterTypes', { showType: false }, goalSettings.showType)
+        useSettingsContextMenuEvent('showTypes', { showType: true }, !goalSettings.showType)
+        useSettingsContextMenuEvent('filterInstances', { showInstance: false }, goalSettings.showInstance)
+        useSettingsContextMenuEvent('showInstances', { showInstance: true }, !goalSettings.showInstance)
+        useSettingsContextMenuEvent(
+            'filterHiddenAssumptions',
+            { showHiddenAssumption: false },
+            goalSettings.showHiddenAssumption,
+        )
+        useSettingsContextMenuEvent(
+            'showHiddenAssumptions',
+            { showHiddenAssumption: true },
+            !goalSettings.showHiddenAssumption,
+        )
+        useSettingsContextMenuEvent('filterLetValues', { showLetValues: false }, goalSettings.showLetValue)
+        useSettingsContextMenuEvent('showLetValues', { showLetValues: true }, !goalSettings.showLetValue)
+        useContextMenuEvent('saveSettings', () => saveConfig(), goalSettingsDifferFromDefaultConfig, [saveConfig])
 
         const setOpenRef = React.useRef<React.Dispatch<React.SetStateAction<boolean>>>()
         useEvent(
@@ -402,7 +476,10 @@ export const FilteredGoals = React.memo(
         )
 
         return (
-            <div style={{ display: goals !== undefined ? 'block' : 'none' }}>
+            <div
+                style={{ display: goals !== undefined ? 'block' : 'none' }}
+                data-vscode-context={JSON.stringify(context)}
+            >
                 <Details setOpenRef={r => (setOpenRef.current = r)} initiallyOpen={initiallyOpen}>
                     <>
                         {headerChildren}
@@ -412,13 +489,11 @@ export const FilteredGoals = React.memo(
                                 e.preventDefault()
                             }}
                         >
-                            {copyToCommentButton}
-                            {sortButton}
-                            {filterButton}
+                            {settingsButton}
                         </span>
                     </>
                     <div className="ml1">
-                        {goals && <Goals goals={goals} filter={goalFilters} displayCount={displayCount}></Goals>}
+                        {goals && <Goals goals={goals} settings={goalSettings} displayCount={displayCount}></Goals>}
                     </div>
                 </Details>
             </div>

--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -69,10 +69,10 @@ function goalSettingsStateOfConfig(config: InfoviewConfig): GoalSettingsState {
         reverse: config.reverseTacticState,
         hideGoalNames: !config.showGoalNames,
         emphasizeFirstGoal: config.emphasizeFirstGoal,
-        showType: !config.filterTypes,
-        showInstance: !config.filterInstances,
-        showHiddenAssumption: !config.filterHiddenAssumptions,
-        showLetValue: !config.filterLetValues,
+        showType: !config.hideTypeAssumptions,
+        showInstance: !config.hideInstanceAssumptions,
+        showHiddenAssumption: !config.hideHiddenAssumptions,
+        showLetValue: !config.hideLetValues,
     }
 }
 
@@ -326,10 +326,10 @@ export const FilteredGoals = React.memo(
                 reverseTacticState: goalSettings.reverse,
                 showGoalNames: !goalSettings.hideGoalNames,
                 emphasizeFirstGoal: goalSettings.emphasizeFirstGoal,
-                filterTypes: !goalSettings.showType,
-                filterInstances: !goalSettings.showInstance,
-                filterHiddenAssumptions: !goalSettings.showHiddenAssumption,
-                filterLetValues: !goalSettings.showLetValue,
+                hideTypeAssumptions: !goalSettings.showType,
+                hideInstanceAssumptions: !goalSettings.showInstance,
+                hideHiddenAssumptions: !goalSettings.showHiddenAssumption,
+                hideLetValues: !goalSettings.showLetValue,
             })
         }, [config, ec.api, goalSettings])
 
@@ -363,6 +363,30 @@ export const FilteredGoals = React.memo(
                 )}
                 <br />
                 {mkSettingButton(
+                    s => ({ ...s, showType: !s.showType }),
+                    gs => !gs.showType,
+                    'Hide type assumptions',
+                )}
+                <br />
+                {mkSettingButton(
+                    s => ({ ...s, showInstance: !s.showInstance }),
+                    gs => !gs.showInstance,
+                    'Hide instance assumptions',
+                )}
+                <br />
+                {mkSettingButton(
+                    s => ({ ...s, showHiddenAssumption: !s.showHiddenAssumption }),
+                    gs => !gs.showHiddenAssumption,
+                    'Hide hidden assumptions',
+                )}
+                <br />
+                {mkSettingButton(
+                    s => ({ ...s, showLetValue: !s.showLetValue }),
+                    gs => !gs.showLetValue,
+                    'Hide let-values',
+                )}
+                <br />
+                {mkSettingButton(
                     s => ({ ...s, hideGoalNames: !s.hideGoalNames }),
                     gs => gs.hideGoalNames,
                     'Hide goal names',
@@ -372,30 +396,6 @@ export const FilteredGoals = React.memo(
                     s => ({ ...s, emphasizeFirstGoal: !s.emphasizeFirstGoal }),
                     gs => gs.emphasizeFirstGoal,
                     'Emphasize first goal',
-                )}
-                <br />
-                {mkSettingButton(
-                    s => ({ ...s, showType: !s.showType }),
-                    gs => !gs.showType,
-                    'Filter types',
-                )}
-                <br />
-                {mkSettingButton(
-                    s => ({ ...s, showInstance: !s.showInstance }),
-                    gs => !gs.showInstance,
-                    'Filter instances',
-                )}
-                <br />
-                {mkSettingButton(
-                    s => ({ ...s, showHiddenAssumption: !s.showHiddenAssumption }),
-                    gs => !gs.showHiddenAssumption,
-                    'Filter hidden assumptions',
-                )}
-                <br />
-                {mkSettingButton(
-                    s => ({ ...s, showLetValue: !s.showLetValue }),
-                    gs => !gs.showLetValue,
-                    'Filter let-values',
                 )}
                 <br className="saveConfigLineBreak" style={disabledSaveStyle} />
                 <a
@@ -433,6 +433,22 @@ export const FilteredGoals = React.memo(
 
         useSettingsContextMenuEvent('displayTargetBeforeAssumptions', { reverse: true }, !goalSettings.reverse)
         useSettingsContextMenuEvent('displayAssumptionsBeforeTarget', { reverse: false }, goalSettings.reverse)
+        useSettingsContextMenuEvent('hideTypeAssumptions', { showType: false }, goalSettings.showType)
+        useSettingsContextMenuEvent('showTypeAssumptions', { showType: true }, !goalSettings.showType)
+        useSettingsContextMenuEvent('hideInstanceAssumptions', { showInstance: false }, goalSettings.showInstance)
+        useSettingsContextMenuEvent('showInstanceAssumptions', { showInstance: true }, !goalSettings.showInstance)
+        useSettingsContextMenuEvent(
+            'hideHiddenAssumptions',
+            { showHiddenAssumption: false },
+            goalSettings.showHiddenAssumption,
+        )
+        useSettingsContextMenuEvent(
+            'showHiddenAssumptions',
+            { showHiddenAssumption: true },
+            !goalSettings.showHiddenAssumption,
+        )
+        useSettingsContextMenuEvent('hideLetValues', { showLetValues: false }, goalSettings.showLetValue)
+        useSettingsContextMenuEvent('showLetValues', { showLetValues: true }, !goalSettings.showLetValue)
         useSettingsContextMenuEvent('hideGoalNames', { hideGoalNames: true }, !goalSettings.hideGoalNames)
         useSettingsContextMenuEvent('showGoalNames', { hideGoalNames: false }, goalSettings.hideGoalNames)
         useSettingsContextMenuEvent(
@@ -445,22 +461,6 @@ export const FilteredGoals = React.memo(
             { emphasizeFirstGoal: false },
             goalSettings.emphasizeFirstGoal,
         )
-        useSettingsContextMenuEvent('filterTypes', { showType: false }, goalSettings.showType)
-        useSettingsContextMenuEvent('showTypes', { showType: true }, !goalSettings.showType)
-        useSettingsContextMenuEvent('filterInstances', { showInstance: false }, goalSettings.showInstance)
-        useSettingsContextMenuEvent('showInstances', { showInstance: true }, !goalSettings.showInstance)
-        useSettingsContextMenuEvent(
-            'filterHiddenAssumptions',
-            { showHiddenAssumption: false },
-            goalSettings.showHiddenAssumption,
-        )
-        useSettingsContextMenuEvent(
-            'showHiddenAssumptions',
-            { showHiddenAssumption: true },
-            !goalSettings.showHiddenAssumption,
-        )
-        useSettingsContextMenuEvent('filterLetValues', { showLetValues: false }, goalSettings.showLetValue)
-        useSettingsContextMenuEvent('showLetValues', { showLetValues: true }, !goalSettings.showLetValue)
         useContextMenuEvent('saveSettings', () => saveConfig(), goalSettingsDifferFromDefaultConfig, [saveConfig])
 
         const setOpenRef = React.useRef<React.Dispatch<React.SetStateAction<boolean>>>()

--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -192,7 +192,7 @@ function GoalInfoDisplay(props: GoalInfoDisplayProps) {
     return (
         <>
             <LocationsContext.Provider value={locs}>
-                <span data-vscode-context={JSON.stringify({ selectedLocationsId })}>
+                <span data-vscode-context={JSON.stringify(selectedLocs.length === 0 ? {} : { selectedLocationsId })}>
                     <FilteredGoals key="goals" headerChildren="Tactic state" initiallyOpen goals={goals} displayCount />
                 </span>
             </LocationsContext.Provider>

--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -80,7 +80,7 @@ const InfoStatusBar = React.memo((props: InfoStatusBarProps) => {
             {isPinned && !isPaused && ' (pinned)'}
             {!isPinned && isPaused && ' (paused)'}
             {isPinned && isPaused && ' (pinned and paused)'}
-            <span style={spinnerStyle} className="mh2 codicon codicon-loading" title="updating">
+            <span style={spinnerStyle} className="mh2 codicon codicon-loading" title="Updating ...">
                 <style>
                     {`
                         @keyframes spin {
@@ -103,7 +103,17 @@ const InfoStatusBar = React.memo((props: InfoStatusBarProps) => {
                         onClick={_ => {
                             void ec.revealPosition(pos)
                         }}
-                        title="reveal file location"
+                        title="Go to pinned location in file"
+                    />
+                )}
+                {isPaused && (
+                    <a
+                        className="link pointer mh2 dim codicon codicon-refresh"
+                        data-id="update"
+                        onClick={_ => {
+                            void triggerUpdate()
+                        }}
+                        title="Refresh paused state"
                     />
                 )}
                 <a
@@ -112,7 +122,7 @@ const InfoStatusBar = React.memo((props: InfoStatusBarProps) => {
                     onClick={_ => {
                         onPin(pos)
                     }}
-                    title={isPinned ? 'unpin' : 'pin'}
+                    title={isPinned ? 'Unpin state' : 'Pin state to top'}
                 />
                 <a
                     className={
@@ -123,15 +133,7 @@ const InfoStatusBar = React.memo((props: InfoStatusBarProps) => {
                     onClick={_ => {
                         setPaused(!isPaused)
                     }}
-                    title={isPaused ? 'continue updating' : 'pause updating'}
-                />
-                <a
-                    className="link pointer mh2 dim codicon codicon-refresh"
-                    data-id="update"
-                    onClick={_ => {
-                        void triggerUpdate()
-                    }}
-                    title="update"
+                    title={isPaused ? 'Unpause state' : 'Pause state'}
                 />
             </span>
         </summary>
@@ -194,14 +196,16 @@ function GoalInfoDisplay(props: GoalInfoDisplayProps) {
                     <FilteredGoals key="goals" headerChildren="Tactic state" initiallyOpen goals={goals} displayCount />
                 </span>
             </LocationsContext.Provider>
-            <FilteredGoals
-                key="term-goal"
-                headerChildren="Expected type"
-                goals={termGoal !== undefined ? { goals: [termGoal] } : undefined}
-                initiallyOpen={config.showExpectedType}
-                displayCount={false}
-                togglingAction="toggleExpectedType"
-            />
+            {config.expectedTypeVisibility !== 'Hidden' && (
+                <FilteredGoals
+                    key="term-goal"
+                    headerChildren="Expected type"
+                    goals={termGoal !== undefined ? { goals: [termGoal] } : undefined}
+                    initiallyOpen={config.expectedTypeVisibility === 'Expanded by default'}
+                    displayCount={false}
+                    togglingAction="toggleExpectedType"
+                />
+            )}
             {userWidgets.map(widget => {
                 const inner = (
                     <PanelWidgetDisplay
@@ -327,7 +331,7 @@ function InfoDisplay(props0: InfoDisplayProps & InfoPinnable) {
         setShouldRefresh(true)
     }
 
-    const { kind, goals, rpcSess } = props
+    const { kind, pos, onPin, goals, rpcSess } = props
 
     const ec = React.useContext(EditorContext)
 
@@ -353,10 +357,70 @@ function InfoDisplay(props0: InfoDisplayProps & InfoPinnable) {
         'togglePaused',
     )
 
+    const id = React.useId()
+    useEvent(
+        ec.events.clickedContextMenu,
+        _ => {
+            setPaused(true)
+        },
+        [setPaused],
+        `pause:${id}`,
+    )
+    useEvent(
+        ec.events.clickedContextMenu,
+        _ => {
+            setPaused(false)
+        },
+        [setPaused],
+        `unpause:${id}`,
+    )
+    useEvent(
+        ec.events.clickedContextMenu,
+        _ => {
+            if (isCursor) {
+                onPin(pos)
+            }
+        },
+        [isCursor, onPin, pos],
+        `pin:${id}`,
+    )
+    useEvent(
+        ec.events.clickedContextMenu,
+        _ => {
+            if (!isCursor) {
+                onPin(pos)
+            }
+        },
+        [isCursor, onPin, pos],
+        `unpin:${id}`,
+    )
+    useEvent(
+        ec.events.clickedContextMenu,
+        _ => {
+            void triggerDisplayUpdate()
+        },
+        [isCursor, onPin, pos],
+        `refresh:${id}`,
+    )
+    useEvent(ec.events.clickedContextMenu, async _ => void ec.revealPosition(pos), [pos], `goToPinnedLocation:${id}`)
+
+    const pauseContext = isPaused ? { unpauseId: id } : { pauseId: id }
+    const pinContext = isCursor ? { pinId: id } : { unpinId: id }
+    const refreshContext = isPaused ? { refreshId: id } : {}
+    const goToPinnedLocationContext = !isCursor ? { goToPinnedLocationId: id } : {}
+
     return (
         <RpcContext.Provider value={rpcSess}>
-            <EnvPosContext.Provider value={props.pos}>
-                <details open>
+            <EnvPosContext.Provider value={pos}>
+                <details
+                    data-vscode-context={JSON.stringify({
+                        ...pauseContext,
+                        ...pinContext,
+                        ...refreshContext,
+                        ...goToPinnedLocationContext,
+                    })}
+                    open
+                >
                     <InfoStatusBar
                         {...props}
                         triggerUpdate={triggerDisplayUpdate}

--- a/lean4-infoview/src/infoview/traceExplorer.tsx
+++ b/lean4-infoview/src/infoview/traceExplorer.tsx
@@ -175,8 +175,10 @@ function InteractiveMessageTag({ tag: embed }: InteractiveTagProps<MsgEmbed>): J
         return (
             <Goal
                 goal={embed.goal}
-                filter={{
+                settings={{
                     reverse: false,
+                    hideGoalNames: false,
+                    emphasizeFirstGoal: false,
                     showType: true,
                     showInstance: true,
                     showHiddenAssumption: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,10 +28,10 @@
         },
         "lean4-infoview": {
             "name": "@leanprover/infoview",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@leanprover/infoview-api": "~0.6.0",
+                "@leanprover/infoview-api": "~0.7.0",
                 "@vscode-elements/react-elements": "^0.5.0",
                 "@vscode/codicons": "^0.0.32",
                 "es-module-lexer": "^1.5.4",
@@ -67,7 +67,7 @@
         },
         "lean4-infoview-api": {
             "name": "@leanprover/infoview-api",
-            "version": "0.6.0",
+            "version": "0.7.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "typescript": "^5.4.5",
@@ -16906,8 +16906,8 @@
             "version": "0.0.201",
             "license": "Apache-2.0",
             "dependencies": {
-                "@leanprover/infoview": "~0.8.3",
-                "@leanprover/infoview-api": "~0.6.0",
+                "@leanprover/infoview": "~0.8.4",
+                "@leanprover/infoview-api": "~0.7.0",
                 "@leanprover/unicode-input": "~0.1.4",
                 "@leanprover/unicode-input-component": "~0.1.4",
                 "@vscode-elements/elements": "^1.7.1",

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -189,7 +189,7 @@
                     "default": false,
                     "markdownDescription": "Default to filtering instance assumptions from the local context."
                 },
-                "lean4.infoview.hideHiddenAssumptions": {
+                "lean4.infoview.hideInaccessibleAssumptions": {
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "Default to filtering hidden assumptions from the local context."
@@ -460,16 +460,16 @@
                 "description": "This command is an implementation detail of the 'Show Instance Assumptions' context menu option in the infoview."
             },
             {
-                "command": "lean4.infoview.hideHiddenAssumptions",
+                "command": "lean4.infoview.hideInaccessibleAssumptions",
                 "category": "Lean 4",
-                "title": "Hide Hidden Assumptions",
-                "description": "This command is an implementation detail of the 'Hide Hidden Assumptions' context menu option in the infoview."
+                "title": "Hide Inaccessible Assumptions",
+                "description": "This command is an implementation detail of the 'Hide Inaccessible Assumptions' context menu option in the infoview."
             },
             {
-                "command": "lean4.infoview.showHiddenAssumptions",
+                "command": "lean4.infoview.showInaccessibleAssumptions",
                 "category": "Lean 4",
-                "title": "Show Hidden Assumptions",
-                "description": "This command is an implementation detail of the 'Show Hidden Assumptions' context menu option in the infoview."
+                "title": "Show Inaccessible Assumptions",
+                "description": "This command is an implementation detail of the 'Show Inaccessible Assumptions' context menu option in the infoview."
             },
             {
                 "command": "lean4.infoview.hideLetValues",
@@ -912,11 +912,11 @@
                     "when": "false"
                 },
                 {
-                    "command": "lean4.infoview.hideHiddenAssumptions",
+                    "command": "lean4.infoview.hideInaccessibleAssumptions",
                     "when": "false"
                 },
                 {
-                    "command": "lean4.infoview.showHiddenAssumptions",
+                    "command": "lean4.infoview.showInaccessibleAssumptions",
                     "when": "false"
                 },
                 {
@@ -1326,13 +1326,13 @@
                     "group": "0_settings@6"
                 },
                 {
-                    "command": "lean4.infoview.hideHiddenAssumptions",
-                    "when": "webviewId == 'lean4_infoview' && hideHiddenAssumptionsId",
+                    "command": "lean4.infoview.hideInaccessibleAssumptions",
+                    "when": "webviewId == 'lean4_infoview' && hideInaccessibleAssumptionsId",
                     "group": "0_settings@7"
                 },
                 {
-                    "command": "lean4.infoview.showHiddenAssumptions",
-                    "when": "webviewId == 'lean4_infoview' && showHiddenAssumptionsId",
+                    "command": "lean4.infoview.showInaccessibleAssumptions",
+                    "when": "webviewId == 'lean4_infoview' && showInaccessibleAssumptionsId",
                     "group": "0_settings@8"
                 },
                 {

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -150,7 +150,18 @@
                 "lean4.infoview.showExpectedType": {
                     "type": "boolean",
                     "default": true,
-                    "markdownDescription": "Show the expected type by default."
+                    "markdownDescription": "Show the expected type by default.",
+                    "deprecationMessage": "Superseded by the 'InfoView: Expected Type Visibility' setting."
+                },
+                "lean4.infoview.expectedTypeVisibility": {
+                    "type": "string",
+                    "enum": [
+                        "Expanded by default",
+                        "Collapsed by default",
+                        "Hidden"
+                    ],
+                    "default": "Expanded by default",
+                    "markdownDescription": "Default visibility of the expected type."
                 },
                 "lean4.infoview.showGoalNames": {
                     "type": "boolean",
@@ -163,9 +174,30 @@
                     "markdownDescription": "Display goals other than the main goal in a smaller font size."
                 },
                 "lean4.infoview.reverseTacticState": {
+                    "title": "Display Target Before Assumptions",
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "Default to showing the goal type first and then the local context."
+                },
+                "lean4.infoview.filterTypes": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Default to filtering type assumptions from the local context."
+                },
+                "lean4.infoview.filterInstances": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Default to filtering instance assumptions from the local context."
+                },
+                "lean4.infoview.filterHiddenAssumptions": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Default to filtering hidden assumptions from the local context."
+                },
+                "lean4.infoview.filterLetValues": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Default to filtering type assumptions from the local context."
                 },
                 "lean4.infoview.showTooltipOnHover": {
                     "type": "boolean",
@@ -336,6 +368,150 @@
                 "category": "Lean 4",
                 "title": "Unselect All",
                 "description": "This command is an implementation detail of the 'Unselect All' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.pause",
+                "category": "Lean 4",
+                "title": "Pause State",
+                "description": "This command is an implementation detail of the 'Pause State' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.unpause",
+                "category": "Lean 4",
+                "title": "Unpause State",
+                "description": "This command is an implementation detail of the 'Unpause State' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.pin",
+                "category": "Lean 4",
+                "title": "Pin State to Top",
+                "description": "This command is an implementation detail of the 'Pin State to Top' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.unpin",
+                "category": "Lean 4",
+                "title": "Unpin State",
+                "description": "This command is an implementation detail of the 'Unpin State' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.refresh",
+                "category": "Lean 4",
+                "title": "Refresh Paused State",
+                "description": "This command is an implementation detail of the 'Refresh Paused State' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.pauseAllMessages",
+                "category": "Lean 4",
+                "title": "Pause 'All Messages'",
+                "description": "This command is an implementation detail of the 'Pause 'All Messages'' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.unpauseAllMessages",
+                "category": "Lean 4",
+                "title": "Unpause 'All Messages'",
+                "description": "This command is an implementation detail of the 'Unpause 'All Messages'' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.goToPinnedLocation",
+                "category": "Lean 4",
+                "title": "Go to Pinned Location",
+                "description": "This command is an implementation detail of the 'Go to Pinned Location' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.goToMessageLocation",
+                "category": "Lean 4",
+                "title": "Go to Source Location of Message",
+                "description": "This command is an implementation detail of the 'Go to Source Location of Message' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.displayTargetBeforeAssumptions",
+                "category": "Lean 4",
+                "title": "Display Target Before Assumptions",
+                "description": "This command is an implementation detail of the 'Display Target Before Assumptions' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.displayAssumptionsBeforeTarget",
+                "category": "Lean 4",
+                "title": "Display Assumptions Before Target",
+                "description": "This command is an implementation detail of the 'Display Assumptions Before Target' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.hideGoalNames",
+                "category": "Lean 4",
+                "title": "Hide Goal Names",
+                "description": "This command is an implementation detail of the 'Hide Goal Names' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.showGoalNames",
+                "category": "Lean 4",
+                "title": "Show Goal Names",
+                "description": "This command is an implementation detail of the 'Show Goal Names' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.emphasizeFirstGoal",
+                "category": "Lean 4",
+                "title": "Emphasize First Goal",
+                "description": "This command is an implementation detail of the 'Emphasize First Goal' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.deemphasizeFirstGoal",
+                "category": "Lean 4",
+                "title": "De-Emphasize First Goal",
+                "description": "This command is an implementation detail of the 'De-Emphasize First Goal' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.filterTypes",
+                "category": "Lean 4",
+                "title": "Filter Types",
+                "description": "This command is an implementation detail of the 'Filter Types' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.showTypes",
+                "category": "Lean 4",
+                "title": "Show Types",
+                "description": "This command is an implementation detail of the 'Show Types' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.filterInstances",
+                "category": "Lean 4",
+                "title": "Filter Instances",
+                "description": "This command is an implementation detail of the 'Filter Instances' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.showInstances",
+                "category": "Lean 4",
+                "title": "Show Instances",
+                "description": "This command is an implementation detail of the 'Show Instances' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.filterHiddenAssumptions",
+                "category": "Lean 4",
+                "title": "Filter Hidden Assumptions",
+                "description": "This command is an implementation detail of the 'Filter Hidden Assumptions' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.showHiddenAssumptions",
+                "category": "Lean 4",
+                "title": "Show Hidden Assumptions",
+                "description": "This command is an implementation detail of the 'Show Hidden Assumptions' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.filterLetValues",
+                "category": "Lean 4",
+                "title": "Filter Let-Values",
+                "description": "This command is an implementation detail of the 'Filter Let-Values' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.showLetValues",
+                "category": "Lean 4",
+                "title": "Show Let-Values",
+                "description": "This command is an implementation detail of the 'Show Let-Values' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.saveSettings",
+                "category": "Lean 4",
+                "title": "Save Current Settings to Default Settings",
+                "description": "This command is an implementation detail of the 'Save Current Settings to Default Settings' context menu option in the infoview."
             },
             {
                 "command": "lean4.loogle.search",
@@ -676,6 +852,102 @@
                     "when": "false"
                 },
                 {
+                    "command": "lean4.infoview.pause",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.unpause",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.pin",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.unpin",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.refresh",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.pauseAllMessages",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.unpauseAllMessages",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.goToPinnedLocation",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.goToMessageLocation",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.displayTargetBeforeAssumptions",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.displayAssumptionsBeforeTarget",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.hideGoalNames",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.showGoalNames",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.emphasizeFirstGoal",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.deemphasizeFirstGoal",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.filterTypes",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.showTypes",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.filterInstances",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.showInstances",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.filterHiddenAssumptions",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.showHiddenAssumptions",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.filterLetValues",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.showLetValues",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.saveSettings",
+                    "when": "false"
+                },
+                {
                     "command": "lean4.loogle.search"
                 },
                 {
@@ -953,19 +1225,150 @@
             "webview/context": [
                 {
                     "command": "lean4.infoview.goToDefinition",
-                    "when": "webviewId == 'lean4_infoview' && interactiveCodeTagId"
+                    "when": "webviewId == 'lean4_infoview' && interactiveCodeTagId",
+                    "group": "0_term@1"
+                },
+                {
+                    "command": "lean4.infoview.goToPinnedLocation",
+                    "when": "webviewId == 'lean4_infoview' && goToPinnedLocationId",
+                    "group": "0_term@2"
+                },
+                {
+                    "command": "lean4.infoview.goToMessageLocation",
+                    "when": "webviewId == 'lean4_infoview' && goToMessageLocationId",
+                    "group": "0_term@3"
                 },
                 {
                     "command": "lean4.infoview.select",
-                    "when": "webviewId == 'lean4_infoview' && selectableLocationId"
+                    "when": "webviewId == 'lean4_infoview' && selectableLocationId",
+                    "group": "0_term@4"
                 },
                 {
                     "command": "lean4.infoview.unselect",
-                    "when": "webviewId == 'lean4_infoview' && unselectableLocationId"
+                    "when": "webviewId == 'lean4_infoview' && unselectableLocationId",
+                    "group": "0_term@5"
                 },
                 {
                     "command": "lean4.infoview.unselectAll",
-                    "when": "webviewId == 'lean4_infoview' && selectedLocationsId"
+                    "when": "webviewId == 'lean4_infoview' && selectedLocationsId",
+                    "group": "0_term@6"
+                },
+                {
+                    "command": "lean4.infoview.pin",
+                    "when": "webviewId == 'lean4_infoview' && pinId",
+                    "group": "1_info@1"
+                },
+                {
+                    "command": "lean4.infoview.unpin",
+                    "when": "webviewId == 'lean4_infoview' && unpinId",
+                    "group": "1_info@2"
+                },
+                {
+                    "command": "lean4.infoview.pause",
+                    "when": "webviewId == 'lean4_infoview' && pauseId",
+                    "group": "1_info@3"
+                },
+                {
+                    "command": "lean4.infoview.unpause",
+                    "when": "webviewId == 'lean4_infoview' && unpauseId",
+                    "group": "1_info@4"
+                },
+                {
+                    "command": "lean4.infoview.refresh",
+                    "when": "webviewId == 'lean4_infoview' && refreshId",
+                    "group": "1_info@5"
+                },
+                {
+                    "command": "lean4.infoview.pauseAllMessages",
+                    "when": "webviewId == 'lean4_infoview' && pauseAllMessagesId",
+                    "group": "1_info@6"
+                },
+                {
+                    "command": "lean4.infoview.unpauseAllMessages",
+                    "when": "webviewId == 'lean4_infoview' && unpauseAllMessagesId",
+                    "group": "1_info@7"
+                },
+                {
+                    "submenu": "lean4.infoview.contextMenuSettings",
+                    "when": "webviewId == 'lean4_infoview'",
+                    "group": "z_settings@1"
+                }
+            ],
+            "lean4.infoview.contextMenuSettings": [
+                {
+                    "command": "lean4.infoview.displayTargetBeforeAssumptions",
+                    "when": "webviewId == 'lean4_infoview' && displayTargetBeforeAssumptionsId",
+                    "group": "0_settings@1"
+                },
+                {
+                    "command": "lean4.infoview.displayAssumptionsBeforeTarget",
+                    "when": "webviewId == 'lean4_infoview' && displayAssumptionsBeforeTargetId",
+                    "group": "0_settings@2"
+                },
+                {
+                    "command": "lean4.infoview.hideGoalNames",
+                    "when": "webviewId == 'lean4_infoview' && hideGoalNamesId",
+                    "group": "0_settings@3"
+                },
+                {
+                    "command": "lean4.infoview.showGoalNames",
+                    "when": "webviewId == 'lean4_infoview' && showGoalNamesId",
+                    "group": "0_settings@4"
+                },
+                {
+                    "command": "lean4.infoview.emphasizeFirstGoal",
+                    "when": "webviewId == 'lean4_infoview' && emphasizeFirstGoalId",
+                    "group": "0_settings@5"
+                },
+                {
+                    "command": "lean4.infoview.deemphasizeFirstGoal",
+                    "when": "webviewId == 'lean4_infoview' && deemphasizeFirstGoalId",
+                    "group": "0_settings@6"
+                },
+                {
+                    "command": "lean4.infoview.filterTypes",
+                    "when": "webviewId == 'lean4_infoview' && filterTypesId",
+                    "group": "0_settings@7"
+                },
+                {
+                    "command": "lean4.infoview.showTypes",
+                    "when": "webviewId == 'lean4_infoview' && showTypesId",
+                    "group": "0_settings@8"
+                },
+                {
+                    "command": "lean4.infoview.filterInstances",
+                    "when": "webviewId == 'lean4_infoview' && filterInstancesId",
+                    "group": "0_settings@9"
+                },
+                {
+                    "command": "lean4.infoview.showInstances",
+                    "when": "webviewId == 'lean4_infoview' && showInstancesId",
+                    "group": "0_settings@10"
+                },
+                {
+                    "command": "lean4.infoview.filterHiddenAssumptions",
+                    "when": "webviewId == 'lean4_infoview' && filterHiddenAssumptionsId",
+                    "group": "0_settings@11"
+                },
+                {
+                    "command": "lean4.infoview.showHiddenAssumptions",
+                    "when": "webviewId == 'lean4_infoview' && showHiddenAssumptionsId",
+                    "group": "0_settings@12"
+                },
+                {
+                    "command": "lean4.infoview.filterLetValues",
+                    "when": "webviewId == 'lean4_infoview' && filterLetValuesId",
+                    "group": "0_settings@13"
+                },
+                {
+                    "command": "lean4.infoview.showLetValues",
+                    "when": "webviewId == 'lean4_infoview' && showLetValuesId",
+                    "group": "0_settings@14"
+                },
+                {
+                    "command": "lean4.infoview.saveSettings",
+                    "when": "webviewId == 'lean4_infoview' && saveSettingsId",
+                    "group": "1_save@1"
                 }
             ]
         },
@@ -997,6 +1400,10 @@
             {
                 "id": "lean4.titlebar.documentation",
                 "label": "Documentation…"
+            },
+            {
+                "id": "lean4.infoview.contextMenuSettings",
+                "label": "Settings…"
             }
         ],
         "semanticTokenScopes": [
@@ -1129,8 +1536,8 @@
         "test": "node ./out/test/suite/runTest.js"
     },
     "dependencies": {
-        "@leanprover/infoview": "~0.8.3",
-        "@leanprover/infoview-api": "~0.6.0",
+        "@leanprover/infoview": "~0.8.4",
+        "@leanprover/infoview-api": "~0.7.0",
         "@leanprover/unicode-input": "~0.1.4",
         "@leanprover/unicode-input-component": "~0.1.4",
         "@vscode/codicons": "^0.0.36",

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -179,22 +179,22 @@
                     "default": false,
                     "markdownDescription": "Default to showing the goal type first and then the local context."
                 },
-                "lean4.infoview.filterTypes": {
+                "lean4.infoview.hideTypeAssumptions": {
                     "type": "boolean",
                     "default": false,
-                    "markdownDescription": "Default to filtering type assumptions from the local context."
+                    "markdownDescription": "Default to hiding type assumptions from the local context."
                 },
-                "lean4.infoview.filterInstances": {
+                "lean4.infoview.hideInstanceAssumptions": {
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "Default to filtering instance assumptions from the local context."
                 },
-                "lean4.infoview.filterHiddenAssumptions": {
+                "lean4.infoview.hideHiddenAssumptions": {
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "Default to filtering hidden assumptions from the local context."
                 },
-                "lean4.infoview.filterLetValues": {
+                "lean4.infoview.hideLetValues": {
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "Default to filtering type assumptions from the local context."
@@ -436,6 +436,54 @@
                 "description": "This command is an implementation detail of the 'Display Assumptions Before Target' context menu option in the infoview."
             },
             {
+                "command": "lean4.infoview.hideTypeAssumptions",
+                "category": "Lean 4",
+                "title": "Hide Type Assumptions",
+                "description": "This command is an implementation detail of the 'Hide Type Assumptions' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.showTypeAssumptions",
+                "category": "Lean 4",
+                "title": "Show Type Assumptions",
+                "description": "This command is an implementation detail of the 'Show Type Assumptions' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.hideInstanceAssumptions",
+                "category": "Lean 4",
+                "title": "Hide Instance Assumptions",
+                "description": "This command is an implementation detail of the 'Hide Instance Assumptions' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.showInstanceAssumptions",
+                "category": "Lean 4",
+                "title": "Show Instance Assumptions",
+                "description": "This command is an implementation detail of the 'Show Instance Assumptions' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.hideHiddenAssumptions",
+                "category": "Lean 4",
+                "title": "Hide Hidden Assumptions",
+                "description": "This command is an implementation detail of the 'Hide Hidden Assumptions' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.showHiddenAssumptions",
+                "category": "Lean 4",
+                "title": "Show Hidden Assumptions",
+                "description": "This command is an implementation detail of the 'Show Hidden Assumptions' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.hideLetValues",
+                "category": "Lean 4",
+                "title": "Hide Let-Values",
+                "description": "This command is an implementation detail of the 'Hide Let-Values' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.showLetValues",
+                "category": "Lean 4",
+                "title": "Show Let-Values",
+                "description": "This command is an implementation detail of the 'Show Let-Values' context menu option in the infoview."
+            },
+            {
                 "command": "lean4.infoview.hideGoalNames",
                 "category": "Lean 4",
                 "title": "Hide Goal Names",
@@ -458,54 +506,6 @@
                 "category": "Lean 4",
                 "title": "De-Emphasize First Goal",
                 "description": "This command is an implementation detail of the 'De-Emphasize First Goal' context menu option in the infoview."
-            },
-            {
-                "command": "lean4.infoview.filterTypes",
-                "category": "Lean 4",
-                "title": "Filter Types",
-                "description": "This command is an implementation detail of the 'Filter Types' context menu option in the infoview."
-            },
-            {
-                "command": "lean4.infoview.showTypes",
-                "category": "Lean 4",
-                "title": "Show Types",
-                "description": "This command is an implementation detail of the 'Show Types' context menu option in the infoview."
-            },
-            {
-                "command": "lean4.infoview.filterInstances",
-                "category": "Lean 4",
-                "title": "Filter Instances",
-                "description": "This command is an implementation detail of the 'Filter Instances' context menu option in the infoview."
-            },
-            {
-                "command": "lean4.infoview.showInstances",
-                "category": "Lean 4",
-                "title": "Show Instances",
-                "description": "This command is an implementation detail of the 'Show Instances' context menu option in the infoview."
-            },
-            {
-                "command": "lean4.infoview.filterHiddenAssumptions",
-                "category": "Lean 4",
-                "title": "Filter Hidden Assumptions",
-                "description": "This command is an implementation detail of the 'Filter Hidden Assumptions' context menu option in the infoview."
-            },
-            {
-                "command": "lean4.infoview.showHiddenAssumptions",
-                "category": "Lean 4",
-                "title": "Show Hidden Assumptions",
-                "description": "This command is an implementation detail of the 'Show Hidden Assumptions' context menu option in the infoview."
-            },
-            {
-                "command": "lean4.infoview.filterLetValues",
-                "category": "Lean 4",
-                "title": "Filter Let-Values",
-                "description": "This command is an implementation detail of the 'Filter Let-Values' context menu option in the infoview."
-            },
-            {
-                "command": "lean4.infoview.showLetValues",
-                "category": "Lean 4",
-                "title": "Show Let-Values",
-                "description": "This command is an implementation detail of the 'Show Let-Values' context menu option in the infoview."
             },
             {
                 "command": "lean4.infoview.saveSettings",
@@ -896,6 +896,38 @@
                     "when": "false"
                 },
                 {
+                    "command": "lean4.infoview.hideTypeAssumptions",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.showTypeAssumptions",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.hideInstanceAssumptions",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.showInstanceAssumptions",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.hideHiddenAssumptions",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.showHiddenAssumptions",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.hideLetValues",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.showLetValues",
+                    "when": "false"
+                },
+                {
                     "command": "lean4.infoview.hideGoalNames",
                     "when": "false"
                 },
@@ -909,38 +941,6 @@
                 },
                 {
                     "command": "lean4.infoview.deemphasizeFirstGoal",
-                    "when": "false"
-                },
-                {
-                    "command": "lean4.infoview.filterTypes",
-                    "when": "false"
-                },
-                {
-                    "command": "lean4.infoview.showTypes",
-                    "when": "false"
-                },
-                {
-                    "command": "lean4.infoview.filterInstances",
-                    "when": "false"
-                },
-                {
-                    "command": "lean4.infoview.showInstances",
-                    "when": "false"
-                },
-                {
-                    "command": "lean4.infoview.filterHiddenAssumptions",
-                    "when": "false"
-                },
-                {
-                    "command": "lean4.infoview.showHiddenAssumptions",
-                    "when": "false"
-                },
-                {
-                    "command": "lean4.infoview.filterLetValues",
-                    "when": "false"
-                },
-                {
-                    "command": "lean4.infoview.showLetValues",
                     "when": "false"
                 },
                 {
@@ -1306,63 +1306,63 @@
                     "group": "0_settings@2"
                 },
                 {
-                    "command": "lean4.infoview.hideGoalNames",
-                    "when": "webviewId == 'lean4_infoview' && hideGoalNamesId",
+                    "command": "lean4.infoview.hideTypeAssumptions",
+                    "when": "webviewId == 'lean4_infoview' && hideTypeAssumptionsId",
                     "group": "0_settings@3"
                 },
                 {
-                    "command": "lean4.infoview.showGoalNames",
-                    "when": "webviewId == 'lean4_infoview' && showGoalNamesId",
+                    "command": "lean4.infoview.showTypeAssumptions",
+                    "when": "webviewId == 'lean4_infoview' && showTypeAssumptionsId",
                     "group": "0_settings@4"
                 },
                 {
-                    "command": "lean4.infoview.emphasizeFirstGoal",
-                    "when": "webviewId == 'lean4_infoview' && emphasizeFirstGoalId",
+                    "command": "lean4.infoview.hideInstanceAssumptions",
+                    "when": "webviewId == 'lean4_infoview' && hideInstanceAssumptionsId",
                     "group": "0_settings@5"
                 },
                 {
-                    "command": "lean4.infoview.deemphasizeFirstGoal",
-                    "when": "webviewId == 'lean4_infoview' && deemphasizeFirstGoalId",
+                    "command": "lean4.infoview.showInstanceAssumptions",
+                    "when": "webviewId == 'lean4_infoview' && showInstanceAssumptionsId",
                     "group": "0_settings@6"
                 },
                 {
-                    "command": "lean4.infoview.filterTypes",
-                    "when": "webviewId == 'lean4_infoview' && filterTypesId",
+                    "command": "lean4.infoview.hideHiddenAssumptions",
+                    "when": "webviewId == 'lean4_infoview' && hideHiddenAssumptionsId",
                     "group": "0_settings@7"
-                },
-                {
-                    "command": "lean4.infoview.showTypes",
-                    "when": "webviewId == 'lean4_infoview' && showTypesId",
-                    "group": "0_settings@8"
-                },
-                {
-                    "command": "lean4.infoview.filterInstances",
-                    "when": "webviewId == 'lean4_infoview' && filterInstancesId",
-                    "group": "0_settings@9"
-                },
-                {
-                    "command": "lean4.infoview.showInstances",
-                    "when": "webviewId == 'lean4_infoview' && showInstancesId",
-                    "group": "0_settings@10"
-                },
-                {
-                    "command": "lean4.infoview.filterHiddenAssumptions",
-                    "when": "webviewId == 'lean4_infoview' && filterHiddenAssumptionsId",
-                    "group": "0_settings@11"
                 },
                 {
                     "command": "lean4.infoview.showHiddenAssumptions",
                     "when": "webviewId == 'lean4_infoview' && showHiddenAssumptionsId",
-                    "group": "0_settings@12"
+                    "group": "0_settings@8"
                 },
                 {
-                    "command": "lean4.infoview.filterLetValues",
-                    "when": "webviewId == 'lean4_infoview' && filterLetValuesId",
-                    "group": "0_settings@13"
+                    "command": "lean4.infoview.hideLetValues",
+                    "when": "webviewId == 'lean4_infoview' && hideLetValuesId",
+                    "group": "0_settings@9"
                 },
                 {
                     "command": "lean4.infoview.showLetValues",
                     "when": "webviewId == 'lean4_infoview' && showLetValuesId",
+                    "group": "0_settings@10"
+                },
+                {
+                    "command": "lean4.infoview.hideGoalNames",
+                    "when": "webviewId == 'lean4_infoview' && hideGoalNamesId",
+                    "group": "0_settings@11"
+                },
+                {
+                    "command": "lean4.infoview.showGoalNames",
+                    "when": "webviewId == 'lean4_infoview' && showGoalNamesId",
+                    "group": "0_settings@12"
+                },
+                {
+                    "command": "lean4.infoview.emphasizeFirstGoal",
+                    "when": "webviewId == 'lean4_infoview' && emphasizeFirstGoalId",
+                    "group": "0_settings@13"
+                },
+                {
+                    "command": "lean4.infoview.deemphasizeFirstGoal",
+                    "when": "webviewId == 'lean4_infoview' && deemphasizeFirstGoalId",
                     "group": "0_settings@14"
                 },
                 {

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -81,8 +81,17 @@ export function getInfoViewDebounceTime(): number {
     return workspace.getConfiguration('lean4.infoview').get('debounceTime', 50)
 }
 
-export function getInfoViewShowExpectedType(): boolean {
+function getInfoViewShowExpectedType(): boolean {
     return workspace.getConfiguration('lean4.infoview').get('showExpectedType', true)
+}
+
+export function getInfoViewExpectedTypeVisibility(): 'Expanded by default' | 'Collapsed by default' | 'Hidden' {
+    const show = getInfoViewShowExpectedType()
+    const visibility = workspace.getConfiguration('lean4.infoview').get('expectedTypeVisibility', 'Expanded by default')
+    if (!show && visibility === 'Expanded by default') {
+        return 'Collapsed by default'
+    }
+    return visibility
 }
 
 export function getInfoViewShowGoalNames(): boolean {
@@ -95,6 +104,22 @@ export function getInfoViewEmphasizeFirstGoal(): boolean {
 
 export function getInfoViewReverseTacticState(): boolean {
     return workspace.getConfiguration('lean4.infoview').get('reverseTacticState', false)
+}
+
+export function getInfoViewFilterTypes(): boolean {
+    return workspace.getConfiguration('lean4.infoview').get('filterTypes', false)
+}
+
+export function getInfoViewFilterInstances(): boolean {
+    return workspace.getConfiguration('lean4.infoview').get('filterInstances', false)
+}
+
+export function getInfoViewFilterHiddenAssumptions(): boolean {
+    return workspace.getConfiguration('lean4.infoview').get('filterHiddenAssumptions', false)
+}
+
+export function getInfoViewFilterLetValues(): boolean {
+    return workspace.getConfiguration('lean4.infoview').get('filterLetValues', false)
 }
 
 export function getInfoViewShowTooltipOnHover(): boolean {

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -106,20 +106,20 @@ export function getInfoViewReverseTacticState(): boolean {
     return workspace.getConfiguration('lean4.infoview').get('reverseTacticState', false)
 }
 
-export function getInfoViewFilterTypes(): boolean {
-    return workspace.getConfiguration('lean4.infoview').get('filterTypes', false)
+export function getInfoViewHideTypeAssumptions(): boolean {
+    return workspace.getConfiguration('lean4.infoview').get('hideTypeAssumptions', false)
 }
 
-export function getInfoViewFilterInstances(): boolean {
-    return workspace.getConfiguration('lean4.infoview').get('filterInstances', false)
+export function getInfoViewHideInstanceAssumptions(): boolean {
+    return workspace.getConfiguration('lean4.infoview').get('hideInstanceAssumptions', false)
 }
 
-export function getInfoViewFilterHiddenAssumptions(): boolean {
-    return workspace.getConfiguration('lean4.infoview').get('filterHiddenAssumptions', false)
+export function getInfoViewHideHiddenAssumptions(): boolean {
+    return workspace.getConfiguration('lean4.infoview').get('hideHiddenAssumptions', false)
 }
 
-export function getInfoViewFilterLetValues(): boolean {
-    return workspace.getConfiguration('lean4.infoview').get('filterLetValues', false)
+export function getInfoViewHideLetValues(): boolean {
+    return workspace.getConfiguration('lean4.infoview').get('hideLetValues', false)
 }
 
 export function getInfoViewShowTooltipOnHover(): boolean {

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -114,8 +114,8 @@ export function getInfoViewHideInstanceAssumptions(): boolean {
     return workspace.getConfiguration('lean4.infoview').get('hideInstanceAssumptions', false)
 }
 
-export function getInfoViewHideHiddenAssumptions(): boolean {
-    return workspace.getConfiguration('lean4.infoview').get('hideHiddenAssumptions', false)
+export function getInfoViewHideInaccessibleAssumptions(): boolean {
+    return workspace.getConfiguration('lean4.infoview').get('hideInaccessibleAssumptions', false)
 }
 
 export function getInfoViewHideLetValues(): boolean {

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -1,6 +1,7 @@
 import {
     EditorApi,
     InfoviewApi,
+    InfoviewConfig,
     LeanFileProgressParams,
     RpcConnected,
     RpcConnectParams,
@@ -12,6 +13,7 @@ import {
 import { join } from 'path'
 import {
     commands,
+    ConfigurationTarget,
     Diagnostic,
     Disposable,
     env,
@@ -34,8 +36,12 @@ import {
     getInfoViewAutoOpenShowsGoal,
     getInfoViewDebounceTime,
     getInfoViewEmphasizeFirstGoal,
+    getInfoViewExpectedTypeVisibility,
+    getInfoViewFilterHiddenAssumptions,
+    getInfoViewFilterInstances,
+    getInfoViewFilterLetValues,
+    getInfoViewFilterTypes,
     getInfoViewReverseTacticState,
-    getInfoViewShowExpectedType,
     getInfoViewShowGoalNames,
     getInfoViewShowTooltipOnHover,
     getInfoViewStyle,
@@ -138,6 +144,44 @@ export class InfoProvider implements Disposable {
     }
 
     private editorApi: EditorApi = {
+        saveConfig: async (config: InfoviewConfig) => {
+            await workspace
+                .getConfiguration('lean4.infoview')
+                .update('allErrorsOnLine', config.allErrorsOnLine, ConfigurationTarget.Global)
+            await workspace
+                .getConfiguration('lean4.infoview')
+                .update('autoOpenShowsGoal', config.autoOpenShowsGoal, ConfigurationTarget.Global)
+            await workspace
+                .getConfiguration('lean4.infoview')
+                .update('debounceTime', config.debounceTime, ConfigurationTarget.Global)
+            await workspace
+                .getConfiguration('lean4.infoview')
+                .update('expectedTypeVisibility', config.expectedTypeVisibility, ConfigurationTarget.Global)
+            await workspace
+                .getConfiguration('lean4.infoview')
+                .update('showGoalNames', config.showGoalNames, ConfigurationTarget.Global)
+            await workspace
+                .getConfiguration('lean4.infoview')
+                .update('emphasizeFirstGoal', config.emphasizeFirstGoal, ConfigurationTarget.Global)
+            await workspace
+                .getConfiguration('lean4.infoview')
+                .update('reverseTacticState', config.reverseTacticState, ConfigurationTarget.Global)
+            await workspace
+                .getConfiguration('lean4.infoview')
+                .update('filterTypes', config.filterTypes, ConfigurationTarget.Global)
+            await workspace
+                .getConfiguration('lean4.infoview')
+                .update('filterInstances', config.filterInstances, ConfigurationTarget.Global)
+            await workspace
+                .getConfiguration('lean4.infoview')
+                .update('filterHiddenAssumptions', config.filterHiddenAssumptions, ConfigurationTarget.Global)
+            await workspace
+                .getConfiguration('lean4.infoview')
+                .update('filterLetValues', config.filterLetValues, ConfigurationTarget.Global)
+            await workspace
+                .getConfiguration('lean4.infoview')
+                .update('showTooltipOnHover', config.showTooltipOnHover, ConfigurationTarget.Global)
+        },
         sendClientRequest: async (uri: string, method: string, params: any): Promise<any> => {
             const extUri = parseExtUri(uri)
             if (extUri === undefined) {
@@ -375,6 +419,114 @@ export class InfoProvider implements Disposable {
             commands.registerCommand('lean4.infoview.unselectAll', args =>
                 this.webviewPanel?.api.clickedContextMenu({ entry: 'unselectAll', id: args.selectedLocationsId }),
             ),
+            commands.registerCommand('lean4.infoview.pause', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'pause', id: args.pauseId }),
+            ),
+            commands.registerCommand('lean4.infoview.unpause', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'unpause', id: args.unpauseId }),
+            ),
+            commands.registerCommand('lean4.infoview.pin', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'pin', id: args.pinId }),
+            ),
+            commands.registerCommand('lean4.infoview.unpin', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'unpin', id: args.unpinId }),
+            ),
+            commands.registerCommand('lean4.infoview.refresh', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'refresh', id: args.refreshId }),
+            ),
+            commands.registerCommand('lean4.infoview.pauseAllMessages', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'pauseAllMessages',
+                    id: args.pauseAllMessagesId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.unpauseAllMessages', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'unpauseAllMessages',
+                    id: args.unpauseAllMessagesId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.goToPinnedLocation', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'goToPinnedLocation',
+                    id: args.goToPinnedLocationId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.goToMessageLocation', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'goToMessageLocation',
+                    id: args.goToMessageLocationId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.displayTargetBeforeAssumptions', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'displayTargetBeforeAssumptions',
+                    id: args.displayTargetBeforeAssumptionsId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.displayAssumptionsBeforeTarget', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'displayAssumptionsBeforeTarget',
+                    id: args.displayAssumptionsBeforeTargetId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.hideGoalNames', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'hideGoalNames',
+                    id: args.hideGoalNamesId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.showGoalNames', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'showGoalNames',
+                    id: args.showGoalNamesId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.emphasizeFirstGoal', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'emphasizeFirstGoal',
+                    id: args.emphasizeFirstGoalId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.deemphasizeFirstGoal', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'deemphasizeFirstGoal',
+                    id: args.deemphasizeFirstGoalId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.filterTypes', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'filterTypes', id: args.filterTypesId }),
+            ),
+            commands.registerCommand('lean4.infoview.showTypes', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'showTypes', id: args.showTypesId }),
+            ),
+            commands.registerCommand('lean4.infoview.filterInstances', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'filterInstances', id: args.filterInstancesId }),
+            ),
+            commands.registerCommand('lean4.infoview.showInstances', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'showInstances', id: args.showInstancesId }),
+            ),
+            commands.registerCommand('lean4.infoview.filterHiddenAssumptions', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'filterHiddenAssumptions',
+                    id: args.filterHiddenAssumptionsId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.showHiddenAssumptions', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'showHiddenAssumptions',
+                    id: args.showHiddenAssumptionsId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.filterLetValues', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'filterLetValues', id: args.filterLetValuesId }),
+            ),
+            commands.registerCommand('lean4.infoview.showLetValues', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'showLetValues', id: args.showLetValuesId }),
+            ),
+            commands.registerCommand('lean4.infoview.saveSettings', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'saveSettings', id: args.saveSettingsId }),
+            ),
         )
     }
 
@@ -592,7 +744,7 @@ export class InfoProvider implements Disposable {
         } else {
             const webviewPanel = window.createWebviewPanel(
                 'lean4_infoview',
-                'Lean Infoview',
+                'Lean InfoView',
                 { viewColumn: viewColumnOfInfoView(), preserveFocus: true },
                 {
                     enableFindWidget: true,
@@ -669,10 +821,14 @@ export class InfoProvider implements Disposable {
             allErrorsOnLine: getInfoViewAllErrorsOnLine(),
             autoOpenShowsGoal: getInfoViewAutoOpenShowsGoal(),
             debounceTime: getInfoViewDebounceTime(),
-            showExpectedType: getInfoViewShowExpectedType(),
+            expectedTypeVisibility: getInfoViewExpectedTypeVisibility(),
             showGoalNames: getInfoViewShowGoalNames(),
             emphasizeFirstGoal: getInfoViewEmphasizeFirstGoal(),
             reverseTacticState: getInfoViewReverseTacticState(),
+            filterTypes: getInfoViewFilterTypes(),
+            filterInstances: getInfoViewFilterInstances(),
+            filterHiddenAssumptions: getInfoViewFilterHiddenAssumptions(),
+            filterLetValues: getInfoViewFilterLetValues(),
             showTooltipOnHover: getInfoViewShowTooltipOnHover(),
         })
     }

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -37,10 +37,10 @@ import {
     getInfoViewDebounceTime,
     getInfoViewEmphasizeFirstGoal,
     getInfoViewExpectedTypeVisibility,
-    getInfoViewFilterHiddenAssumptions,
-    getInfoViewFilterInstances,
-    getInfoViewFilterLetValues,
-    getInfoViewFilterTypes,
+    getInfoViewHideHiddenAssumptions,
+    getInfoViewHideInstanceAssumptions,
+    getInfoViewHideLetValues,
+    getInfoViewHideTypeAssumptions,
     getInfoViewReverseTacticState,
     getInfoViewShowGoalNames,
     getInfoViewShowTooltipOnHover,
@@ -168,16 +168,16 @@ export class InfoProvider implements Disposable {
                 .update('reverseTacticState', config.reverseTacticState, ConfigurationTarget.Global)
             await workspace
                 .getConfiguration('lean4.infoview')
-                .update('filterTypes', config.filterTypes, ConfigurationTarget.Global)
+                .update('hideTypeAssumptions', config.hideTypeAssumptions, ConfigurationTarget.Global)
             await workspace
                 .getConfiguration('lean4.infoview')
-                .update('filterInstances', config.filterInstances, ConfigurationTarget.Global)
+                .update('hideInstanceAssumptions', config.hideInstanceAssumptions, ConfigurationTarget.Global)
             await workspace
                 .getConfiguration('lean4.infoview')
-                .update('filterHiddenAssumptions', config.filterHiddenAssumptions, ConfigurationTarget.Global)
+                .update('hideHiddenAssumptions', config.hideHiddenAssumptions, ConfigurationTarget.Global)
             await workspace
                 .getConfiguration('lean4.infoview')
-                .update('filterLetValues', config.filterLetValues, ConfigurationTarget.Global)
+                .update('hideLetValues', config.hideLetValues, ConfigurationTarget.Global)
             await workspace
                 .getConfiguration('lean4.infoview')
                 .update('showTooltipOnHover', config.showTooltipOnHover, ConfigurationTarget.Global)
@@ -470,6 +470,48 @@ export class InfoProvider implements Disposable {
                     id: args.displayAssumptionsBeforeTargetId,
                 }),
             ),
+            commands.registerCommand('lean4.infoview.hideTypeAssumptions', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'hideTypeAssumptions',
+                    id: args.hideTypeAssumptionsId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.showTypeAssumptions', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'showTypeAssumptions',
+                    id: args.showTypeAssumptionsId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.hideInstanceAssumptions', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'hideInstanceAssumptions',
+                    id: args.hideInstanceAssumptionsId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.showInstanceAssumptions', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'showInstanceAssumptions',
+                    id: args.showInstanceAssumptionsId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.hideHiddenAssumptions', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'hideHiddenAssumptions',
+                    id: args.hideHiddenAssumptionsId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.showHiddenAssumptions', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'showHiddenAssumptions',
+                    id: args.showHiddenAssumptionsId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.hideLetValues', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'hideLetValues', id: args.hideLetValuesId }),
+            ),
+            commands.registerCommand('lean4.infoview.showLetValues', args =>
+                this.webviewPanel?.api.clickedContextMenu({ entry: 'showLetValues', id: args.showLetValuesId }),
+            ),
             commands.registerCommand('lean4.infoview.hideGoalNames', args =>
                 this.webviewPanel?.api.clickedContextMenu({
                     entry: 'hideGoalNames',
@@ -493,36 +535,6 @@ export class InfoProvider implements Disposable {
                     entry: 'deemphasizeFirstGoal',
                     id: args.deemphasizeFirstGoalId,
                 }),
-            ),
-            commands.registerCommand('lean4.infoview.filterTypes', args =>
-                this.webviewPanel?.api.clickedContextMenu({ entry: 'filterTypes', id: args.filterTypesId }),
-            ),
-            commands.registerCommand('lean4.infoview.showTypes', args =>
-                this.webviewPanel?.api.clickedContextMenu({ entry: 'showTypes', id: args.showTypesId }),
-            ),
-            commands.registerCommand('lean4.infoview.filterInstances', args =>
-                this.webviewPanel?.api.clickedContextMenu({ entry: 'filterInstances', id: args.filterInstancesId }),
-            ),
-            commands.registerCommand('lean4.infoview.showInstances', args =>
-                this.webviewPanel?.api.clickedContextMenu({ entry: 'showInstances', id: args.showInstancesId }),
-            ),
-            commands.registerCommand('lean4.infoview.filterHiddenAssumptions', args =>
-                this.webviewPanel?.api.clickedContextMenu({
-                    entry: 'filterHiddenAssumptions',
-                    id: args.filterHiddenAssumptionsId,
-                }),
-            ),
-            commands.registerCommand('lean4.infoview.showHiddenAssumptions', args =>
-                this.webviewPanel?.api.clickedContextMenu({
-                    entry: 'showHiddenAssumptions',
-                    id: args.showHiddenAssumptionsId,
-                }),
-            ),
-            commands.registerCommand('lean4.infoview.filterLetValues', args =>
-                this.webviewPanel?.api.clickedContextMenu({ entry: 'filterLetValues', id: args.filterLetValuesId }),
-            ),
-            commands.registerCommand('lean4.infoview.showLetValues', args =>
-                this.webviewPanel?.api.clickedContextMenu({ entry: 'showLetValues', id: args.showLetValuesId }),
             ),
             commands.registerCommand('lean4.infoview.saveSettings', args =>
                 this.webviewPanel?.api.clickedContextMenu({ entry: 'saveSettings', id: args.saveSettingsId }),
@@ -825,10 +837,10 @@ export class InfoProvider implements Disposable {
             showGoalNames: getInfoViewShowGoalNames(),
             emphasizeFirstGoal: getInfoViewEmphasizeFirstGoal(),
             reverseTacticState: getInfoViewReverseTacticState(),
-            filterTypes: getInfoViewFilterTypes(),
-            filterInstances: getInfoViewFilterInstances(),
-            filterHiddenAssumptions: getInfoViewFilterHiddenAssumptions(),
-            filterLetValues: getInfoViewFilterLetValues(),
+            hideTypeAssumptions: getInfoViewHideTypeAssumptions(),
+            hideInstanceAssumptions: getInfoViewHideInstanceAssumptions(),
+            hideHiddenAssumptions: getInfoViewHideHiddenAssumptions(),
+            hideLetValues: getInfoViewHideLetValues(),
             showTooltipOnHover: getInfoViewShowTooltipOnHover(),
         })
     }

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -37,7 +37,7 @@ import {
     getInfoViewDebounceTime,
     getInfoViewEmphasizeFirstGoal,
     getInfoViewExpectedTypeVisibility,
-    getInfoViewHideHiddenAssumptions,
+    getInfoViewHideInaccessibleAssumptions,
     getInfoViewHideInstanceAssumptions,
     getInfoViewHideLetValues,
     getInfoViewHideTypeAssumptions,
@@ -174,7 +174,7 @@ export class InfoProvider implements Disposable {
                 .update('hideInstanceAssumptions', config.hideInstanceAssumptions, ConfigurationTarget.Global)
             await workspace
                 .getConfiguration('lean4.infoview')
-                .update('hideHiddenAssumptions', config.hideHiddenAssumptions, ConfigurationTarget.Global)
+                .update('hideInaccessibleAssumptions', config.hideInaccessibleAssumptions, ConfigurationTarget.Global)
             await workspace
                 .getConfiguration('lean4.infoview')
                 .update('hideLetValues', config.hideLetValues, ConfigurationTarget.Global)
@@ -494,16 +494,16 @@ export class InfoProvider implements Disposable {
                     id: args.showInstanceAssumptionsId,
                 }),
             ),
-            commands.registerCommand('lean4.infoview.hideHiddenAssumptions', args =>
+            commands.registerCommand('lean4.infoview.hideInaccessibleAssumptions', args =>
                 this.webviewPanel?.api.clickedContextMenu({
-                    entry: 'hideHiddenAssumptions',
-                    id: args.hideHiddenAssumptionsId,
+                    entry: 'hideInaccessibleAssumptions',
+                    id: args.hideInaccessibleAssumptionsId,
                 }),
             ),
-            commands.registerCommand('lean4.infoview.showHiddenAssumptions', args =>
+            commands.registerCommand('lean4.infoview.showInaccessibleAssumptions', args =>
                 this.webviewPanel?.api.clickedContextMenu({
-                    entry: 'showHiddenAssumptions',
-                    id: args.showHiddenAssumptionsId,
+                    entry: 'showInaccessibleAssumptions',
+                    id: args.showInaccessibleAssumptionsId,
                 }),
             ),
             commands.registerCommand('lean4.infoview.hideLetValues', args =>
@@ -839,7 +839,7 @@ export class InfoProvider implements Disposable {
             reverseTacticState: getInfoViewReverseTacticState(),
             hideTypeAssumptions: getInfoViewHideTypeAssumptions(),
             hideInstanceAssumptions: getInfoViewHideInstanceAssumptions(),
-            hideHiddenAssumptions: getInfoViewHideHiddenAssumptions(),
+            hideInaccessibleAssumptions: getInfoViewHideInaccessibleAssumptions(),
             hideLetValues: getInfoViewHideLetValues(),
             showTooltipOnHover: getInfoViewShowTooltipOnHover(),
         })

--- a/vscode-lean4/test/suite/info/info.test.ts
+++ b/vscode-lean4/test/suite/info/info.test.ts
@@ -8,7 +8,6 @@ import {
     clickInfoViewButton,
     closeActiveEditor,
     closeAllEditors,
-    findWord,
     gotoDefinition,
     gotoPosition,
     initLean4Untitled,
@@ -21,30 +20,6 @@ import {
 } from '../utils/helpers'
 
 suite('InfoView Test Suite', () => {
-    test('Copy to Comment', async () => {
-        logger.log('=================== Copy to Comment ===================')
-
-        const a = 37
-        const b = 22
-        const expectedEval1 = (a * b).toString()
-
-        const features = await initLean4Untitled(`#eval ${a}*${b}`)
-        const info = features.infoProvider
-        assert(info, 'No InfoProvider export')
-
-        await assertStringInInfoviewAt('#eval', info, expectedEval1)
-
-        logger.log('Clicking copyToComment button in InfoView')
-        await clickInfoViewButton(info, 'copy-to-comment')
-
-        logger.log(`Checking editor contains ${expectedEval1}`)
-        const editor = vscode.window.activeTextEditor
-        assert(editor !== undefined, 'no active editor')
-        await findWord(editor, expectedEval1)
-
-        await closeAllEditors()
-    }).timeout(60000)
-
     test('Pinning and unpinning', async () => {
         logger.log('=================== Pinning and unpinning ===================')
 

--- a/vscode-lean4/test/suite/simple/simple.test.ts
+++ b/vscode-lean4/test/suite/simple/simple.test.ts
@@ -107,7 +107,7 @@ suite('Lean4 Basics Test Suite', () => {
 
         // if goto definition worked, then we are in Version.lean and we should see the Lake version string.
         expectedVersion = 'Lake Version:'
-        html = await waitForInfoviewHtml(info, expectedVersion)
+        html = await waitForInfoviewHtmlAt('#eval s!"Lake', info, expectedVersion)
 
         // make sure test is always run in predictable state, which is no file or folder open
         await closeAllEditors()


### PR DESCRIPTION
This PR revamps the option and action UX of the InfoView. This work is motivated by several reports from users that they never knew that certain InfoView functionality existed, and intends to make these features more discoverable. Closes #592.

Specifically, the following adjustments are made:
- The filter menu was difficult to discover and users had trouble finding the 'reverse tactic state' functionality. To improve this, all goal state settings have been moved into a single 'Settings' menu that uses a standard cog icon, which should hopefully be much more recognizable. 
- All goal state settings are now also available in the 'Settings' submenu of the InfoView context menu.
- The 'Unselect All' context menu entry is now only visible when there is something to be unselected, as is the case for other context menu entries.
- All goal state settings can be persisted to the VS Code user settings with a context menu action or a button in the settings menu. Clients that do not support this functionality can hide the button in the settings menu by hiding the elements with `saveConfigButton` and `saveConfigLineBreak` classes.
- The `reverseTacticState`, `showGoalNames` and `emphasizeFirstGoal` settings have been made available in the InfoView goal state settings menu.
- All InfoView actions have been made available in the context menu.
- The 'Copy to comment' and 'Copy to clipboard' actions have been removed. As of [vscode#206529](https://github.com/microsoft/vscode/pull/206529), copying from VS Code webviews should work correctly out-of-the-box, so there is no need for these additional buttons that may unnecessarily complicate the UI anymore.
- The 'Refresh' action has been adjusted so that it is only displayed when the InfoView is paused to explicitly hint at the fact that it can be used to refresh the goal state while the InfoView is paused. Many users used to think that this was just the "Retry if InfoView is broken" button, which is practically never necessary.
- The tooltips of all InfoView icons have been adjusted to be a bit more descriptive.
- The `lean4.infoview.showExpectedType` setting has been deprecated in favor of the new `lean4.infoview.expectedTypeVisibility` setting, which allows hiding the expected type section entirely, as this section was reported to be confusing for students in a teaching environment.

<details>
<summary>Adjusted InfoView UI (Click to open)</summary>

![Adjusted InfoView UI](https://github.com/user-attachments/assets/3988695f-ff5b-4355-92fa-fdd62aae6cae)

</details>

<details>
<summary>New settings menu (Click to open)</summary>

![New settings menu](https://github.com/user-attachments/assets/14721d72-f9c3-423e-a642-40a1e12348a6)

</details>

<details>
<summary>New InfoView context menu (Click to open)</summary>

![New InfoView context menu](https://github.com/user-attachments/assets/e7b7b129-b74a-40f9-9fd6-63db2d4bba5e)

</details>