### PR TITLE
test: change recursive `rmdir` to `rm` to fix DEP0147 warning

### DIFF
--- a/vscode-lean4/test/suite/runTest.ts
+++ b/vscode-lean4/test/suite/runTest.ts
@@ -7,7 +7,7 @@ import { logger } from '../../src/utils/logger'
 
 function clearUserWorkspaceData(vscodeTest: string) {
     const workspaceData = path.join(vscodeTest, 'user-data', 'Workspaces')
-    fs.rmdir(workspaceData, { recursive: true }, err => {
+    fs.rm(workspaceData, { recursive: true }, err => {
         logger.log(`deleted user workspace data ${workspaceData} is deleted!`)
     })
 }

--- a/vscode-lean4/test/suite/utils/helpers.ts
+++ b/vscode-lean4/test/suite/utils/helpers.ts
@@ -325,7 +325,7 @@ function nullHandler() {
 export function cleanTempFolder(name: string) {
     const path = join(os.tmpdir(), name)
     if (fs.existsSync(path)) {
-        fs.rmdirSync(path, { recursive: true })
+        fs.rmSync(path, { recursive: true })
     }
 }
 


### PR DESCRIPTION
This PR changes `rmdir*(..., {recursive: true})` to `rm*(..., {recursive: true})` as recommended in [DEP0147](https://nodejs.org/api/deprecations.html#dep0147-fsrmdirpath--recursive-true-).

This removes clutter in the testing suite output and prevents errors when the feature is removed by NodeJS.