### PR TITLE
feat: improve server startup progress bar message

### DIFF
--- a/vscode-lean4/src/utils/batch.ts
+++ b/vscode-lean4/src/utils/batch.ts
@@ -32,6 +32,16 @@ function createCannotLaunchExecutionResult(message: string): ExecutionResult {
     }
 }
 
+export function formatCommandExecutionOutput(
+    workingDirectory: string | undefined,
+    executablePath: string,
+    args: string[],
+) {
+    const formattedCwd = workingDirectory ? `${workingDirectory}` : ''
+    const formattedArgs = args.map(arg => (arg.includes(' ') ? `"${arg}"` : arg)).join(' ')
+    return `${formattedCwd}> ${executablePath} ${formattedArgs}`
+}
+
 export function batchExecuteWithProc(
     executablePath: string,
     args: string[],
@@ -54,9 +64,7 @@ export function batchExecuteWithProc(
         options = { ...options, env }
     }
     if (channel?.combined) {
-        const formattedCwd = workingDirectory ? `${workingDirectory}` : ''
-        const formattedArgs = args.map(arg => (arg.includes(' ') ? `"${arg}"` : arg)).join(' ')
-        channel.combined.appendLine(`${formattedCwd}> ${executablePath} ${formattedArgs}`)
+        channel.combined.appendLine(formatCommandExecutionOutput(workingDirectory, executablePath, args))
     }
 
     let proc: ChildProcessWithoutNullStreams


### PR DESCRIPTION
This PR adjusts the progress bar message to reflect that it is cloning missing packages (suggesting that it may hence take a while). It also adjusts the output of `lake serve` in the output panel to mention the command that was called.