### PR TITLE
fix: make git installation more resilient against ssl tampering

### DIFF
--- a/vscode-lean4/media/guide-installLean-windows.md
+++ b/vscode-lean4/media/guide-installLean-windows.md
@@ -11,7 +11,7 @@ The automatic installation will run a script to install Elan and Git.
 On newer Windows systems that support the package manager [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/), the following script will be executed:
 ```powershell
 # Install Git using `winget`.
-winget install -e --id Git.Git --silent --accept-package-agreements --accept-source-agreements --disable-interactivity
+winget install -e --id Git.Git --source winget --silent --accept-package-agreements --accept-source-agreements --disable-interactivity
 # Download the Elan installation script at https://github.com/leanprover/elan/blob/master/elan-init.ps1 and run it. Elan will be installed to `%USERPROFILE%\.elan`.
 $installCode = (Invoke-WebRequest -Uri "https://elan.lean-lang.org/elan-init.ps1" -UseBasicParsing -ErrorAction Stop).Content
 $installer = [ScriptBlock]::Create([System.Text.Encoding]::UTF8.GetString($installCode))

--- a/vscode-lean4/src/utils/depInstaller.ts
+++ b/vscode-lean4/src/utils/depInstaller.ts
@@ -363,7 +363,7 @@ function dependencyInstallationMethod(p: MissingDependencyInstallationProcedure)
                 }
             }
             const windowsWingetGitInstallScript =
-                'winget install -e --id Git.Git --silent --accept-package-agreements --accept-source-agreements --disable-interactivity'
+                'winget install -e --id Git.Git --source winget --silent --accept-package-agreements --accept-source-agreements --disable-interactivity'
             return {
                 kind: 'Automatic',
                 shell: 'Windows',


### PR DESCRIPTION
This PR makes the installation of Git in the extension more resilient. On a Windows server, I witnessed the following error with the current installation:
```
Failed when searching source: msstore
An unexpected error occurred while executing the command:
0x8a15005e : The server certificate did not match any of the expected values.
```
I'm not sure whether this issue is specific to the Windows server, but explicitly setting the source prevents this issue from occurring. 