### PR TITLE
chore: ensure that on-push release job runs

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -243,6 +243,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Compute next version
         id: version
@@ -277,6 +278,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Compute next version
         id: version


### PR DESCRIPTION
GitHub won't run on-push CI that was triggered by a manual workflow dispatch, but it should do it if we set a PAT.