### PR TITLE
fix: remove html highlighting from markdown grammar

### DIFF
--- a/vscode-lean4/syntaxes/lean4-markdown.json
+++ b/vscode-lean4/syntaxes/lean4-markdown.json
@@ -39,13 +39,7 @@
                     "include": "#link-def"
                 },
                 {
-                    "include": "#html"
-                },
-                {
                     "include": "#inline"
-                },
-                {
-                    "include": "text.html.derivative"
                 },
                 {
                     "include": "#heading-setext"
@@ -2015,77 +2009,6 @@
                 }
             ]
         },
-        "html": {
-            "patterns": [
-                {
-                    "begin": "(^|\\G)\\s*(<!--)",
-                    "captures": {
-                        "1": {
-                            "name": "punctuation.definition.comment.html"
-                        },
-                        "2": {
-                            "name": "punctuation.definition.comment.html"
-                        }
-                    },
-                    "end": "(-->)",
-                    "name": "comment.block.html"
-                },
-                {
-                    "begin": "(?i)(^|\\G)\\s*(?=<(script|style|pre)(\\s|$|>)(?!.*?</(script|style|pre)>))",
-                    "end": "(?i)(.*)((</)(script|style|pre)(>))",
-                    "endCaptures": {
-                        "1": {
-                            "patterns": [
-                                {
-                                    "include": "text.html.derivative"
-                                }
-                            ]
-                        },
-                        "2": {
-                            "name": "meta.tag.structure.$4.end.html"
-                        },
-                        "3": {
-                            "name": "punctuation.definition.tag.begin.html"
-                        },
-                        "4": {
-                            "name": "entity.name.tag.html"
-                        },
-                        "5": {
-                            "name": "punctuation.definition.tag.end.html"
-                        }
-                    },
-                    "patterns": [
-                        {
-                            "begin": "(\\s*|$)",
-                            "patterns": [
-                                {
-                                    "include": "text.html.derivative"
-                                }
-                            ],
-                            "while": "(?i)^(?!.*</(script|style|pre)>|\\s*-/)"
-                        }
-                    ]
-                },
-                {
-                    "begin": "(?i)(^|\\G)\\s*(?=</?[a-zA-Z]+[^\\s/&gt;]*(\\s|$|/?>))",
-                    "patterns": [
-                        {
-                            "include": "text.html.derivative"
-                        }
-                    ],
-                    "while": "^(?!\\s*$|\\s*-/)"
-                },
-                {
-                    "begin": "(^|\\G)\\s*(?=(<[a-zA-Z0-9\\-](/?>|\\s.*?>)|</[a-zA-Z0-9\\-]>)\\s*$)",
-                    "patterns": [
-                        {
-                            "include": "text.html.derivative"
-                        }
-                    ],
-                    "while": "^(?!\\s*$|\\s*-/)"
-                }
-            ]
-        },
         "link-def": {
             "captures": {
                 "1": {
@@ -2137,9 +2060,6 @@
             "patterns": [
                 {
                     "include": "#inline"
-                },
-                {
-                    "include": "text.html.derivative"
                 },
                 {
                     "include": "#heading-setext"
@@ -2198,9 +2118,6 @@
                     "include": "#inline"
                 },
                 {
-                    "include": "text.html.derivative"
-                },
-                {
                     "include": "#heading-setext"
                 }
             ],
@@ -2229,12 +2146,6 @@
         "inline": {
             "patterns": [
                 {
-                    "include": "#ampersand"
-                },
-                {
-                    "include": "#bracket"
-                },
-                {
                     "include": "#bold"
                 },
                 {
@@ -2271,11 +2182,6 @@
                     "include": "#link-ref-shortcut"
                 }
             ]
-        },
-        "ampersand": {
-            "comment": "Markdown will convert this for us. We match it so that the HTML grammar will not mark it up as invalid.",
-            "match": "&(?!([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+);)",
-            "name": "meta.other.valid-ampersand.markdown"
         },
         "bold": {
             "begin": "(?x) (\\*\\*(?=\\w)|(?<!\\w)\\*\\*|(?<!\\w)\\b__)(?=\\S) (?=\n  (\n    <[^>]*+>              # HTML tags\n    | (?<raw>`+)([^`]|(?!(?<!`)\\k<raw>(?!`))`)*+\\k<raw>\n                      # Raw\n    | \\\\[\\\\`*_{}\\[\\]()#.!+\\->]?+      # Escapes\n    | \\[\n    (\n        (?<square>          # Named group\n          [^\\[\\]\\\\]        # Match most chars\n          | \\\\.            # Escaped chars\n          | \\[ \\g<square>*+ \\]    # Nested brackets\n        )*+\n      \\]\n      (\n        (              # Reference Link\n          [ ]?          # Optional space\n          \\[[^\\]]*+\\]        # Ref name\n        )\n        | (              # Inline Link\n          \\(            # Opening paren\n            [ \\t]*+        # Optional whitespace\n            <?(.*?)>?      # URL\n            [ \\t]*+        # Optional whitespace\n            (          # Optional Title\n              (?<title>['\"])\n              (.*?)\n              \\k<title>\n            )?\n          \\)\n        )\n      )\n    )\n    | (?!(?<=\\S)\\1).            # Everything besides\n                      # style closer\n  )++\n  (?<=\\S)(?=__\\b|\\*\\*)\\1                # Close\n)\n",
@@ -2288,23 +2194,7 @@
             "name": "markup.bold.markdown",
             "patterns": [
                 {
-                    "applyEndPatternLast": 1,
-                    "begin": "(?=<[^>]*?>)",
-                    "end": "(?<=>)",
-                    "patterns": [
-                        {
-                            "include": "text.html.derivative"
-                        }
-                    ]
-                },
-                {
                     "include": "#escape"
-                },
-                {
-                    "include": "#ampersand"
-                },
-                {
-                    "include": "#bracket"
                 },
                 {
                     "include": "#raw"
@@ -2340,11 +2230,6 @@
                     "include": "#link-ref-shortcut"
                 }
             ]
-        },
-        "bracket": {
-            "comment": "Markdown will convert this for us. We match it so that the HTML grammar will not mark it up as invalid.",
-            "match": "<(?![a-zA-Z/?\\$!])",
-            "name": "meta.other.valid-bracket.markdown"
         },
         "escape": {
             "match": "\\\\[-`*_#+.!(){}\\[\\]\\\\>]",
@@ -2433,23 +2318,7 @@
             "name": "markup.italic.markdown",
             "patterns": [
                 {
-                    "applyEndPatternLast": 1,
-                    "begin": "(?=<[^>]*?>)",
-                    "end": "(?<=>)",
-                    "patterns": [
-                        {
-                            "include": "text.html.derivative"
-                        }
-                    ]
-                },
-                {
                     "include": "#escape"
-                },
-                {
-                    "include": "#ampersand"
-                },
-                {
-                    "include": "#bracket"
                 },
                 {
                     "include": "#raw"


### PR DESCRIPTION
This PR removes the highlighting for HTML tags in the TextMate grammar for Lean comments.

The Lean TextMate grammar uses a patched version of the official Markdown TextMate grammar, which includes highlighting for HTML (by deferring to VS Code's own HTML highlighting).

In most TextMate rules of the patched Markdown grammar, we explicitly account for the closing token `-/` to terminate whatever rule the Markdown grammar was currently parsing, but this is not possible in the HTML grammar, since it is handled by VS Code.

HTML tag highlighting in the Markdown of Lean comments isn't very useful but has caused plenty of highlighting problems in the past, so this PR removes it.