### PR TITLE
fix: stale infoview messages

### DIFF
--- a/lean4-infoview/src/infoview/messages.tsx
+++ b/lean4-infoview/src/infoview/messages.tsx
@@ -277,7 +277,7 @@ function mkMessageViewProps(
         return { uri, diag: m }
     })
 
-    return addUniqueKeys(views, v => DocumentPosition.toString({ uri: v.uri, ...v.diag.range.start }))
+    return addUniqueKeys(views, v => JSON.stringify(v))
 }
 
 /** Shows the given messages assuming they are for the given file. */


### PR DESCRIPTION
This PR fixes a bug where the InfoView would sometimes display stale messages.

The cause of this issue is the introduction of an additional state variable for the message in #658 and the use of an inadequate key in #464.