### PR TITLE
feat: adjustments for elan path toolchains

### DIFF
--- a/vscode-lean4/src/utils/elan.ts
+++ b/vscode-lean4/src/utils/elan.ts
@@ -68,8 +68,9 @@ export type ElanRemoteUnresolvedToolchain = {
     release: string
     fromChannel: ElanOption<string>
 }
+export type ElanPathUnresolvedToolchain = { kind: 'Path'; path: string }
 
-export type ElanUnresolvedToolchain = ElanLocalUnresolvedToolchain | ElanRemoteUnresolvedToolchain
+export type ElanUnresolvedToolchain = ElanLocalUnresolvedToolchain | ElanRemoteUnresolvedToolchain | ElanPathUnresolvedToolchain
 
 export namespace ElanUnresolvedToolchain {
     export function toolchainName(unresolved: ElanUnresolvedToolchain): string {
@@ -78,6 +79,8 @@ export namespace ElanUnresolvedToolchain {
                 return unresolved.toolchain
             case 'Remote':
                 return unresolved.githubRepoOrigin + ':' + unresolved.release
+            case 'Path':
+                return unresolved.path
         }
     }
 }
@@ -155,6 +158,11 @@ function zodElanUnresolvedToolchain() {
                 from_channel: z.nullable(z.string()),
             }),
         }),
+        z.object({
+            Path: z.object({
+                path: z.string()
+            })
+        })
     ])
 }
 
@@ -204,10 +212,18 @@ function convertElanUnresolvedToolchain(
                   release: string
                   from_channel: string | null
               }
+          }
+        | {
+              Path: {
+                  path: string
+              }
           },
 ): ElanUnresolvedToolchain {
     if ('Local' in zodElanUnresolvedToolchain) {
         return { kind: 'Local', toolchain: zodElanUnresolvedToolchain.Local.name }
+    }
+    if ('Path' in zodElanUnresolvedToolchain) {
+        return { kind: 'Path', path: zodElanUnresolvedToolchain.Path.path }
     }
     zodElanUnresolvedToolchain satisfies {
         Remote: {

--- a/vscode-lean4/src/utils/leanCmdRunner.ts
+++ b/vscode-lean4/src/utils/leanCmdRunner.ts
@@ -147,7 +147,7 @@ export class LeanCommandRunner {
             return runWithActiveToolchain
         }
 
-        if (unresolvedToolchain.kind === 'Local') {
+        if (unresolvedToolchain.kind === 'Local' || unresolvedToolchain.kind === 'Path') {
             return runWithActiveToolchain
         }
 
@@ -253,7 +253,7 @@ export class LeanCommandRunner {
             return runWithActiveToolchain
         }
 
-        if (unresolvedToolchain.kind === 'Local' || unresolvedToolchain.fromChannel === undefined) {
+        if (unresolvedToolchain.kind === 'Local' || unresolvedToolchain.kind === 'Path' || unresolvedToolchain.fromChannel === undefined) {
             return runWithActiveToolchain
         }
 


### PR DESCRIPTION
This PR adds vscode-lean4 support for the extended `elan dump-state` format in Elan 4.2.0, which includes information on path toolchains.