### PR TITLE
feat: setup diagnostic for whether OS is unsupported

### DIFF
--- a/vscode-lean4/src/diagnostics/fullDiagnostics.ts
+++ b/vscode-lean4/src/diagnostics/fullDiagnostics.ts
@@ -10,6 +10,7 @@ import {
     ElanDumpStateWithoutNetQueryResult,
     ElanVersionDiagnosis,
     LeanVersionDiagnosis,
+    OSVersionDiagnosis,
     ProjectSetupDiagnosis,
     SetupDiagnoser,
     SystemQueryResult,
@@ -31,6 +32,13 @@ export type FullDiagnostics = {
 
 function formatCommandOutput(cmdOutput: string): string {
     return '\n```\n' + cmdOutput + '\n```'
+}
+
+function formatOperatingSystem(os: string, versionDiagnosis: OSVersionDiagnosis): string {
+    if (versionDiagnosis.kind === 'Unsupported') {
+        return `${os} (Unsupported; recommended version: ${versionDiagnosis.recommendedVersion})`
+    }
+    return os
 }
 
 function formatVSCodeVersionDiagnosis(d: VSCodeVersionDiagnosis): string {
@@ -167,7 +175,7 @@ function formatElanInfo(d: FullDiagnostics): string {
 
 export function formatFullDiagnostics(d: FullDiagnostics): string {
     return [
-        `**Operating system**: ${d.systemInfo.operatingSystem}`,
+        `**Operating system**: ${formatOperatingSystem(d.systemInfo.operatingSystem, d.systemInfo.osVersionDiagnosis)}`,
         `**CPU architecture**: ${d.systemInfo.cpuArchitecture}`,
         `**CPU model**: ${d.systemInfo.cpuModels}`,
         `**Available RAM**: ${d.systemInfo.totalMemory}`,

--- a/vscode-lean4/src/diagnostics/setupDiagnostics.ts
+++ b/vscode-lean4/src/diagnostics/setupDiagnostics.ts
@@ -324,6 +324,16 @@ export class SetupDiagnostics {
                 return 'Fulfilled'
         }
     }
+
+    async checkIsOperatingSystemSupported(): Promise<PreconditionCheckResult> {
+        const systemInfo = diagnose({ channel: undefined, cwdUri: undefined }).querySystemInformation()
+        if (systemInfo.osVersionDiagnosis.kind === 'Unsupported') {
+            return await this.n.displaySetupWarning(
+                `Operating system version is unsupported. The current OS version is ${systemInfo.osType} (${systemInfo.osVersionDiagnosis.currentVersion}), but a version of at least ${systemInfo.osType} (${systemInfo.osVersionDiagnosis.recommendedVersion}) is recommended to run new Lean versions.`,
+            )
+        }
+        return 'Fulfilled'
+    }
 }
 
 export async function checkAll(

--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -191,6 +191,7 @@ async function checkLean4FeaturePreconditions(
     d: SetupDiagnostics,
 ): Promise<PreconditionCheckResult> {
     return await checkAll(
+        () => d.checkIsOperatingSystemSupported(),
         () => d.checkAreDependenciesInstalled(depInstaller, leanInstaller.getOutputChannel(), cwdUri),
         () => d.checkIsLean4Installed(leanInstaller, context, cwdUri, 'PromptAboutUpdate'),
         () =>


### PR DESCRIPTION
This PR adds a setup diagnostic that displays a warning if we detect that the user's OS version is unsupported for new Lean versions.

The macOS version is a placeholder for now.