### PR TITLE
fix: remove backtick name highlighting

### DIFF
--- a/vscode-lean4/syntaxes/lean4.json
+++ b/vscode-lean4/syntaxes/lean4.json
@@ -91,7 +91,6 @@
             "match": "(?<!\\]|\\w)'(\\\\(x[0-9A-Fa-f][0-9A-Fa-f]|u[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]|.))'",
             "captures": { "1": { "name": "constant.character.escape.lean4" } }
         },
-        { "match": "`+[^\\[(]\\S+", "name": "entity.name.lean4" },
         {
             "match": "\\b([0-9]+|0([xX][0-9a-fA-F]+)|[-]?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?)\\b",
             "name": "constant.numeric.lean4"


### PR DESCRIPTION
This PR removes the text mate grammar scope for name literals. As far as I can tell, it isn't being used in the VS Code default themes.

Example of something that is causing problems with the current highlighting where the whole file is highlighted:
```
def x := s!"{`False} "

def y := 1
```
