### PR TITLE
fix: 'no active Lean tab' error when Lean tab is active

### DIFF
--- a/vscode-lean4/src/utils/leanEditorProvider.ts
+++ b/vscode-lean4/src/utils/leanEditorProvider.ts
@@ -141,6 +141,8 @@ export class LeanEditorProvider implements Disposable {
         this.subscriptions.push(window.onDidChangeVisibleTextEditors(editors => this.updateVisibleTextEditors(editors)))
 
         this._activeLeanEditor = this.filterLeanEditor(window.activeTextEditor)
+        this._lastActiveLeanEditor = this.filterLeanEditor(window.activeTextEditor)
+        this._lastActiveLeanDocument = this.filterLeanDocument(window.activeTextEditor?.document)
         this.subscriptions.push(window.onDidChangeActiveTextEditor(editor => this.updateActiveTextEditor(editor)))
 
         this._leanDocuments = this.filterLeanDocuments(workspace.textDocuments)


### PR DESCRIPTION
This PR fixes a bug where after starting VS Code, commands that need the last active Lean editor would produce a 'no active Lean tab' error despite a tab being active.