### PR TITLE
chore: revert "Release 0.0.226"

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -2,7 +2,7 @@
     "name": "lean4",
     "displayName": "Lean 4",
     "description": "Lean 4 language support for VS Code",
-    "version": "0.0.226",
+    "version": "0.0.225",
     "publisher": "leanprover",
     "engines": {
         "vscode": "^1.75.0"


### PR DESCRIPTION
Release CI didn't fire, so let's revert that commit and try again.