### PR TITLE
feat: improve `lake exe cache get` error reporting

### DIFF
--- a/vscode-lean4/src/utils/batch.ts
+++ b/vscode-lean4/src/utils/batch.ts
@@ -273,13 +273,17 @@ export function displayResultError(result: ExecutionResult, message: string) {
     if (result.exitCode === ExecutionExitCode.Success) {
         throw Error()
     }
-    const errorMessage: string = formatErrorMessage(result, message)
+    displayOutputError(result.combined, message)
+}
+
+export function displayOutputError(output: string, message: string) {
+    const errorMessage: string = formatErrorMessage(output, message)
     displayNotificationWithOutput('Error', errorMessage)
 }
 
-function formatErrorMessage(error: ExecutionResult, message: string): string {
-    if (error.combined === '') {
+function formatErrorMessage(output: string, message: string): string {
+    if (output === '') {
         return `${message}`
     }
-    return `${message} Command output: ${error.combined}`
+    return `${message} Command output: ${output}`
 }

--- a/vscode-lean4/src/utils/lake.ts
+++ b/vscode-lean4/src/utils/lake.ts
@@ -1,10 +1,7 @@
 import { OutputChannel } from 'vscode'
-import { ExecutionExitCode, ExecutionResult } from './batch'
+import { displayOutputError, ExecutionExitCode, ExecutionResult } from './batch'
 import { FileUri } from './exturi'
 import { leanRunner, ToolchainUpdateMode } from './leanCmdRunner'
-
-export const cacheNotFoundError = 'unknown executable `cache`'
-export const cacheNotFoundExitError = '=> Operation failed. Exit Code: 1.'
 
 export type LakeRunnerOptions = {
     channel: OutputChannel
@@ -13,6 +10,13 @@ export type LakeRunnerOptions = {
     toolchain?: string | undefined
     toolchainUpdateMode: ToolchainUpdateMode
 }
+
+export type TryFetchMathlibCacheResult = { kind: 'Success' } | { kind: 'Error'; output: string } | { kind: 'Cancelled' }
+
+export type FetchMathlibCacheResult =
+    // Invariant: `result.exitCode !== ExecutionExitCode.Cancelled`
+    // since this exit code always gets mapped to `{ kind: 'Cancelled' }`.
+    { kind: 'CacheAvailable'; result: ExecutionResult } | { kind: 'CacheUnavailable' } | { kind: 'Cancelled' }
 
 export class LakeRunner {
     constructor(readonly options: LakeRunnerOptions) {}
@@ -38,34 +42,80 @@ export class LakeRunner {
         return this.runLakeCommandWithProgress('clean', [], 'Cleaning Lean project')
     }
 
-    async fetchMathlibCache(filterError: boolean = false): Promise<ExecutionResult> {
-        const prompt = 'Checking Mathlib build artifact cache'
-        return this.runLakeCommandWithProgress('exe', ['cache', 'get'], prompt, line => {
-            if (filterError && line.includes(cacheNotFoundError)) {
-                return undefined
-            }
-            return line
-        })
+    private async runFetchMathlibCacheCommand(args: string[], prompt: string): Promise<FetchMathlibCacheResult> {
+        const availability = await this.isMathlibCacheGetAvailable()
+        if (availability === 'Cancelled') {
+            return { kind: 'Cancelled' }
+        }
+        if (availability === 'Unavailable') {
+            return { kind: 'CacheUnavailable' }
+        }
+        const result = await this.runLakeCommandWithProgress('exe', ['cache', 'get'].concat(args), prompt)
+        if (result.exitCode === ExecutionExitCode.Cancelled) {
+            return { kind: 'Cancelled' }
+        }
+        return { kind: 'CacheAvailable', result }
     }
 
-    async fetchMathlibCacheForFile(projectRelativeFileUri: FileUri): Promise<ExecutionResult> {
-        const prompt = `Fetching Mathlib build artifact cache for ${projectRelativeFileUri.baseName()}`
-        return this.runLakeCommandWithProgress('exe', ['cache', 'get', projectRelativeFileUri.fsPath], prompt)
+    private async tryRunFetchMathlibCacheCommand(args: string[], prompt: string): Promise<TryFetchMathlibCacheResult> {
+        const fetchResult = await this.runFetchMathlibCacheCommand(args, prompt)
+        if (fetchResult.kind === 'Cancelled') {
+            return { kind: 'Cancelled' }
+        }
+        if (fetchResult.kind === 'CacheUnavailable') {
+            return { kind: 'Success' }
+        }
+        if (fetchResult.result.exitCode === ExecutionExitCode.Cancelled) {
+            return { kind: 'Cancelled' }
+        }
+        if (fetchResult.result.exitCode !== ExecutionExitCode.Success) {
+            return { kind: 'Error', output: fetchResult.result.combined }
+        }
+        return { kind: 'Success' }
     }
 
-    async isMathlibCacheGetAvailable(): Promise<'Yes' | 'No' | 'Cancelled'> {
+    async fetchMathlibCache(): Promise<FetchMathlibCacheResult> {
+        return this.runFetchMathlibCacheCommand([], 'Fetching Mathlib build artifact cache')
+    }
+
+    async tryFetchMathlibCache(): Promise<TryFetchMathlibCacheResult> {
+        return this.tryRunFetchMathlibCacheCommand([], 'Fetching Mathlib build artifact cache')
+    }
+
+    async tryFetchMathlibCacheWithError(): Promise<'Success' | 'Failure'> {
+        const fetchResult = await this.tryFetchMathlibCache()
+        if (fetchResult.kind === 'Cancelled') {
+            return 'Failure'
+        }
+        if (fetchResult.kind !== 'Success') {
+            displayOutputError(fetchResult.output, 'Cannot fetch Mathlib build artifact cache.')
+            return 'Failure'
+        }
+        return 'Success'
+    }
+
+    async fetchMathlibCacheForFile(projectRelativeFileUri: FileUri): Promise<FetchMathlibCacheResult> {
+        return this.runFetchMathlibCacheCommand(
+            [projectRelativeFileUri.fsPath],
+            `Fetching Mathlib build artifact cache for ${projectRelativeFileUri.baseName()}`,
+        )
+    }
+
+    async isMathlibCacheGetAvailable(): Promise<'Available' | 'Unavailable' | 'Cancelled'> {
         const result: ExecutionResult = await this.runLakeCommandWithProgress(
             'exe',
             ['cache'],
             'Checking whether this is a Mathlib project',
+            // Filter the `lake exe cache` help string.
+            _line => undefined,
         )
         if (result.exitCode === ExecutionExitCode.Cancelled) {
             return 'Cancelled'
         }
         if (result.exitCode === ExecutionExitCode.Success) {
-            return 'Yes'
+            return 'Available'
         }
-        return 'No'
+        return 'Unavailable'
     }
 
     private async runLakeCommandWithProgress(


### PR DESCRIPTION
This PR ensures that the VS Code extension always reports the error that occurred when `lake exe cache get` fails in Mathlib or in a project downstream of Mathlib. Previously, this was only the case for project creation commands.