### PR TITLE
test: allow bootstrap tests to succeed when targeted toolchains already exist

### DIFF
--- a/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
+++ b/vscode-lean4/test/suite/bootstrap/bootstrap.test.ts
@@ -17,11 +17,11 @@ suite('Lean4 Bootstrap Test Suite', () => {
         const result = await batchExecute(method.script, [], undefined, undefined, undefined, method.shell)
         assert(result.exitCode === ExecutionExitCode.Success)
         const result2 = await batchExecute('elan', ['toolchain', 'install', 'leanprover/lean4:' + getTestLeanVersion()])
-        assert(result2.exitCode === ExecutionExitCode.Success)
+        assert(result2.exitCode === ExecutionExitCode.Success || result2.stderr.includes('is already installed'))
         const result3 = await batchExecute('elan', ['default', 'leanprover/lean4:' + getTestLeanVersion()])
         assert(result3.exitCode === ExecutionExitCode.Success)
         const result4 = await batchExecute('elan', ['toolchain', 'install', 'leanprover/lean4:' + getAltBuildVersion()])
-        assert(result4.exitCode === ExecutionExitCode.Success)
+        assert(result4.exitCode === ExecutionExitCode.Success || result4.stderr.includes('is already installed'))
 
         logger.log('Lean installation is complete.')
 


### PR DESCRIPTION
Currently, running tests locally as described in [`dev.md`](https://github.com/leanprover/vscode-lean4/blob/master/docs/dev.md) works at most one time.
In subsequent runs, the user's local `elan` installation already has the test and build toolchains installed.
This causes `elan toolchain install leanprover/lean4:x-y-z` to fail with the message
```
error: 'leanprover/lean4:x-y-z' is already installed
```

This PR makes the assertion succeed if the `...is already installed` error is printed, even if the exit code indicates failure.
This allows the test suit to be run multiple times locally.