### PR TITLE
fix: markdown highlighting comment termination bugs

### DIFF
--- a/vscode-lean4/syntaxes/lean4-markdown.json
+++ b/vscode-lean4/syntaxes/lean4-markdown.json
@@ -2062,7 +2062,7 @@
                                     "include": "text.html.derivative"
                                 }
                             ],
-                            "while": "(?i)^(?!.*</(script|style|pre)>)"
+                            "while": "(?i)^(?!.*</(script|style|pre)>|\\s*-/)"
                         }
                     ]
                 },
@@ -2073,7 +2073,7 @@
                             "include": "text.html.derivative"
                         }
                     ],
-                    "while": "^(?!\\s*$)"
+                    "while": "^(?!\\s*$|\\s*-/)"
                 },
                 {
                     "begin": "(^|\\G)\\s*(?=(<[a-zA-Z0-9\\-](/?>|\\s.*?>)|</[a-zA-Z0-9\\-]>)\\s*$)",
@@ -2082,7 +2082,7 @@
                             "include": "text.html.derivative"
                         }
                     ],
-                    "while": "^(?!\\s*$)"
+                    "while": "^(?!\\s*$|\\s*-/)"
                 }
             ]
         },
@@ -2284,7 +2284,7 @@
                     "name": "punctuation.definition.bold.markdown"
                 }
             },
-            "end": "(?<=\\S)(\\1)",
+            "end": "(?<=\\S)(\\1)|(?=$)",
             "name": "markup.bold.markdown",
             "patterns": [
                 {
@@ -2429,7 +2429,7 @@
                     "name": "punctuation.definition.italic.markdown"
                 }
             },
-            "end": "(?<=\\S)(\\1)((?!\\1)|(?=\\1\\1))",
+            "end": "(?<=\\S)(\\1)((?!\\1)|(?=\\1\\1))|(?=$)",
             "name": "markup.italic.markdown",
             "patterns": [
                 {


### PR DESCRIPTION
Fixes #369 and #656, as well as the issues reported at https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Comment.20syntax.20highlighting/near/565502952 and https://leanprover.zulipchat.com/#narrow/channel/561906-Editors-.26-UIs/topic/Syntax.20highlighting.20bug.20makes.20everything.20blue/near/573942750.