### PR TITLE
fix: closing infoview can yield 'undefined' error

### DIFF
--- a/vscode-lean4/src/infoview.ts
+++ b/vscode-lean4/src/infoview.ts
@@ -951,7 +951,7 @@ export class InfoProvider implements Disposable {
                 },
                 processing,
             }
-            await this.webviewPanel.api.gotServerNotification('$/lean/fileProgress', params)
+            await this.webviewPanel?.api.gotServerNotification('$/lean/fileProgress', params)
         }
     }
 


### PR DESCRIPTION
Potential fix for #755.