### PR TITLE
fix: unicode file paths displayed as URI-encoded in the infoview

### DIFF
--- a/lean4-infoview/src/infoview/info.tsx
+++ b/lean4-infoview/src/infoview/info.tsx
@@ -61,7 +61,7 @@ const InfoStatusBar = React.memo((props: InfoStatusBarProps) => {
         ready: '',
     }
     const statusColor = statusColTable[status]
-    const locationString = `${basename(pos.uri)}:${pos.line + 1}:${pos.character}`
+    const locationString = `${basename(decodeURIComponent(pos.uri))}:${pos.line + 1}:${pos.character}`
     const isPinned = kind === 'pin'
 
     const spinnerStyle: React.CSSProperties = {


### PR DESCRIPTION
Potential fix for #759. Decode file paths using `decodeURIComponent`.