### PR TITLE
fix: respect infoview display settings for goals in messages (#734)

### DIFF
--- a/lean4-infoview/src/infoview/goals.tsx
+++ b/lean4-infoview/src/infoview/goals.tsx
@@ -64,7 +64,7 @@ interface GoalSettingsState {
     showLetValue: boolean
 }
 
-function goalSettingsStateOfConfig(config: InfoviewConfig): GoalSettingsState {
+export function goalSettingsStateOfConfig(config: InfoviewConfig): GoalSettingsState {
     return {
         reverse: config.reverseTacticState,
         hideGoalNames: !config.showGoalNames,

--- a/lean4-infoview/src/infoview/traceExplorer.tsx
+++ b/lean4-infoview/src/infoview/traceExplorer.tsx
@@ -9,7 +9,8 @@
 
 import { HighlightedMsgEmbed, HighlightedTraceEmbed, lazyTraceChildrenToInteractive } from '@leanprover/infoview-api'
 import * as React from 'react'
-import { Goal } from './goals'
+import { ConfigContext } from './contexts'
+import { Goal, goalSettingsStateOfConfig } from './goals'
 import {
     InteractiveCode,
     InteractiveTaggedText,
@@ -117,26 +118,13 @@ function Trace(traceEmbed: HighlightedTraceEmbed) {
 function InteractiveMessageTag({
     tag: embed,
 }: InteractiveTagProps<HighlightedMsgEmbed, HighlightedMsgEmbed>): JSX.Element {
+    const config = React.useContext(ConfigContext)
     if (embed === 'highlighted') {
         return <span className="highlighted-text"></span>
     }
     if ('expr' in embed) return <InteractiveCode fmt={embed.expr} />
     else if ('goal' in embed)
-        return (
-            <Goal
-                goal={embed.goal}
-                settings={{
-                    reverse: false,
-                    hideGoalNames: false,
-                    emphasizeFirstGoal: false,
-                    showType: true,
-                    showInstance: true,
-                    showHiddenAssumption: true,
-                    showLetValue: true,
-                }}
-                additionalClassNames=""
-            />
-        )
+        return <Goal goal={embed.goal} settings={goalSettingsStateOfConfig(config)} additionalClassNames="" />
     else if ('widget' in embed)
         return <DynamicComponent hash={embed.widget.wi.javascriptHash} props={embed.widget.wi.props} />
     else if ('trace' in embed) return <Trace {...embed.trace} />


### PR DESCRIPTION
## Summary

- Goals embedded in messages (e.g. the "unsolved goals" diagnostic) were rendered by `InteractiveMessageTag` in `traceExplorer.tsx` with a hardcoded settings object, so user infoview settings such as **Display target before assumptions** (`reverseTacticState`) were ignored for these goals.
- The main goal panel derives its settings from config via `goalSettingsStateOfConfig(config)`; the message path duplicated a frozen subset, so every display toggle was ignored for message-embedded goals.

## Changes

- `lean4-infoview/src/infoview/goals.tsx`: export the existing `goalSettingsStateOfConfig` helper.
- `lean4-infoview/src/infoview/traceExplorer.tsx`: read `ConfigContext` and pass `goalSettingsStateOfConfig(config)` to `<Goal>`, replacing the hardcoded settings block so message-embedded goals respect the same display settings as the main goal panel.

Fixes #734