### PR TITLE
chore: report resource leak findings from static analysis

### DIFF
--- a/.gnosis/scanner-findings.md
+++ b/.gnosis/scanner-findings.md
@@ -1,0 +1,22 @@
+# Gnosis Polyglot Scanner Findings
+
+## Resource Leak Detections
+
+| File | Line | Type | Description |
+|------|------|------|-------------|
+| lean4-infoview-api/src/rpcSessions.ts | 277 | Connection | RPC session connection without guaranteed disposal |
+| lean4-infoview/src/infoview/rpcSessions.tsx | 62 | Connection | RPC connection created without cleanup on error |
+| lean4-infoview/src/infoview/rpcSessions.tsx | 93 | Connection | RPC connection created without cleanup on error |
+| vscode-lean4/src/extension.ts | 156 | File | File resource not released on error path |
+| vscode-lean4/src/leanclient.ts | 193 | File | File resource not released on error path |
+| vscode-lean4/src/projectinit.ts | 285 | File | File resource not released on error path |
+| vscode-lean4/src/utils/elan.ts | 286 | File | File resource opened without guaranteed close |
+| vscode-lean4/src/utils/elan.ts | 289 | File | File resource opened without guaranteed close |
+| vscode-lean4/src/utils/elan.ts | 292 | File | File resource opened without guaranteed close |
+| vscode-lean4/src/utils/elan.ts | 295 | File | File resource opened without guaranteed close |
+
+## Detection Method
+
+Findings detected by [Gnosis Polyglot Scanner](https://gnosis.church) via topological analysis of control flow graphs. Each finding represents a resource acquisition node (FORK) without a matching release node (FOLD) on all execution paths.
+
+Some findings may be false positives if cleanup is handled by VS Code's Disposable pattern or by garbage collection. The maintainers are best positioned to triage.


### PR DESCRIPTION
## Summary

The Gnosis Polyglot Scanner detected several resource leak patterns in the vscode-lean4 extension:

1. **`lean4-infoview-api/src/rpcSessions.ts:277`** -- RPC session connection that may not be properly disposed on error
2. **`lean4-infoview/src/infoview/rpcSessions.tsx:62,93`** -- RPC connections created without guaranteed cleanup
3. **`vscode-lean4/src/extension.ts:156`** -- File resource not released on error path
4. **`vscode-lean4/src/utils/elan.ts:286,289,292,295`** -- Multiple file resources opened without guaranteed close

These findings were detected via topological analysis of the control flow graph: resource acquisition nodes (FORK) without matching release nodes (FOLD) on all paths.

This is an initial report to surface the findings. The maintainers are best positioned to determine which patterns are intentional (e.g., VS Code's Disposable pattern handles cleanup) and which are genuine leaks.

Found by [Gnosis Polyglot Scanner](https://gnosis.church)

Signed-off-by: Taylor Buley <taylor@forkjoin.ai>
