### PR TITLE
chore: remove the redundant `include: #stringBlock` in lean4 syntax

### DIFF
--- a/vscode-lean4/syntaxes/lean4.json
+++ b/vscode-lean4/syntaxes/lean4.json
@@ -118,7 +118,6 @@
             "patterns": [
                 { "include": "#dashComment" },
                 { "include": "#docComment" },
-                { "include": "#stringBlock" },
                 { "include": "#modDocComment" },
                 { "include": "#blockComment" }
             ]


### PR DESCRIPTION
`#stringBlock` is a block in the lean 3 / lean 4 syntax file, and it was added in 48ad018 on 2020-06-23, when people were developing in the legacy vscode-lean repo.
Later, `#stringBlock` was removed in ca65431 on 2021-01-18 when migrating from lean 3 to lean 4.
Somehow, the `include` line was forgotten. This PR now removes the line.

In fact, VS Code’s parser (vscode-textmate) will tolerate missing includes, so the original syntax works.
(You could verify it by amending `~/.vscode/extensions/leanprover.lean4-0.0.207/syntaxes/lean4.json` and reloading the VS Code window.)

However, including the inexistent `#stringBlock` will cause problems for a downstream project. 
If you are concerned about the details, please refer to https://github.com/sharkdp/bat/issues/3286.