### PR TITLE
feat: re-add copy state/message functionality

### DIFF
--- a/lean4-infoview-api/src/infoviewApi.ts
+++ b/lean4-infoview-api/src/infoviewApi.ts
@@ -132,6 +132,8 @@ export type ContextMenuEntry =
     | 'refresh'
     | 'pauseAllMessages'
     | 'unpauseAllMessages'
+    | 'copyState'
+    | 'copyMessage'
     | 'goToPinnedLocation'
     | 'goToMessageLocation'
     | 'displayTargetBeforeAssumptions'

--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -462,6 +462,15 @@ export const FilteredGoals = React.memo(
             goalSettings.emphasizeFirstGoal,
         )
         useContextMenuEvent('saveSettings', () => saveConfig(), goalSettingsDifferFromDefaultConfig, [saveConfig])
+        useContextMenuEvent(
+            'copyState',
+            () => {
+                if (goals !== undefined) {
+                    void ec.api.copyToClipboard(goalsToString(goals))
+                }
+            },
+            goals !== undefined,
+        )
 
         const setOpenRef = React.useRef<React.Dispatch<React.SetStateAction<boolean>>>()
         useEvent(

--- a/lean4-infoview/src/infoview/messages.tsx
+++ b/lean4-infoview/src/infoview/messages.tsx
@@ -46,16 +46,29 @@ const MessageView = React.memo(({ uri, diag }: MessageViewProps) => {
         [uri, diag.fullRange, diag.range],
     )
 
-    const goToMessageLocationId = React.useId()
+    const messageId = React.useId()
     useEvent(
         ec.events.clickedContextMenu,
         async _ => void ec.revealLocation(loc),
         [loc],
-        `goToMessageLocation:${goToMessageLocationId}`,
+        `goToMessageLocation:${messageId}`,
+    )
+    useEvent(
+        ec.events.clickedContextMenu,
+        async _ => {
+            if (node.current) {
+                void ec.api.copyToClipboard(node.current.innerText)
+            }
+        },
+        [loc],
+        `copyMessage:${messageId}`,
     )
 
     return (
-        <Details initiallyOpen data-vscode-context={JSON.stringify({ goToMessageLocationId })}>
+        <Details
+            initiallyOpen
+            data-vscode-context={JSON.stringify({ goToMessageLocationId: messageId, copyMessageId: messageId })}
+        >
             <span className={severityClass}>
                 {title}
                 <span className="fr" onClick={e => e.preventDefault()}>

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -412,6 +412,18 @@
                 "description": "This command is an implementation detail of the 'Unpause 'All Messages'' context menu option in the infoview."
             },
             {
+                "command": "lean4.infoview.copyState",
+                "category": "Lean 4: InfoView",
+                "title": "Copy State",
+                "description": "This command is an implementation detail of the 'Copy State' context menu option in the infoview."
+            },
+            {
+                "command": "lean4.infoview.copyMessage",
+                "category": "Lean 4: InfoView",
+                "title": "Copy Message",
+                "description": "This command is an implementation detail of the 'Copy Message' context menu option in the infoview."
+            },
+            {
                 "command": "lean4.infoview.goToPinnedLocation",
                 "category": "Lean 4: InfoView",
                 "title": "Go to Pinned Location",
@@ -934,6 +946,14 @@
                     "when": "false"
                 },
                 {
+                    "command": "lean4.infoview.copyState",
+                    "when": "false"
+                },
+                {
+                    "command": "lean4.infoview.copyMessage",
+                    "when": "false"
+                },
+                {
                     "command": "lean4.infoview.goToPinnedLocation",
                     "when": "false"
                 },
@@ -1379,6 +1399,16 @@
                     "command": "lean4.infoview.unpauseAllMessages",
                     "when": "webviewId == 'lean4_infoview' && unpauseAllMessagesId",
                     "group": "1_info@7"
+                },
+                {
+                    "command": "lean4.infoview.copyState",
+                    "when": "webviewId == 'lean4_infoview' && copyStateId",
+                    "group": "1_info@8"
+                },
+                {
+                    "command": "lean4.infoview.copyMessage",
+                    "when": "webviewId == 'lean4_infoview' && copyMessageId",
+                    "group": "1_info@9"
                 },
                 {
                     "submenu": "lean4.infoview.contextMenuSettings",

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -446,6 +446,18 @@ export class InfoProvider implements Disposable {
                     id: args.unpauseAllMessagesId,
                 }),
             ),
+            commands.registerCommand('lean4.infoview.copyState', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'copyState',
+                    id: args.copyStateId,
+                }),
+            ),
+            commands.registerCommand('lean4.infoview.copyMessage', args =>
+                this.webviewPanel?.api.clickedContextMenu({
+                    entry: 'copyMessage',
+                    id: args.copyMessageId,
+                }),
+            ),
             commands.registerCommand('lean4.infoview.goToPinnedLocation', args =>
                 this.webviewPanel?.api.clickedContextMenu({
                     entry: 'goToPinnedLocation',


### PR DESCRIPTION
This PR re-adds the copy state/message to clipboard functionality after it was removed in #606. The functionality is available from the context menu (as the other "edit" webview actions are), not from an icon button.