### PR TITLE
feat: nested lean projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15648,17 +15648,17 @@
             }
         },
         "node_modules/vscode-languageclient": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
-            "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+            "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
             "license": "MIT",
             "dependencies": {
                 "minimatch": "^5.1.0",
                 "semver": "^7.3.7",
-                "vscode-languageserver-protocol": "3.17.3"
+                "vscode-languageserver-protocol": "3.17.5"
             },
             "engines": {
-                "vscode": "^1.67.0"
+                "vscode": "^1.82.0"
             }
         },
         "node_modules/vscode-languageclient/node_modules/minimatch": {
@@ -15672,31 +15672,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/vscode-languageclient/node_modules/vscode-jsonrpc": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-            "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/vscode-languageclient/node_modules/vscode-languageserver-protocol": {
-            "version": "3.17.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-            "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
-            "license": "MIT",
-            "dependencies": {
-                "vscode-jsonrpc": "8.1.0",
-                "vscode-languageserver-types": "3.17.3"
-            }
-        },
-        "node_modules/vscode-languageclient/node_modules/vscode-languageserver-types": {
-            "version": "3.17.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
-            "license": "MIT"
         },
         "node_modules/vscode-languageserver-protocol": {
             "version": "3.17.5",
@@ -16468,7 +16443,7 @@
                 "markdown-it": "^14.1.0",
                 "markdown-it-anchor": "^9.0.1",
                 "semver": "^7.6.0",
-                "vscode-languageclient": "^8.0.2",
+                "vscode-languageclient": "^9.0.1",
                 "zod": "^3.22.4"
             },
             "devDependencies": {

--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -65,11 +65,6 @@
                     "default": true,
                     "markdownDescription": "Enable eager replacement of abbreviations that uniquely identify a symbol."
                 },
-                "lean4.fallBackToStringOccurrenceHighlighting": {
-                    "type": "boolean",
-                    "description": "Fall back to string-based occurrence highlighting when there are no semantic symbol occurrences from the Lean language server to highlight.",
-                    "default": false
-                },
                 "lean4.automaticallyBuildDependencies": {
                     "type": "boolean",
                     "default": false,
@@ -1775,7 +1770,7 @@
         "markdown-it": "^14.1.0",
         "markdown-it-anchor": "^9.0.1",
         "semver": "^7.6.0",
-        "vscode-languageclient": "^8.0.2",
+        "vscode-languageclient": "^9.0.1",
         "zod": "^3.22.4"
     },
     "devDependencies": {

--- a/vscode-lean4/src/config.ts
+++ b/vscode-lean4/src/config.ts
@@ -173,10 +173,6 @@ export function shouldShowSetupWarnings(): boolean {
     return workspace.getConfiguration('lean4').get('showSetupWarnings', true)
 }
 
-export function getFallBackToStringOccurrenceHighlighting(): boolean {
-    return workspace.getConfiguration('lean4').get('fallBackToStringOccurrenceHighlighting', false)
-}
-
 export function showDiagnosticGutterDecorations(): boolean {
     return workspace.getConfiguration('lean4').get('showDiagnosticGutterDecorations', true)
 }

--- a/vscode-lean4/src/utils/clientProvider.ts
+++ b/vscode-lean4/src/utils/clientProvider.ts
@@ -34,7 +34,6 @@ async function checkLean4ProjectPreconditions(
                 toolchainUpdateMode: 'PromptAboutUpdate',
             })
         },
-        () => d.checkIsNestedProjectFolder(existingFolderUris, folderUri, fileUri, stopOtherServer),
     )
 }
 
@@ -200,10 +199,10 @@ export class LeanClientProvider implements Disposable {
     }
 
     // Find the client for a given document.
-    findClient(path: ExtUri) {
+    findClient(path: ExtUri): LeanClient | undefined {
         const candidates = this.getClients().filter(client => client.isInFolderManagedByThisClient(path))
         // All candidate folders are a prefix of `path`, so they must necessarily be prefixes of one another
-        // => the best candidate (the most top-level client folder) is just the one with the shortest path
+        // => the best candidate (the innermost client folder) is just the one with the longest path
         let bestCandidate: LeanClient | undefined
         for (const candidate of candidates) {
             if (!bestCandidate) {
@@ -215,7 +214,7 @@ export class LeanClientProvider implements Disposable {
             if (
                 folder.scheme === 'file' &&
                 bestFolder.scheme === 'file' &&
-                folder.fsPath.length < bestFolder.fsPath.length
+                folder.fsPath.length > bestFolder.fsPath.length
             ) {
                 bestCandidate = candidate
             }

--- a/vscode-lean4/src/utils/exturi.ts
+++ b/vscode-lean4/src/utils/exturi.ts
@@ -58,6 +58,10 @@ export class FileUri {
         return FileUri.fromUriOrError(Uri.joinPath(this.asUri(), ...pathSegments))
     }
 
+    normalize(): FileUri {
+        return this.join()
+    }
+
     isInFolder(folderUri: FileUri): boolean {
         return isFileInFolder(this.fsPath, folderUri.fsPath)
     }
@@ -80,6 +84,14 @@ export function isWorkspaceFolder(uri: FileUri): boolean {
         return false
     }
     return workspace.workspaceFolders.some(folder => uri.equalsUri(folder.uri))
+}
+
+export function getWorkspaceFolderUri(uri: FileUri): FileUri | undefined {
+    const workspaceFolder = workspace.getWorkspaceFolder(uri.asUri())
+    if (workspaceFolder === undefined) {
+        return undefined
+    }
+    return FileUri.fromUri(workspaceFolder.uri)
 }
 
 export class UntitledUri {


### PR DESCRIPTION
This PR adds for language server support for nested Lean projects. With this PR, nested Lean projects do not yield an error anymore. Files in nested projects are associated with the innermost language client containing them.

### Other changes
- The `lean4.fallBackToStringOccurrenceHighlighting` is removed. We put this functionality behind the `lean4.fallBackToStringOccurrenceHighlighting` setting (that is disabled by default) in #377 with the goal of removing it eventually.
- The language client library is updated from 8.0.2 to 9.0.2.

### Implementation notes
Support for nested Lean projects was not deemed possible previously due to inadequate support for nested language clients in VS Code's language client library. In the language client library (and the VS Code API), files are associated with a language client (or in VS Code with a specific editor functionality) via globs. Hence, nesting two projects would associate the Lean files of the inner project with both the inner and the outer language client, duplicating language server support (e.g. producing duplicate hovers). These globs cannot express subfolder exclusions.

In this PR, we work around this limitation by abusing the general request and notification middleware extension points of the language client library to filter requests and notifications for excluded subfolders (i.e. inner Lean projects). 
For notifications, this is as simple as not emitting the message. For requests, the API does not permit filtering a generic request, so we use another hack: the new middleware throws a `ContentModified` exception for filtered requests, for which the current code of the language client library ensures that it is not displayed to the user and that it returns a default value. For every request type, this default value is chosen by the language client library such that VS Code will ignore the provider of the language client that produces it and query another provider to obtain a result. Thus, we can use this mechanism to triage requests for files in an inner project by letting them pass through to the inner language server and filtering them from communication with the outer language server.