### PR TITLE
Use shallow clone when cloning mathlib (saves 388MB disk space)

### DIFF
--- a/vscode-lean4/src/projectinit.ts
+++ b/vscode-lean4/src/projectinit.ts
@@ -392,7 +392,7 @@ Open this project instead?`
 
             const result: ExecutionResult = await batchExecuteWithProgress(
                 'git',
-                ['clone', projectUri, projectFolder.fsPath],
+                ['clone', '--depth=1', projectUri, projectFolder.fsPath],
                 downloadProjectContext,
                 'Cloning project',
                 { channel: this.channel, allowCancellation: true },


### PR DESCRIPTION
The project setup currently downloads the entire repository history of mathlib, consisting of 24 thousand commits. This requires an additional 388 megabytes of disk space.

Passing `--depth=1` to git performs a shallow clone, which does not download all the commits, saving 388 megabytes of disk space.

This has not been fully tested, but starting to build the shallow clone with `lake build` seems to work.