### PR TITLE
chore: revert "add dev console logging (#784)"

### DIFF
--- a/vscode-lean4/src/extension.ts
+++ b/vscode-lean4/src/extension.ts
@@ -357,15 +357,6 @@ export async function activate(context: ExtensionContext): Promise<Exports> {
         commands.registerCommand('lean4.redisplaySetupError', async () => displayActiveStickyNotification()),
     )
     registerLeanCommandRunner(context)
-    workspace.onDidOpenTextDocument(doc => {
-        console.log(`Document opened (isLeanDoc: ${isLeanDocument(doc)}): ${doc.uri.toString()} with language ${doc.languageId}`)
-    })
-    workspace.onDidCloseTextDocument(doc => {
-        console.log(`Document closed: ${doc.uri.toString()}`)
-    })
-    window.onDidChangeVisibleTextEditors(editors => {
-        console.log(`Visible editors changed. Currently visible editors: ${editors.map(ed => ed.document.uri.toString())}`)
-    })
 
     const alwaysEnabledFeatures: AlwaysEnabledFeatures = await displayInternalErrorsIn(
         'activating Lean 4 extension',


### PR DESCRIPTION
Nobody ended up providing more information based on this debug logging, so we are removing this again for now.