### PR TITLE
feat: sort 'all messages' by proximity to cursor by default

### DIFF
--- a/lean4-infoview-api/src/infoviewApi.ts
+++ b/lean4-infoview-api/src/infoviewApi.ts
@@ -8,6 +8,7 @@ import type {
 } from 'vscode-languageserver-protocol'
 
 export type ExpectedTypeVisibility = 'Expanded by default' | 'Collapsed by default' | 'Hidden'
+export type MessageOrder = 'Sort by proximity to text cursor' | 'Sort by message location'
 
 export interface InfoviewConfig {
     allErrorsOnLine: boolean
@@ -22,6 +23,7 @@ export interface InfoviewConfig {
     hideInaccessibleAssumptions: boolean
     hideLetValues: boolean
     showTooltipOnHover: boolean
+    messageOrder: MessageOrder
 }
 
 /**
@@ -109,6 +111,7 @@ export const defaultInfoviewConfig: InfoviewConfig = {
     hideInaccessibleAssumptions: false,
     hideLetValues: false,
     showTooltipOnHover: true,
+    messageOrder: 'Sort by proximity to text cursor',
 }
 
 export type InfoviewActionKind =

--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -267,7 +267,12 @@ const InfoDisplayContent = React.memo((props: InfoDisplayContentProps) => {
                 <Details initiallyOpen key="messages">
                     <>Messages ({messages.length})</>
                     <div className="ml1">
-                        <MessagesList uri={pos.uri} messages={messages} />
+                        <MessagesList
+                            uri={pos.uri}
+                            messages={messages}
+                            pos={pos}
+                            sortOrder={'Sort by proximity to text cursor'}
+                        />
                     </div>
                 </Details>
             </div>

--- a/lean4-infoview/src/infoview/messages.tsx
+++ b/lean4-infoview/src/infoview/messages.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import fastIsEqual from 'react-fast-compare'
-import { Diagnostic, DiagnosticSeverity, DocumentUri, Location } from 'vscode-languageserver-protocol'
+import { Diagnostic, DiagnosticSeverity, DocumentUri, Location, Position, Range } from 'vscode-languageserver-protocol'
 
-import { LeanDiagnostic, LeanPublishDiagnosticsParams, RpcErrorCode } from '@leanprover/infoview-api'
+import { LeanDiagnostic, LeanPublishDiagnosticsParams, MessageOrder, RpcErrorCode } from '@leanprover/infoview-api'
 
 import { getInteractiveDiagnostics, InteractiveDiagnostic } from '@leanprover/infoview-api'
 import { Details } from './collapsing'
@@ -15,7 +15,9 @@ import {
     DocumentPosition,
     escapeHtml,
     Keyed,
+    PositionHelpers,
     useEvent,
+    useEventResult,
     usePausableState,
     useServerNotificationState,
 } from './util'
@@ -79,35 +81,130 @@ const MessageView = React.memo(({ uri, diag }: MessageViewProps) => {
     )
 }, fastIsEqual)
 
-function mkMessageViewProps(uri: DocumentUri, messages: InteractiveDiagnostic[]): Keyed<MessageViewProps>[] {
-    const views: MessageViewProps[] = messages
-        .sort((msga, msgb) => {
-            const a = msga.fullRange?.end || msga.range.end
-            const b = msgb.fullRange?.end || msgb.range.end
-            return a.line === b.line ? a.character - b.character : a.line - b.line
-        })
-        .map(m => {
-            return { uri, diag: m }
-        })
+function comparePosition(p1: Position, p2: Position): number {
+    const l = p1.line - p2.line
+    if (l !== 0) {
+        return l
+    }
+    return p1.character - p2.character
+}
+
+function compareRange(r1: Range, r2: Range): number {
+    const s = comparePosition(r1.start, r2.start)
+    if (s !== 0) {
+        return s
+    }
+    return comparePosition(r1.end, r2.end)
+}
+
+type Proximity = { relation: 'Before' | 'After' | 'Inside'; lineDistance: number; characterOffset: number }
+
+function computeProximity(r: Range, p: Position): Proximity {
+    if (PositionHelpers.isLessThanOrEqual(r.end, p)) {
+        return {
+            relation: 'Before',
+            lineDistance: p.line - r.end.line,
+            characterOffset: r.end.character,
+        }
+    }
+    if (PositionHelpers.isLessThan(p, r.start)) {
+        return {
+            relation: 'After',
+            lineDistance: r.start.line - p.line,
+            characterOffset: r.start.character,
+        }
+    }
+    return {
+        relation: 'Inside',
+        lineDistance: p.line - r.start.line,
+        characterOffset: r.start.character,
+    }
+}
+
+function relationPriority(r: 'Before' | 'After' | 'Inside'): number {
+    switch (r) {
+        case 'Inside':
+            return 0
+        case 'Before':
+            return 1
+        case 'After':
+            return 2
+    }
+}
+
+function compareProximity(p1: Proximity, p2: Proximity): number {
+    const ld = p1.lineDistance - p2.lineDistance
+    if (ld !== 0) {
+        return ld
+    }
+    const r = relationPriority(p1.relation) - relationPriority(p2.relation)
+    if (r !== 0) {
+        return r
+    }
+    const rel = p1.relation
+    if (rel === 'Before' || rel === 'Inside') {
+        return p2.characterOffset - p1.characterOffset
+    }
+    rel satisfies 'After'
+    return p1.characterOffset - p2.characterOffset
+}
+
+function sortDiags(
+    idiags: InteractiveDiagnostic[],
+    sortOrder: MessageOrder,
+    p: DocumentPosition | undefined,
+): InteractiveDiagnostic[] {
+    if (p === undefined || sortOrder === 'Sort by message location') {
+        return idiags.toSorted((d1, d2) => compareRange(d1.fullRange ?? d1.range, d2.fullRange ?? d2.range))
+    }
+    sortOrder satisfies 'Sort by proximity to text cursor'
+    return idiags.toSorted((d1, d2) => {
+        const p1 = computeProximity(d1.range, p)
+        const p2 = computeProximity(d2.range, p)
+        return compareProximity(p1, p2)
+    })
+}
+
+function mkMessageViewProps(
+    uri: DocumentUri,
+    messages: InteractiveDiagnostic[],
+    sortOrder: MessageOrder,
+    pos: DocumentPosition | undefined,
+): Keyed<MessageViewProps>[] {
+    const views: MessageViewProps[] = sortDiags(messages, sortOrder, pos).map(m => {
+        return { uri, diag: m }
+    })
 
     return addUniqueKeys(views, v => DocumentPosition.toString({ uri: v.uri, ...v.diag.range.start }))
 }
 
 /** Shows the given messages assuming they are for the given file. */
-export const MessagesList = React.memo(({ uri, messages }: { uri: DocumentUri; messages: InteractiveDiagnostic[] }) => {
-    const should_hide = messages.length === 0
-    if (should_hide) {
-        return <>No messages.</>
-    }
+export const MessagesList = React.memo(
+    ({
+        uri,
+        messages,
+        sortOrder,
+        pos,
+    }: {
+        uri: DocumentUri
+        messages: InteractiveDiagnostic[]
+        sortOrder: MessageOrder
+        pos: DocumentPosition | undefined
+    }) => {
+        const should_hide = messages.length === 0
+        if (should_hide) {
+            return <>No messages.</>
+        }
 
-    return (
-        <div className="ml1">
-            {mkMessageViewProps(uri, messages).map(m => (
-                <MessageView {...m} key={m.key} />
-            ))}
-        </div>
-    )
-})
+        return (
+            <div className="ml1">
+                {mkMessageViewProps(uri, messages, sortOrder, pos).map(m => (
+                    <MessageView {...m} key={m.key} />
+                ))}
+            </div>
+        )
+    },
+)
 
 function lazy<T>(f: () => T): () => T {
     let state: { t: T } | undefined
@@ -126,6 +223,12 @@ export function AllMessages({ uri: uri0 }: { uri: DocumentUri }) {
     const diags0 = React.useMemo(() => dc.get(uri0) || [], [dc, uri0]).filter(
         diag => diag.isSilent === undefined || !diag.isSilent,
     )
+
+    const curPos: DocumentPosition | undefined = useEventResult(ec.events.changedCursorLocation, loc =>
+        loc ? { uri: loc.uri, ...loc.range.start } : undefined,
+    )
+
+    const [sortOrder, setSortOrder] = React.useState<MessageOrder>(config.messageOrder)
 
     const iDiags0 = React.useMemo(
         () =>
@@ -202,6 +305,17 @@ export function AllMessages({ uri: uri0 }: { uri: DocumentUri }) {
                         }}
                     >
                         <a
+                            className={'link pointer mh2 dim codicon codicon-sort-precedence'}
+                            onClick={_ => {
+                                setSortOrder(o =>
+                                    o === 'Sort by message location'
+                                        ? 'Sort by proximity to text cursor'
+                                        : 'Sort by message location',
+                                )
+                            }}
+                            title={sortOrder}
+                        ></a>
+                        <a
                             className={
                                 'link pointer mh2 dim codicon ' +
                                 (isPaused ? 'codicon-debug-continue' : 'codicon-debug-pause')
@@ -213,7 +327,13 @@ export function AllMessages({ uri: uri0 }: { uri: DocumentUri }) {
                         ></a>
                     </span>
                 </>
-                <AllMessagesBody uri={uri} messages={iDiags} setNumDiags={setNumDiags} />
+                <AllMessagesBody
+                    uri={uri}
+                    messages={iDiags}
+                    setNumDiags={setNumDiags}
+                    sortOrder={sortOrder}
+                    pos={curPos}
+                />
             </Details>
         </RpcContext.Provider>
     )
@@ -223,10 +343,12 @@ interface AllMessagesBodyProps {
     uri: DocumentUri
     messages: () => Promise<InteractiveDiagnostic[]>
     setNumDiags: React.Dispatch<React.SetStateAction<number | undefined>>
+    sortOrder: MessageOrder
+    pos: DocumentPosition | undefined
 }
 
 /** We factor out the body of {@link AllMessages} which lazily fetches its contents only when expanded. */
-function AllMessagesBody({ uri, messages, setNumDiags }: AllMessagesBodyProps) {
+function AllMessagesBody({ uri, messages, setNumDiags, sortOrder, pos }: AllMessagesBodyProps) {
     const [msgs, setMsgs] = React.useState<InteractiveDiagnostic[] | undefined>(undefined)
     React.useEffect(() => {
         const fn = async () => {
@@ -238,7 +360,7 @@ function AllMessagesBody({ uri, messages, setNumDiags }: AllMessagesBodyProps) {
     }, [messages, setNumDiags])
     React.useEffect(() => () => /* Called on unmount. */ setNumDiags(undefined), [setNumDiags])
     if (msgs === undefined) return <>Loading messages...</>
-    else return <MessagesList uri={uri} messages={msgs} />
+    else return <MessagesList uri={uri} messages={msgs} sortOrder={sortOrder} pos={pos} />
 }
 
 /**

--- a/lean4-infoview/src/infoview/util.ts
+++ b/lean4-infoview/src/infoview/util.ts
@@ -31,6 +31,9 @@ export namespace PositionHelpers {
     export function isLessThanOrEqual(p1: Position, p2: Position): boolean {
         return p1.line < p2.line || (p1.line === p2.line && p1.character <= p2.character)
     }
+    export function isLessThan(p1: Position, p2: Position): boolean {
+        return p1.line < p2.line || (p1.line === p2.line && p1.character < p2.character)
+    }
 }
 
 export namespace RangeHelpers {

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -204,6 +204,15 @@
                     "default": true,
                     "markdownDescription": "Show the tooltip for an interactive element (e.g. a subexpression) when the pointer hovers over that element. When disabled, the element must be clicked for the tooltip to show up."
                 },
+                "lean4.infoview.messageOrder": {
+                    "type": "string",
+                    "enum": [
+                        "Sort by proximity to text cursor",
+                        "Sort by message location"
+                    ],
+                    "default": "Sort by proximity to text cursor",
+                    "markdownDescription": "Set the sort order of 'All Messages' in the InfoView."
+                },
                 "lean4.elaborationDelay": {
                     "type": "number",
                     "default": 200,

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -126,6 +126,10 @@ export function getInfoViewShowTooltipOnHover(): boolean {
     return workspace.getConfiguration('lean4.infoview').get('showTooltipOnHover', true)
 }
 
+export function getInfoViewMessageOrder(): 'Sort by proximity to text cursor' | 'Sort by message location' {
+    return workspace.getConfiguration('lean4.infoview').get('messageOrder', 'Sort by proximity to text cursor')
+}
+
 export function getElaborationDelay(): number {
     return workspace.getConfiguration('lean4').get('elaborationDelay', 200)
 }

--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -41,6 +41,7 @@ import {
     getInfoViewHideInstanceAssumptions,
     getInfoViewHideLetValues,
     getInfoViewHideTypeAssumptions,
+    getInfoViewMessageOrder,
     getInfoViewReverseTacticState,
     getInfoViewShowGoalNames,
     getInfoViewShowTooltipOnHover,
@@ -181,6 +182,9 @@ export class InfoProvider implements Disposable {
             await workspace
                 .getConfiguration('lean4.infoview')
                 .update('showTooltipOnHover', config.showTooltipOnHover, ConfigurationTarget.Global)
+            await workspace
+                .getConfiguration('lean4.infoview')
+                .update('messageOrder', config.messageOrder, ConfigurationTarget.Global)
         },
         sendClientRequest: async (uri: string, method: string, params: any): Promise<any> => {
             const extUri = parseExtUri(uri)
@@ -842,6 +846,7 @@ export class InfoProvider implements Disposable {
             hideInaccessibleAssumptions: getInfoViewHideInaccessibleAssumptions(),
             hideLetValues: getInfoViewHideLetValues(),
             showTooltipOnHover: getInfoViewShowTooltipOnHover(),
+            messageOrder: getInfoViewMessageOrder(),
         })
     }
 


### PR DESCRIPTION
This PR changes the default message order of 'All Messages' in the InfoView to be sorted by proximity to the text cursor. Both an InfoView icon button and a VS Code setting are available to switch this setting to instead order messages by their location.