### PR TITLE
fix: don't enable server logging by default

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -254,7 +254,7 @@
                 },
                 "lean4.logging.enabled": {
                     "type": "boolean",
-                    "default": "false",
+                    "default": false,
                     "markdownDescription": "Whether to log Lean language server messages."
                 },
                 "lean4.logging.dir": {


### PR DESCRIPTION
This PR fixes a bug where (on current core master) server logging was accidentally enabled by default.