### PR TITLE
feat: add shortcut for `↦`

### DIFF
--- a/lean4-unicode-input/src/abbreviations.json
+++ b/lean4-unicode-input/src/abbreviations.json
@@ -544,6 +544,7 @@
     "member": "∈",
     "mem": "∈",
     "measuredangle": "∡",
+    "ma": "↦",
     "mapsto": "↦",
     "male": "♂",
     "maltese": "✠",


### PR DESCRIPTION
Currently `\ma` turns into `♂`. This PR changes it to much more common `↦` (`\mapsto`).

Zulip discussion: [#mathlib4 > Switch to ↦ (\mapsto) globally @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Switch.20to.20.E2.86.A6.20.28.5Cmapsto.29.20globally/near/535319694)