### PR TITLE
feat: distinguish message tally by severity

### DIFF
--- a/lean4-infoview/src/infoview/index.css
+++ b/lean4-infoview/src/infoview/index.css
@@ -30,6 +30,13 @@ body {
     height: 16px;
 }
 
+.font-codicon {
+    font-weight: var(--vscode-editor-font-weight) !important;
+    font-size: var(--vscode-editor-font-size) !important;
+    line-height: var(--vscode-editor-line-height) !important;
+    vertical-align: middle;
+}
+
 /* These are syntax highlights for the string goal view. */
 .goal-goals {
     color: var(--vscode-lean4-infoView\.goalCount);

--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -19,7 +19,7 @@ import { Details } from './collapsing'
 import { ConfigContext, EditorContext, EnvPosContext, LspDiagnosticsContext, ProgressContext } from './contexts'
 import { GoalsLocation, Locations, LocationsContext } from './goalLocation'
 import { FilteredGoals, goalsToString } from './goals'
-import { lspDiagToInteractive, MessagesList } from './messages'
+import { lspDiagToInteractive, MessagesList, TallyDisplay, tallyOfDiags } from './messages'
 import { RpcContext, useRpcSessionAtPos } from './rpcSessions'
 import { PanelWidgetDisplay } from './userWidget'
 import {
@@ -263,7 +263,9 @@ const InfoDisplayContent = React.memo((props: InfoDisplayContentProps) => {
             <GoalInfoDisplay pos={pos} goals={goals} termGoal={termGoal} userWidgets={userWidgets} />
             <div style={hasMessages ? {} : { display: 'none' }} key="messages">
                 <Details initiallyOpen key="messages">
-                    <>Messages ({messages.length})</>
+                    <>
+                        Messages <TallyDisplay t={tallyOfDiags(messages)}></TallyDisplay>
+                    </>
                     <div className="ml1">
                         <MessagesList
                             uri={pos.uri}

--- a/lean4-infoview/src/infoview/util.ts
+++ b/lean4-infoview/src/infoview/util.ts
@@ -8,6 +8,16 @@ import { isRpcError, RpcErrorCode } from '@leanprover/infoview-api'
 import { EditorContext } from './contexts'
 import { EventEmitter } from './event'
 
+export function count<T>(xs: T[], p: (v: T) => boolean): number {
+    let n = 0
+    for (const x of xs) {
+        if (p(x)) {
+            n++
+        }
+    }
+    return n
+}
+
 /** A document URI and a position in that document. */
 export interface DocumentPosition extends Position {
     uri: DocumentUri


### PR DESCRIPTION
This PR distinguishes the message counters of "Messages" and "All Messages" in the InfoView by severity.

<img width="198" height="82" alt="image" src="https://github.com/user-attachments/assets/4583c822-bdb5-42b9-a069-65b1df9fd658" />

Closes #574.