### PR TITLE
feat: add a second two sided abbreviation for ‖z‖

### DIFF
--- a/lean4-unicode-input/src/abbreviations.json
+++ b/lean4-unicode-input/src/abbreviations.json
@@ -13,6 +13,7 @@
     "f<>": "‹$CURSOR›",
     "f<<>>": "«$CURSOR»",
     "[--]": "⁅$CURSOR⁆",
+    "||||": "‖$CURSOR‖",
     "nnnorm": "‖$CURSOR‖₊",
     "norm": "‖$CURSOR‖",
     "floor": "⌊$CURSOR⌋",


### PR DESCRIPTION
We already have `norm`, but this matches the convention for other "bracketed" abbreviations where `\<opening><closing>` produces `<opening>$CURSOR<closing>`.