### PR TITLE
chore: bump recommended elan version to 4.0.0

### DIFF
--- a/vscode-lean4/src/diagnostics/setupDiagnoser.ts
+++ b/vscode-lean4/src/diagnostics/setupDiagnoser.ts
@@ -35,7 +35,7 @@ export type LakeAvailabilityResult =
 export type ElanDumpStateWithoutNetQueryResult = ElanDumpStateWithoutNetResult | { kind: 'PreEagerResolutionVersion' }
 export type ElanDumpStateWithNetQueryResult = ElanDumpStateWithNetResult | { kind: 'PreEagerResolutionVersion' }
 
-const recommendedElanVersion = new SemVer('3.1.1')
+const recommendedElanVersion = new SemVer('4.0.0')
 // Should be bumped in a release *before* we bump the version requirement of the VS Code extension so that
 // users know that they need to update and do not get stuck on an old VS Code version.
 const recommendedVSCodeVersion = new SemVer('1.75.0')


### PR DESCRIPTION
Elan 4.0.0 has been out for a while now, so we now issue a warning if the Elan version is older than that.