### PR TITLE
feat: clean up click interactions

### DIFF
--- a/lean4-infoview/src/infoview/collapsing.tsx
+++ b/lean4-infoview/src/infoview/collapsing.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { preventDoubleClickTextSelection, withPreventedClickOnTextSelection } from './util'
 
 /** Returns `[node, isVisible]`. Attach `node` to the dom element you care about as `<div ref={node}>...</div>` and
  * `isVisible` will change depending on whether the node is visible in the viewport or not. */
@@ -30,6 +31,7 @@ interface DetailsProps extends React.PropsWithoutRef<React.HTMLProps<HTMLDetails
     initiallyOpen?: boolean
     children: [React.ReactNode, ...React.ReactNode[]]
     setOpenRef?: (_: React.Dispatch<React.SetStateAction<boolean>>) => void
+    selectable?: boolean | undefined
 }
 
 /** Like `<details>` but can be programatically revealed using `setOpenRef`.
@@ -38,6 +40,7 @@ export function Details({
     initiallyOpen,
     children: [summary, ...children],
     setOpenRef,
+    selectable,
     ...props
 }: DetailsProps): JSX.Element {
     const [isOpen, setOpen] = React.useState<boolean>(initiallyOpen === undefined ? false : initiallyOpen)
@@ -45,12 +48,17 @@ export function Details({
     return (
         <details open={isOpen} {...props}>
             <summary
-                className="mv2 pointer "
-                onClick={e => {
-                    if (!e.defaultPrevented) setOpen(!isOpen)
+                className={'mv2 pointer ' + (!selectable ? 'non-selectable ' : '')}
+                onClick={withPreventedClickOnTextSelection(e => {
+                    if (e.defaultPrevented) {
+                        e.preventDefault()
+                        return
+                    }
+                    setOpen(!isOpen)
                     // See https://github.com/facebook/react/issues/15486#issuecomment-873516817
                     e.preventDefault()
-                }}
+                })}
+                onMouseDown={e => preventDoubleClickTextSelection(e)}
             >
                 {summary}
             </summary>

--- a/lean4-infoview/src/infoview/errors.tsx
+++ b/lean4-infoview/src/infoview/errors.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { withPreventedClickOnTextSelection } from './util'
 
 /** Error boundary as described in https://reactjs.org/docs/error-boundaries.html */
 export class ErrorBoundary extends React.Component<{ children?: React.ReactNode }, { error: string | undefined }> {
@@ -26,7 +27,10 @@ export class ErrorBoundary extends React.Component<{ children?: React.ReactNode 
                     {this.state.error}
                     <br />
                     <br />
-                    <a className="link pointer dim " onClick={() => this.setState({ error: undefined })}>
+                    <a
+                        className="link pointer dim "
+                        onClick={withPreventedClickOnTextSelection(() => this.setState({ error: undefined }))}
+                    >
                         Click to reload.
                     </a>
                 </div>

--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -15,7 +15,7 @@ import { Locations, LocationsContext, SelectableLocationSettings, useSelectableL
 import { useHoverHighlight } from './hoverHighlight'
 import { InteractiveCode } from './interactiveCode'
 import { WithTooltipOnHover } from './tooltips'
-import { useEvent } from './util'
+import { preventClickOnTextSelection, preventDoubleClickTextSelection, useEvent } from './util'
 
 /** Returns true if `h` is inaccessible according to Lean's default name rendering. */
 function isInaccessibleName(h: string): boolean {
@@ -242,7 +242,11 @@ export const Goal = React.memo((props: GoalProps) => {
     if (goal.userName && !settings.hideGoalNames) {
         return (
             <details open className={cn}>
-                <summary className="mv1 pointer">
+                <summary
+                    className="mv1 pointer"
+                    onClick={e => preventClickOnTextSelection(e)}
+                    onMouseDown={e => preventDoubleClickTextSelection(e)}
+                >
                     <strong className="goal-case">case </strong>
                     {goal.userName}
                 </summary>
@@ -339,7 +343,7 @@ export const FilteredGoals = React.memo(
             name: string,
         ) => (
             <a
-                className="link pointer tooltip-menu-content"
+                className="link pointer tooltip-menu-content non-selectable"
                 onClick={_ => {
                     setGoalSettings(settingFn)
                 }}
@@ -399,7 +403,7 @@ export const FilteredGoals = React.memo(
                 )}
                 <br className="saveConfigLineBreak" style={disabledSaveStyle} />
                 <a
-                    className="link pointer tooltip-menu-content saveConfigButton"
+                    className="link pointer tooltip-menu-content saveConfigButton non-selectable"
                     style={disabledSaveStyle}
                     onClick={_ => saveConfig()}
                 >
@@ -485,10 +489,7 @@ export const FilteredGoals = React.memo(
         )
 
         return (
-            <div
-                style={{ display: goals !== undefined ? 'block' : 'none' }}
-                data-vscode-context={JSON.stringify(context)}
-            >
+            <div style={goals !== undefined ? {} : { display: 'none' }} data-vscode-context={JSON.stringify(context)}>
                 <Details setOpenRef={r => (setOpenRef.current = r)} initiallyOpen={initiallyOpen}>
                     <>
                         {headerChildren}

--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -8,6 +8,7 @@ body {
 .font-code {
     color: var(--vscode-editor-foreground);
     font-family: var(--vscode-editor-font-family);
+    font-feature-settings: var(--vscode-editor-font-feature-settings);
     font-weight: var(--vscode-editor-font-weight);
     font-size: var(--vscode-editor-font-size);
     line-height: var(--vscode-editor-line-height);
@@ -174,7 +175,7 @@ select {
     line-height: var(--vscode-editor-line-height);
 }
 
-.tooltip-code-content a:hover {
+*[data-has-tooltip-on-hover] {
     cursor: pointer;
 }
 
@@ -272,4 +273,8 @@ select {
 
 .b--transparent {
     border-color: transparent;
+}
+
+.non-selectable {
+    user-select: none;
 }

--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -32,6 +32,7 @@ import {
     useAsyncWithTrigger,
     useEvent,
     usePausableState,
+    withPreventedClickOnTextSelection,
 } from './util'
 
 type InfoStatus = 'updating' | 'error' | 'ready'
@@ -75,7 +76,7 @@ const InfoStatusBar = React.memo((props: InfoStatusBarProps) => {
     }
 
     return (
-        <summary style={{ transition: 'color 0.5s ease' }} className={'mv2 pointer ' + statusColor}>
+        <summary style={{ transition: 'color 0.5s ease' }} className={'mv2 pointer non-selectable' + statusColor}>
             {locationString}
             {isPinned && !isPaused && ' (pinned)'}
             {!isPinned && isPaused && ' (paused)'}
@@ -220,7 +221,7 @@ function GoalInfoDisplay(props: GoalInfoDisplayProps) {
                 if (widget.name)
                     return (
                         <details key={`widget::${widget.id}::${widget.range?.toString()}`} open>
-                            <summary className="mv2 pointer">{widget.name}</summary>
+                            <summary className="mv2 pointer non-selectable">{widget.name}</summary>
                             {inner}
                         </details>
                     )
@@ -252,10 +253,7 @@ const InfoDisplayContent = React.memo((props: InfoDisplayContentProps) => {
                     Error updating: {error}.
                     <a
                         className="link pointer dim"
-                        onClick={e => {
-                            e.preventDefault()
-                            void triggerUpdate()
-                        }}
+                        onClick={withPreventedClickOnTextSelection(_ => void triggerUpdate())}
                     >
                         {' '}
                         Try again.
@@ -263,7 +261,7 @@ const InfoDisplayContent = React.memo((props: InfoDisplayContentProps) => {
                 </div>
             )}
             <GoalInfoDisplay pos={pos} goals={goals} termGoal={termGoal} userWidgets={userWidgets} />
-            <div style={{ display: hasMessages ? 'block' : 'none' }} key="messages">
+            <div style={hasMessages ? {} : { display: 'none' }} key="messages">
                 <Details initiallyOpen key="messages">
                     <>Messages ({messages.length})</>
                     <div className="ml1">
@@ -283,20 +281,14 @@ const InfoDisplayContent = React.memo((props: InfoDisplayContentProps) => {
                         Updating is paused.{' '}
                         <a
                             className="link pointer dim"
-                            onClick={e => {
-                                e.preventDefault()
-                                void triggerUpdate()
-                            }}
+                            onClick={withPreventedClickOnTextSelection(_ => void triggerUpdate())}
                         >
                             Refresh
                         </a>{' '}
                         or{' '}
                         <a
                             className="link pointer dim"
-                            onClick={e => {
-                                e.preventDefault()
-                                setPaused(false)
-                            }}
+                            onClick={withPreventedClickOnTextSelection(_ => setPaused(false))}
                         >
                             resume updating
                         </a>{' '}

--- a/lean4-infoview/src/infoview/interactiveCode.tsx
+++ b/lean4-infoview/src/infoview/interactiveCode.tsx
@@ -301,6 +301,7 @@ function InteractiveCodeTag({ tag: ct, fmt }: InteractiveTagProps<SubexprInfo, H
                     ht.onClick(e)
                     tt.onClick()
                 }}
+                onMouseDown={e => ht.onMouseDown(e)}
                 onPointerDown={e => {
                     sl.onPointerDown(e)
                     ht.onPointerDown(e)

--- a/lean4-infoview/src/infoview/util.ts
+++ b/lean4-infoview/src/infoview/util.ts
@@ -430,3 +430,36 @@ export function useAsyncPersistent<T>(fn: () => Promise<T>, deps: React.Dependen
     }
     return state
 }
+
+export function isAnyTextSelected(): boolean {
+    const s = window.getSelection()
+    return s !== null && !s.isCollapsed
+}
+
+export function preventClickOnTextSelection(e: React.MouseEvent<HTMLElement, MouseEvent>) {
+    if (isAnyTextSelected()) {
+        e.preventDefault()
+        return true
+    }
+    return false
+}
+
+export function withPreventedClickOnTextSelection(
+    f: React.MouseEventHandler<HTMLElement>,
+): React.MouseEventHandler<HTMLElement> {
+    return e => {
+        const isPrevented = preventClickOnTextSelection(e)
+        if (isPrevented) {
+            return
+        }
+        f(e)
+    }
+}
+
+export function preventDoubleClickTextSelection(e: React.MouseEvent<HTMLElement, MouseEvent>): boolean {
+    if (e.detail > 1) {
+        e.preventDefault()
+        return true
+    }
+    return false
+}


### PR DESCRIPTION
This PR ensures that all interactive InfoView features interact nicely with text selections and that we consistently use the cursor pointer for clickable elements. 

Specifically:
- Interactive components won't trigger when releasing the mouse while selecting text.
- Interactive components that toggle a state do not select text when double-clicking.
- Section headers (except for case tags) are not selectable.
- Interactive components use the cursor pointer.
- The InfoView now reflects the font feature settings of the editor (e.g. disabling ligatures).