### PR TITLE
chore: hide "show imports" and "show imported by" commands in command palette

### DIFF
--- a/vscode-lean4/package.json
+++ b/vscode-lean4/package.json
@@ -1273,11 +1273,11 @@
                 },
                 {
                     "command": "lean4.leanModuleHierarchy.showImports",
-                    "when": "lean4.isLeanFeatureSetActive"
+                    "when": "false"
                 },
                 {
                     "command": "lean4.leanModuleHierarchy.showImportedBy",
-                    "when": "lean4.isLeanFeatureSetActive"
+                    "when": "false"
                 }
             ],
             "editor/title": [


### PR DESCRIPTION
The correct commands are the "Show Module Hierarchy" and "Show Inverse Module Hierarchy" commands - the two commands in the title are internal implementation details of the module hierarchy UI.