### PR TITLE
fix: don't display popups during mouse selection

### DIFF
--- a/lean4-infoview/package.json
+++ b/lean4-infoview/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@leanprover/infoview",
-    "version": "0.8.4",
+    "version": "0.8.5",
     "description": "An interactive display for the Lean 4 theorem prover.",
     "scripts": {
         "watch": "rollup --config --environment NODE_ENV:development --watch",

--- a/lean4-infoview/src/infoview/tooltips.tsx
+++ b/lean4-infoview/src/infoview/tooltips.tsx
@@ -280,7 +280,9 @@ export function useHoverTooltip(
     }
 
     const onPointerOver = (e: React.PointerEvent<HTMLSpanElement>) => {
-        if (!isModifierHeld(e)) {
+        // eslint-disable-next-line no-bitwise
+        const isSelectionHover = (e.buttons & 1) !== 0
+        if (!isModifierHeld(e) && !isSelectionHover) {
             guardMouseEvent(_ => startShowTimeout(), e)
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         },
         "lean4-infoview": {
             "name": "@leanprover/infoview",
-            "version": "0.8.4",
+            "version": "0.8.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "@leanprover/infoview-api": "~0.7.0",
@@ -16903,10 +16903,10 @@
         },
         "vscode-lean4": {
             "name": "lean4",
-            "version": "0.0.201",
+            "version": "0.0.204",
             "license": "Apache-2.0",
             "dependencies": {
-                "@leanprover/infoview": "~0.8.4",
+                "@leanprover/infoview": "~0.8.5",
                 "@leanprover/infoview-api": "~0.7.0",
                 "@leanprover/unicode-input": "~0.1.4",
                 "@leanprover/unicode-input-component": "~0.1.4",

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -1540,7 +1540,7 @@
         "test": "node ./out/test/suite/runTest.js"
     },
     "dependencies": {
-        "@leanprover/infoview": "~0.8.4",
+        "@leanprover/infoview": "~0.8.5",
         "@leanprover/infoview-api": "~0.7.0",
         "@leanprover/unicode-input": "~0.1.4",
         "@leanprover/unicode-input-component": "~0.1.4",


### PR DESCRIPTION
This PR ensures that the tooltip hover popup doesn't trigger while the primary mouse button is being held to prevent it from popping up while user are selecting text.