### PR TITLE
Support PowerShell Constrained Language Mode in the Windows Elan installer

### DIFF
--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -42,7 +42,7 @@ try {
         New-Item -ItemType Directory -Path $elanDir -Force -ErrorAction Stop | Out-Null
         Invoke-WebRequest -Uri "https://elan.lean-lang.org/elan-init.ps1" -UseBasicParsing -OutFile $elanFile -ErrorAction Stop
         Unblock-File -LiteralPath $elanFile -ErrorAction Stop
-        & powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& '$elanFile' -NoPrompt 1 -DefaultToolchain ${elanStableChannel}"
+        & powershell.exe -NoProfile -ExecutionPolicy Unrestricted -Command "& '$elanFile' -NoPrompt 1 -DefaultToolchain ${elanStableChannel}"
         $rc = $LASTEXITCODE
     }
 }

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -19,17 +19,44 @@ import {
     displayStickyNotificationWithOptionalInput,
 } from './notifs'
 
-const windowsInstallationScript = `try {
-    $installCode = (Invoke-WebRequest -Uri "https://elan.lean-lang.org/elan-init.ps1" -UseBasicParsing -ErrorAction Stop).Content
-    $installer = [ScriptBlock]::Create([System.Text.Encoding]::UTF8.GetString($installCode))
-    Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process
-    $rc = & $installer -NoPrompt 1 -DefaultToolchain ${elanStableChannel}
-    exit $rc
-} catch {
+const windowsInstallationScript = `$rc = 1
+try {
+    if ($ExecutionContext.SessionState.LanguageMode -eq 'FullLanguage') {
+        $installCode = (Invoke-WebRequest -Uri "https://elan.lean-lang.org/elan-init.ps1" -UseBasicParsing -ErrorAction Stop).Content
+        $installer = [ScriptBlock]::Create([System.Text.Encoding]::UTF8.GetString($installCode))
+        Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process
+        $rc = & $installer -NoPrompt 1 -DefaultToolchain ${elanStableChannel}
+    }
+    else {
+        # Constrained Language Mode: can't build a script block from a downloaded
+        # string, so write the installer to disk, clear MOTW, and run the file.
+        $temp = $env:TMP
+        if (-not $temp) { $temp = $env:TEMP }
+        if (-not $temp) { $temp = $env:USERPROFILE }
+        if (-not $temp) { $temp = $env:SystemRoot }
+        if (-not $temp) { throw "Unable to resolve a temporary directory. All candidate sources (TMP/TEMP/USERPROFILE/SystemRoot) were not found." }
+
+        $elanDir  = Join-Path $temp "elan"
+        $elanFile = Join-Path $elanDir "elan-init.ps1"
+
+        New-Item -ItemType Directory -Path $elanDir -Force -ErrorAction Stop | Out-Null
+        Invoke-WebRequest -Uri "https://elan.lean-lang.org/elan-init.ps1" -UseBasicParsing -OutFile $elanFile -ErrorAction Stop
+        Unblock-File -LiteralPath $elanFile -ErrorAction Stop
+        & powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& '$elanFile' -NoPrompt 1 -DefaultToolchain ${elanStableChannel}"
+        $rc = $LASTEXITCODE
+    }
+}
+catch {
     Write-Host "Downloading and running the Elan installer failed."
     Write-Host $_
-    exit 1
-}`
+    $rc = 1
+}
+finally {
+    if ($elanFile -and (Test-Path -LiteralPath $elanFile)) {
+        Remove-Item -LiteralPath $elanFile -Force -ErrorAction SilentlyContinue
+    }
+}
+exit $rc`
 
 const unixInstallationScript = `curl "https://elan.lean-lang.org/elan-init.sh" -sSf | sh -s -- -y --default-toolchain ${elanStableChannel}`
 

--- a/vscode-lean4/src/utils/leanInstaller.ts
+++ b/vscode-lean4/src/utils/leanInstaller.ts
@@ -41,7 +41,7 @@ try {
 
         New-Item -ItemType Directory -Path $elanDir -Force -ErrorAction Stop | Out-Null
         Invoke-WebRequest -Uri "https://elan.lean-lang.org/elan-init.ps1" -UseBasicParsing -OutFile $elanFile -ErrorAction Stop
-        Unblock-File -LiteralPath $elanFile -ErrorAction Stop
+        Unblock-File -LiteralPath $elanFile -Confirm:$false -ErrorAction Stop
         & powershell.exe -NoProfile -ExecutionPolicy Unrestricted -Command "& '$elanFile' -NoPrompt 1 -DefaultToolchain ${elanStableChannel}"
         $rc = $LASTEXITCODE
     }


### PR DESCRIPTION
The current Windows installation script breaks under Constrained Language Mode (CLM). It builds the Elan script into a script block in memory before running it with:

`$installer = [ScriptBlock]::Create([System.Text.Encoding]::UTF8.GetString($installCode))`

Both `[System.Text.Encoding]::UTF8.GetString(...)` and `[ScriptBlock]::Create(...)` are method calls, which CLM blocks. The script fails with `MethodInvocationNotSupportedInConstrainedLanguage`.

This is a follow-up to leanprover/elan#204, which made `elan-init.ps1` itself CLM-safe. This PR completes the chain by making vscode-lean4's invocation of the script CLM-safe.

The change wraps the existing logic in a `FullLanguage` check. In `FullLanguage` the behaviour is unchanged. Otherwise (CLM) it:

- resolves a temp directory from environment variables (`TMP`/`TEMP`/`USERPROFILE`/`SystemRoot`); (Equivalent lookup to https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw)
- downloads `elan-init.ps1` to disk via `Invoke-WebRequest -OutFile` in the temp location;
- removes the mark-of-the-web with `Unblock-File`;
- runs the file in a child PowerShell process with `-ExecutionPolicy Unrestricted`; and
- deletes the file afterwards in a `finally` block (only if it exists).

A file is required for CLM-safe behaviour, because there is no clean CLM-safe way to UTF-8-decode the downloaded `byte[]` into a string and run it in memory. Writing the bytes straight to disk avoids decoding entirely.