### PR TITLE
feat: increase delay until completion requests are emitted

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -1609,7 +1609,8 @@
                 "files.eol": "\n",
                 "files.insertFinalNewline": true,
                 "files.trimFinalNewlines": true,
-                "files.trimTrailingWhitespace": true
+                "files.trimTrailingWhitespace": true,
+                "editor.quickSuggestionsDelay": 200
             }
         },
         "walkthroughs": [


### PR DESCRIPTION
This PR increases the delay until VS Code emits an auto-completion request from 10ms to 200ms. A delay of 10ms means that VS Code will immediately emit a completion request for the first character for most users, even if they continue typing, which tends to be very expensive if e.g. `import Mathlib` is at the top of the file.