### PR TITLE
fix: error when installing elan while running server

### DIFF
--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -208,6 +208,7 @@ async function activateLean4Features(
 ): Promise<Lean4EnabledFeatures> {
     const clientProvider = new LeanClientProvider(installer.getOutputChannel())
     elanCommandProvider.setClientProvider(clientProvider)
+    installer.setClientProvider(clientProvider)
     context.subscriptions.push(clientProvider)
 
     const infoProvider = new InfoProvider(clientProvider, context)

--- a/vscode-lean4/src/projectoperations.ts
+++ b/vscode-lean4/src/projectoperations.ts
@@ -378,8 +378,8 @@ export class ProjectOperationProvider implements Disposable {
                 toolchainUpdateMode: 'DoNotUpdate',
             })
 
-            const result: 'Success' | 'IsRestarting' = await activeClient.withStoppedClient(() => command(lakeRunner))
-            if (result === 'IsRestarting') {
+            const result = await activeClient.withStoppedClient(() => command(lakeRunner))
+            if (result.kind === 'IsRestarting') {
                 displayNotification('Error', 'Cannot run project action while restarting the server.')
             }
         } finally {


### PR DESCRIPTION
This PR fixes a bug where trying to re-install Elan from within VS Code while a Lean server is already running would cause the installation to spit out a "could not create link" error on Windows by shutting down all Lean servers when installing Elan.

Reported at [#new members > Lean4 installation problems @ 💬](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Lean4.20installation.20problems/near/543438069).