### PR TITLE
chore: revert "Release 0.0.228 (pre-release)"

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -2,7 +2,7 @@
     "name": "lean4",
     "displayName": "Lean 4",
     "description": "Lean 4 language support for VS Code",
-    "version": "0.0.228",
+    "version": "0.0.227",
     "publisher": "leanprover",
     "engines": {
         "vscode": "^1.75.0"


### PR DESCRIPTION
The 0.0.228 pre-release was botched due to an error with publishing to the VS Code marketplace.