### PR TITLE
Fix ContentModified errors in info view while typing

### DIFF
--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -564,6 +564,7 @@ function InfoAux(props: InfoProps) {
                             // to the RPC sessions. Try again.
                             setUpdaterTick(t => t + 1)
                             reject('retry')
+                            return
                         }
 
                         let errorString = ''

--- a/lean4-infoview/src/infoview/util.ts
+++ b/lean4-infoview/src/infoview/util.ts
@@ -347,7 +347,7 @@ export function discardMethodNotFound(e: unknown): undefined {
     if (isRpcError(e) && e.code === RpcErrorCode.MethodNotFound) {
         return undefined
     } else {
-        throw mapRpcError(e)
+        throw e
     }
 }
 


### PR DESCRIPTION
**Issue:**

While typing up longer proofs, I frequently see an error in the info view: `Error updating: Error fetching goals: Rpc error: ContentModified: File changed.` (maybe it happens to me frequently because my computer is on the older side).

It's super annoying because all the usual premise/goal info in the view is temporarily cleared to display the error and I need to wait for Lean to finish its processing before the info appears again.

Here's a video with me making contrived edits to demonstrate the issue:
https://github.com/user-attachments/assets/a077a113-7821-44bc-a307-40c0b3d37bb4

I checked the code and there should already be logic in place to not clear the info view for this particular rpc error:
<img width="835" height="893" alt="image" src="https://github.com/user-attachments/assets/2c91dbf4-3197-4f54-8ef4-328c9fd8a883" />

**Root cause:**

Debugging, the original rpc error is being thrown from Widget_getWidgets
<img width="753" height="801" alt="image" src="https://github.com/user-attachments/assets/b59494dd-00d2-4c75-83ef-bb1ce75e3182" />

However, it's being handled by `discardMethodNotFound` which for this type of error, will call `mapRpcError`. This will convert the original rpc error with its code information into an opaque `Error` type. This bypasses the aforementioned `RpcErrorCode.ContentModified` check and we end up resolving with the error string incorrectly.

**Fix:**

* Update `discardMethodNotFound` to just rethrow the original exception when it's not the special case of `RpcErrorCode.MethodNotFound` which it's specifically written to handle.
* This allows the info view fetch error handling code to operate on the original rpc exception. `discardMethodNotFound` is not used anywhere else.