### PR TITLE
feat: client-side for trace search

### DIFF
--- a/lean4-infoview-api/package.json
+++ b/lean4-infoview-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@leanprover/infoview-api",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "description": "Types and API for @leanprover/infoview.",
     "scripts": {
         "watch": "tsc --watch",

--- a/lean4-infoview-api/src/infoviewApi.ts
+++ b/lean4-infoview-api/src/infoviewApi.ts
@@ -7,6 +7,19 @@ import type {
     WorkspaceEdit,
 } from 'vscode-languageserver-protocol'
 
+export type ModuleHierarchyOptions = {}
+
+export type HighlightMatchesOptions = {}
+
+export interface RpcOptions {
+    highlightMatchesProvider?: HighlightMatchesOptions | undefined
+}
+
+export interface LeanServerCapabilities {
+    moduleHierarchyProvider?: ModuleHierarchyOptions | undefined
+    rpcProvider?: RpcOptions | undefined
+}
+
 export type ExpectedTypeVisibility = 'Expanded by default' | 'Collapsed by default' | 'Hidden'
 export type MessageOrder = 'Sort by proximity to text cursor' | 'Sort by message location'
 
@@ -180,7 +193,7 @@ export interface InfoviewApi {
     sentClientNotification(method: string, params: any): Promise<void>
 
     /** Must fire with the server's initialization message when the server is started or restarted. */
-    serverRestarted(serverInitializeResult: InitializeResult): Promise<void>
+    serverRestarted(serverInitializeResult: InitializeResult<LeanServerCapabilities>): Promise<void>
     /** Must fire with the server's message when the server is stopped. */
     serverStopped(serverStoppedReason: ServerStoppedReason | undefined): Promise<void>
 

--- a/lean4-infoview-api/src/rpcApi.ts
+++ b/lean4-infoview-api/src/rpcApi.ts
@@ -215,3 +215,38 @@ export function Widget_getWidgetSource(rs: RpcSessionAtPos, pos: Position, hash:
     }
     return rs.call<GetWidgetSourceParams, WidgetSource>('Lean.Widget.getWidgetSource', { pos, hash })
 }
+
+export type HighlightedSubexprInfo = SubexprInfo | 'highlighted'
+
+export type HighlightedCodeWithInfos = TaggedText<HighlightedSubexprInfo>
+
+export interface HighlightedTraceEmbed {
+    indent: number
+    cls: Name
+    msg: TaggedText<HighlightedMsgEmbed>
+    collapsed: boolean // collapsed by default
+    children: StrictOrLazy<TaggedText<HighlightedMsgEmbed>[], LazyTraceChildren>
+}
+
+export type HighlightedMsgEmbed =
+    | { expr: HighlightedCodeWithInfos }
+    | { goal: InteractiveGoal }
+    | { widget: { wi: UserWidgetInstance; alt: TaggedText<HighlightedMsgEmbed> } }
+    | { trace: HighlightedTraceEmbed }
+    | 'highlighted'
+
+interface HighlightMatchesParams {
+    query: string
+    msg: TaggedText<MsgEmbed>
+}
+
+export function highlightMatches(
+    rs: RpcSessionAtPos,
+    query: string,
+    msg: TaggedText<MsgEmbed>,
+): Promise<TaggedText<HighlightedMsgEmbed>> {
+    return rs.call<HighlightMatchesParams, TaggedText<HighlightedMsgEmbed>>('Lean.Widget.highlightMatches', {
+        query,
+        msg,
+    })
+}

--- a/lean4-infoview-api/src/rpcApi.ts
+++ b/lean4-infoview-api/src/rpcApi.ts
@@ -114,7 +114,6 @@ export type MsgEmbed =
     | { goal: InteractiveGoal }
     | { widget: { wi: UserWidgetInstance; alt: TaggedText<MsgEmbed> } }
     | { trace: TraceEmbed }
-    | { lazyTrace: [number, Name, MessageData] } // old collapsible trace support
 
 export type InteractiveDiagnostic = Omit<LeanDiagnostic, 'message'> & { message: TaggedText<MsgEmbed> }
 

--- a/lean4-infoview/package.json
+++ b/lean4-infoview/package.json
@@ -50,7 +50,7 @@
     },
     "dependencies": {
         "@leanprover/infoview-api": "~0.9.0",
-        "@vscode/codicons": "^0.0.32",
+        "@vscode/codicons": "^0.0.40",
         "@vscode-elements/react-elements": "^0.5.0",
         "es-module-lexer": "^1.5.4",
         "es-module-shims": "^1.7.3",

--- a/lean4-infoview/package.json
+++ b/lean4-infoview/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@leanprover/infoview",
-    "version": "0.8.6",
+    "version": "0.9.0",
     "description": "An interactive display for the Lean 4 theorem prover.",
     "scripts": {
         "watch": "rollup --config --environment NODE_ENV:development --watch",
@@ -49,7 +49,7 @@
         "typescript": "^5.4.5"
     },
     "dependencies": {
-        "@leanprover/infoview-api": "~0.8.0",
+        "@leanprover/infoview-api": "~0.9.0",
         "@vscode/codicons": "^0.0.32",
         "@vscode-elements/react-elements": "^0.5.0",
         "es-module-lexer": "^1.5.4",

--- a/lean4-infoview/src/index.tsx
+++ b/lean4-infoview/src/index.tsx
@@ -11,7 +11,7 @@ export { InteractiveCode, InteractiveCodeProps, Markdown } from './infoview/inte
 export { renderInfoview } from './infoview/main'
 export { RpcContext, useRpcSession } from './infoview/rpcSessions'
 export { ServerVersion } from './infoview/serverVersion'
-export { DynamicComponent, DynamicComponentProps, PanelWidgetProps, importWidgetModule } from './infoview/userWidget'
+export { DynamicComponent, DynamicComponentProps, importWidgetModule, PanelWidgetProps } from './infoview/userWidget'
 export {
     DocumentPosition,
     mapRpcError,

--- a/lean4-infoview/src/infoview/contexts.ts
+++ b/lean4-infoview/src/infoview/contexts.ts
@@ -1,11 +1,12 @@
 import * as React from 'react'
-import type { DocumentUri } from 'vscode-languageserver-protocol'
+import { ServerCapabilities, type DocumentUri } from 'vscode-languageserver-protocol'
 
 import {
     defaultInfoviewConfig,
     InfoviewConfig,
     LeanDiagnostic,
     LeanFileProgressProcessingInfo,
+    LeanServerCapabilities,
 } from '@leanprover/infoview-api'
 
 import { EditorConnection } from './editorConnection'
@@ -15,6 +16,7 @@ import { DocumentPosition } from './util'
 // Type-unsafe initializers for contexts which we immediately set up at the top-level.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 export const EditorContext = React.createContext<EditorConnection>(null as any)
+export const CapabilityContext = React.createContext<ServerCapabilities<LeanServerCapabilities> | undefined>(undefined)
 export const VersionContext = React.createContext<ServerVersion | undefined>(undefined)
 
 export const ConfigContext = React.createContext<InfoviewConfig>(defaultInfoviewConfig)

--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -209,6 +209,11 @@ select {
     margin-bottom: 0;
 }
 
+.trace-search {
+    width: 100%;
+    margin-bottom: 1em;
+}
+
 /* MarkupContent Layout */
 .tooltip-code-content ul {
     padding-left: 20px;
@@ -247,6 +252,10 @@ select {
 .removed-text {
     background-color: var(--vscode-diffEditor-removedTextBackground);
     border-radius: 2pt;
+}
+
+.highlighted-text {
+    background-color: var(--vscode-editor-findMatchBackground);
 }
 
 .b--inserted {

--- a/lean4-infoview/src/infoview/main.tsx
+++ b/lean4-infoview/src/infoview/main.tsx
@@ -17,7 +17,7 @@ import {
     LeanFileProgressProcessingInfo,
 } from '@leanprover/infoview-api'
 
-import { ConfigContext, EditorContext, ProgressContext, VersionContext } from './contexts'
+import { CapabilityContext, ConfigContext, EditorContext, ProgressContext, VersionContext } from './contexts'
 import { EditorConnection, EditorEvents } from './editorConnection'
 import { EventEmitter } from './event'
 import { Infos } from './infos'
@@ -61,6 +61,7 @@ function Main() {
         ec.events.serverRestarted,
         result => new ServerVersion(result.serverInfo?.version ?? ''),
     )
+    const capabilities = useEventResult(ec.events.serverRestarted, result => result.capabilities)
     const serverStoppedResult = useEventResult(ec.events.serverStopped)
     // NB: the cursor may temporarily become `undefined` when a file is closed. In this case
     // it's important not to reconstruct the `WithBlah` wrappers below since they contain state
@@ -99,13 +100,15 @@ function Main() {
 
     return (
         <ConfigContext.Provider value={config}>
-            <VersionContext.Provider value={serverVersion}>
-                <WithRpcSessions>
-                    <WithLspDiagnosticsContext>
-                        <ProgressContext.Provider value={allProgress}>{ret}</ProgressContext.Provider>
-                    </WithLspDiagnosticsContext>
-                </WithRpcSessions>
-            </VersionContext.Provider>
+            <CapabilityContext.Provider value={capabilities}>
+                <VersionContext.Provider value={serverVersion}>
+                    <WithRpcSessions>
+                        <WithLspDiagnosticsContext>
+                            <ProgressContext.Provider value={allProgress}>{ret}</ProgressContext.Provider>
+                        </WithLspDiagnosticsContext>
+                    </WithRpcSessions>
+                </VersionContext.Provider>
+            </CapabilityContext.Provider>
         </ConfigContext.Provider>
     )
 }

--- a/lean4-infoview/src/infoview/traceExplorer.tsx
+++ b/lean4-infoview/src/infoview/traceExplorer.tsx
@@ -7,13 +7,7 @@
  * @module
  */
 
-import {
-    InteractiveDiagnostics_msgToInteractive,
-    lazyTraceChildrenToInteractive,
-    MessageData,
-    MsgEmbed,
-    TraceEmbed,
-} from '@leanprover/infoview-api'
+import { lazyTraceChildrenToInteractive, MsgEmbed, TraceEmbed } from '@leanprover/infoview-api'
 import * as React from 'react'
 import { Goal } from './goals'
 import {
@@ -25,65 +19,6 @@ import {
 import { useRpcSession } from './rpcSessions'
 import { DynamicComponent } from './userWidget'
 import { mapRpcError, useAsyncWithTrigger } from './util'
-
-function LazyTrace({ col, cls, msg }: { col: number; cls: string; msg: MessageData }) {
-    const rs = useRpcSession()
-
-    const [tt, fetchTrace] = useAsyncWithTrigger(
-        () => InteractiveDiagnostics_msgToInteractive(rs, msg, col),
-        [rs, msg, col],
-    )
-
-    const [open, setOpen] = React.useState(false)
-
-    if (!open)
-        return (
-            <span
-                className="underline-hover pointer"
-                onClick={ev => {
-                    void fetchTrace()
-                    setOpen(true)
-                    ev.stopPropagation()
-                    ev.preventDefault()
-                }}
-            >
-                [{cls}] &gt;
-            </span>
-        )
-    else if (tt.state === 'resolved')
-        return (
-            <>
-                <span
-                    className="underline-hover pointer"
-                    onClick={ev => {
-                        setOpen(false)
-                        ev.stopPropagation()
-                        ev.preventDefault()
-                    }}
-                >
-                    [{cls}] ∨
-                </span>
-                <InteractiveMessage fmt={tt.value} />
-            </>
-        )
-    else if (tt.state === 'rejected')
-        return (
-            <>
-                <span
-                    className="underline-hover pointer"
-                    onClick={ev => {
-                        void fetchTrace()
-                        ev.stopPropagation()
-                        ev.preventDefault()
-                    }}
-                >
-                    [{cls}] Error (click to retry):
-                </span>{' '}
-                {mapRpcError(tt.error)}
-            </>
-        )
-    else return <span>[{cls}] Loading..</span>
-}
 
 const TraceClassContext = React.createContext<string>('')
 
@@ -189,8 +124,6 @@ function InteractiveMessageTag({ tag: embed }: InteractiveTagProps<MsgEmbed>): J
         )
     else if ('widget' in embed)
         return <DynamicComponent hash={embed.widget.wi.javascriptHash} props={embed.widget.wi.props} />
-    else if ('lazyTrace' in embed)
-        return <LazyTrace col={embed.lazyTrace[0]} cls={embed.lazyTrace[1]} msg={embed.lazyTrace[2]} />
     else if ('trace' in embed) return <Trace {...embed.trace} />
     else return <div>malformed MsgEmbed: {JSON.stringify(embed)}</div>
 }

--- a/lean4-infoview/src/infoview/traceExplorer.tsx
+++ b/lean4-infoview/src/infoview/traceExplorer.tsx
@@ -7,7 +7,7 @@
  * @module
  */
 
-import { lazyTraceChildrenToInteractive, MsgEmbed, TraceEmbed } from '@leanprover/infoview-api'
+import { HighlightedMsgEmbed, HighlightedTraceEmbed, lazyTraceChildrenToInteractive } from '@leanprover/infoview-api'
 import * as React from 'react'
 import { Goal } from './goals'
 import {
@@ -30,7 +30,8 @@ function abbreviateCommonPrefix(parent: string, cls: string): string {
     return clsParts.slice(i).join('.')
 }
 
-function TraceLine({ indent, cls, msg, icon }: TraceEmbed & { icon: string }) {
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+function TraceLine({ indent, cls, msg, icon }: HighlightedTraceEmbed & { icon: string }) {
     const spaces = ' '.repeat(indent)
     const abbrCls = abbreviateCommonPrefix(React.useContext(TraceClassContext), cls)
     return (
@@ -44,13 +45,12 @@ function TraceLine({ indent, cls, msg, icon }: TraceEmbed & { icon: string }) {
     )
 }
 
-function ChildlessTraceNode(traceEmbed: TraceEmbed) {
+function ChildlessTraceNode(traceEmbed: HighlightedTraceEmbed) {
     return <TraceLine {...traceEmbed} icon="" />
 }
 
-function CollapsibleTraceNode(traceEmbed: TraceEmbed) {
+function CollapsibleTraceNode(traceEmbed: HighlightedTraceEmbed) {
     const { cls, collapsed: collapsedByDefault, children: lazyKids } = traceEmbed
-
     const rs = useRpcSession()
     const [children, fetchChildren] = useAsyncWithTrigger(async () => {
         if ('strict' in lazyKids) {
@@ -60,7 +60,7 @@ function CollapsibleTraceNode(traceEmbed: TraceEmbed) {
         }
     }, [rs, lazyKids])
 
-    const [open, setOpen] = React.useState(!collapsedByDefault) // TODO: reset when collapsedByDefault changes?
+    const [open, setOpen] = React.useState(!collapsedByDefault)
     if (open && children.state === 'notStarted') void fetchChildren()
     let icon = open ? '▼' : '▶'
     if (children.state === 'loading') icon += ' ⋯'
@@ -99,12 +99,21 @@ function CollapsibleTraceNode(traceEmbed: TraceEmbed) {
     )
 }
 
-function Trace(traceEmbed: TraceEmbed) {
+function Trace(traceEmbed: HighlightedTraceEmbed) {
     const noChildren = 'strict' in traceEmbed.children && traceEmbed.children.strict.length === 0
-    return noChildren ? <ChildlessTraceNode {...traceEmbed} /> : <CollapsibleTraceNode {...traceEmbed} />
+    return noChildren ? (
+        <ChildlessTraceNode {...traceEmbed} />
+    ) : (
+        <CollapsibleTraceNode key={traceEmbed.collapsed ? 1 : 0} {...traceEmbed} />
+    )
 }
 
-function InteractiveMessageTag({ tag: embed }: InteractiveTagProps<MsgEmbed>): JSX.Element {
+function InteractiveMessageTag({
+    tag: embed,
+}: InteractiveTagProps<HighlightedMsgEmbed, HighlightedMsgEmbed>): JSX.Element {
+    if (embed === 'highlighted') {
+        return <span className="highlighted-text"></span>
+    }
     if ('expr' in embed) return <InteractiveCode fmt={embed.expr} />
     else if ('goal' in embed)
         return (
@@ -128,6 +137,6 @@ function InteractiveMessageTag({ tag: embed }: InteractiveTagProps<MsgEmbed>): J
     else return <div>malformed MsgEmbed: {JSON.stringify(embed)}</div>
 }
 
-export function InteractiveMessage({ fmt }: InteractiveTextComponentProps<MsgEmbed>) {
+export function InteractiveMessage({ fmt }: InteractiveTextComponentProps<HighlightedMsgEmbed>) {
     return InteractiveTaggedText({ fmt, InnerTagUi: InteractiveMessageTag })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,10 +28,10 @@
         },
         "lean4-infoview": {
             "name": "@leanprover/infoview",
-            "version": "0.8.6",
+            "version": "0.9.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@leanprover/infoview-api": "~0.8.0",
+                "@leanprover/infoview-api": "~0.9.0",
                 "@vscode-elements/react-elements": "^0.5.0",
                 "@vscode/codicons": "^0.0.32",
                 "es-module-lexer": "^1.5.4",
@@ -67,7 +67,7 @@
         },
         "lean4-infoview-api": {
             "name": "@leanprover/infoview-api",
-            "version": "0.8.0",
+            "version": "0.9.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "typescript": "^5.4.5",
@@ -16903,11 +16903,11 @@
         },
         "vscode-lean4": {
             "name": "lean4",
-            "version": "0.0.209",
+            "version": "0.0.210",
             "license": "Apache-2.0",
             "dependencies": {
-                "@leanprover/infoview": "~0.8.6",
-                "@leanprover/infoview-api": "~0.8.0",
+                "@leanprover/infoview": "~0.9.0",
+                "@leanprover/infoview-api": "~0.9.0",
                 "@leanprover/unicode-input": "~0.1.5",
                 "@leanprover/unicode-input-component": "~0.1.5",
                 "@vscode-elements/elements": "^1.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
             "dependencies": {
                 "@leanprover/infoview-api": "~0.9.0",
                 "@vscode-elements/react-elements": "^0.5.0",
-                "@vscode/codicons": "^0.0.32",
+                "@vscode/codicons": "^0.0.40",
                 "es-module-lexer": "^1.5.4",
                 "es-module-shims": "^1.7.3",
                 "react-fast-compare": "^3.2.2",
@@ -73,6 +73,11 @@
                 "typescript": "^5.4.5",
                 "vscode-languageserver-protocol": "^3.17.3"
             }
+        },
+        "lean4-infoview/node_modules/@vscode/codicons": {
+            "version": "0.0.40",
+            "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.40.tgz",
+            "integrity": "sha512-R8sEDXthD86JHsk3xERrMcTN6sMovbk1AXYB5/tGoEYCE8DWwya6al5VLrAmQYXC1bQhUHIfHALj8ijQUs11cQ=="
         },
         "lean4-unicode-input": {
             "name": "@leanprover/unicode-input",
@@ -3017,6 +3022,7 @@
             "version": "0.0.32",
             "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.32.tgz",
             "integrity": "sha512-3lgSTWhAzzWN/EPURoY4ZDBEA80OPmnaknNujA3qnI4Iu7AONWd9xF3iE4L+4prIe8E3TUnLQ4pxoaFTEEZNwg==",
+            "dev": true,
             "license": "CC-BY-4.0"
         },
         "node_modules/@vscode/test-electron": {

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -1707,8 +1707,8 @@
         "test": "node ./out/test/suite/runTest.js"
     },
     "dependencies": {
-        "@leanprover/infoview": "~0.8.6",
-        "@leanprover/infoview-api": "~0.8.0",
+        "@leanprover/infoview": "~0.9.0",
+        "@leanprover/infoview-api": "~0.9.0",
         "@leanprover/unicode-input": "~0.1.5",
         "@leanprover/unicode-input-component": "~0.1.5",
         "@vscode/codicons": "^0.0.36",

--- a/vscode-lean4/src/leanclient.ts
+++ b/vscode-lean4/src/leanclient.ts
@@ -35,6 +35,7 @@ import {
     LeanDiagnostic,
     LeanFileProgressParams,
     LeanFileProgressProcessingInfo,
+    LeanServerCapabilities,
     ServerStoppedReason,
 } from '@leanprover/infoview-api'
 import {
@@ -57,7 +58,6 @@ import {
     LeanModuleHierarchyImportsParams,
     LeanPrepareModuleHierarchyParams,
     LeanPublishDiagnosticsParams,
-    LeanServerCapabilities,
     p2cConverter,
     patchConverters,
     setDependencyBuildMode,
@@ -228,6 +228,7 @@ export class LeanClient implements Disposable {
         return this.client?.initializeResult?.capabilities
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
     leanServerCapabilities(): LeanServerCapabilities | undefined {
         return this.serverCapabilities()?.experimental
     }

--- a/vscode-lean4/src/utils/converters.ts
+++ b/vscode-lean4/src/utils/converters.ts
@@ -18,12 +18,6 @@ import * as async from 'vscode-languageclient/lib/common/utils/async'
 import * as ls from 'vscode-languageserver-protocol'
 import { automaticallyBuildDependencies } from '../config'
 
-export type ModuleHierarchyOptions = {}
-
-export interface LeanServerCapabilities {
-    moduleHierarchyProvider?: ModuleHierarchyOptions | undefined
-}
-
 export enum LeanTag {
     UnsolvedGoals = 1,
     GoalsAccomplished = 2,


### PR DESCRIPTION
This PR implements the client-side for a new trace search mechanism in the InfoView.

Demo:
![Search demo](https://github.com/user-attachments/assets/40b43409-8b70-44ee-ba42-2e2693e3120c)
